### PR TITLE
feat: quintic Hermite organic pointer trajectory + flash fix

### DIFF
--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/animation/PointerCurveMath.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/animation/PointerCurveMath.kt
@@ -1,166 +1,422 @@
 package com.niki914.nexus.agentic.animation
 
-import android.graphics.Path
-import android.graphics.PathMeasure
+import kotlin.math.abs
 import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.sqrt
 
 /**
- * Shared pointer animation math.
+ * Shared pointer animation math — quintic Hermite organic trajectory.
  *
  * Both the floating-window pointer overlay and the in-process Compose onboard
- * demo use these functions so the cursor moves with the same feel everywhere.
+ * demo use [buildTrajectory] so the cursor moves with the same feel everywhere.
  */
 object PointerCurveMath {
 
-    // --- Curve shape ---
-    private const val CTRL_DIST_MIN_FRAC = 0.15f
-    private const val CTRL_DIST_MAX_FRAC = 0.55f
-    private const val CTRL_PERP_FRAC = 0.25f
-
-    // --- Speed profile ---
-    private const val MAX_SPEED_PX_PER_S = 4500f
-    private const val MIN_SPEED_PX_PER_S = 200f
-    private const val ACCEL_FRAC = 0.20f
-    private const val DECEL_FRAC = 0.30f
-    private const val SPEED_LUT_SIZE = 100
-    private const val AVG_SPEED_FRAC = 0.55f
-
-    /** Idle heading: pointer tip faces top-left (-135°, rad) */
+    /** Idle heading: pointer tip faces top-left (NW, -135 degrees in radians). */
     const val IDLE_HEADING_RAD = (-Math.PI * 3.0 / 4.0).toFloat()
 
-    // ============================================================
-    // Curve construction
-    // ============================================================
-
-    /**
-     * Builds a cubic bezier from (x1,y1) to (x2,y2) with direction-aware
-     * control points.
-     *
-     * When the pointer flies with its tip (heading aligns with target
-     * direction), the curve is nearly straight.
-     * When flying against the tip, control points push far out and a
-     * perpendicular offset adds a figure-8 side-sweep.
-     */
-    fun buildCurve(
-        x1: Float, y1: Float, headingRad: Float,
-        x2: Float, y2: Float,
-    ): Path {
-        val dx = x2 - x1
-        val dy = y2 - y1
-        val dist = sqrt(dx * dx + dy * dy)
-        if (dist < 2f) return Path().apply {
-            moveTo(x1, y1)
-            lineTo(x2, y2)
-        }
-
-        val hx = cos(headingRad)
-        val hy = sin(headingRad)
-
-        val tx = dx / dist
-        val ty = dy / dist
-
-        val dot = hx * tx + hy * ty
-        val arcFactor = ((1f - dot) / 2f).coerceIn(0f, 1f)
-
-        val px = -hy
-        val py = hx
-
-        val ctrlDist =
-            (CTRL_DIST_MIN_FRAC + arcFactor * (CTRL_DIST_MAX_FRAC - CTRL_DIST_MIN_FRAC)) * dist
-        val perpDist = arcFactor * CTRL_PERP_FRAC * dist
-
-        return Path().apply {
-            moveTo(x1, y1)
-            cubicTo(
-                x1 + hx * ctrlDist + px * perpDist,
-                y1 + hy * ctrlDist + py * perpDist,
-                x2 - hx * ctrlDist - px * perpDist,
-                y2 - hy * ctrlDist - py * perpDist,
-                x2, y2,
-            )
-        }
-    }
-
-    // ============================================================
-    // Speed profile
-    // ============================================================
-
-    fun buildSpeedLut(): FloatArray {
-        val dt = 1f / SPEED_LUT_SIZE
-        val speeds = FloatArray(SPEED_LUT_SIZE + 1) {
-            speedAtT(it.toFloat() / SPEED_LUT_SIZE)
-        }
-        var total = 0f
-        for (i in 1..SPEED_LUT_SIZE) total += (speeds[i - 1] + speeds[i]) / 2f * dt
-        val lut = FloatArray(SPEED_LUT_SIZE + 1)
-        var cum = 0f
-        for (i in 1..SPEED_LUT_SIZE) {
-            cum += (speeds[i - 1] + speeds[i]) / 2f * dt
-            lut[i] = cum / total
-        }
-        return lut
-    }
-
-    private fun speedAtT(t: Float): Float = when {
-        t < ACCEL_FRAC -> {
-            val p = t / ACCEL_FRAC
-            MIN_SPEED_PX_PER_S + (MAX_SPEED_PX_PER_S - MIN_SPEED_PX_PER_S) * p * p
-        }
-        t < 1f - DECEL_FRAC -> MAX_SPEED_PX_PER_S
-        else -> {
-            val p = (t - (1f - DECEL_FRAC)) / DECEL_FRAC
-            MIN_SPEED_PX_PER_S + (MAX_SPEED_PX_PER_S - MIN_SPEED_PX_PER_S) * (1f - p) * (1f - p)
-        }
-    }
-
-    /** Map linear time fraction -> distance fraction via pre-computed LUT. */
-    fun timeToDistance(t: Float, lut: FloatArray): Float {
-        if (t <= 0f) return 0f
-        if (t >= 1f) return 1f
-        val idx = t * SPEED_LUT_SIZE
-        val i = idx.toInt()
-        val frac = idx - i
-        return lut[i] + (lut[i + 1] - lut[i]) * frac
-    }
-
-    // ============================================================
-    // Shared timing constants
-    // ============================================================
-
-    /** Pause between the fly-to-start and swipe phases (ms). */
+    /** Pause between fly-to-start and swipe phases (ms). */
     const val SWIPE_GAP_MS = 80L
 
     /** Duration for the swipe phase in the onboard demo (ms). */
     const val DEMO_SWIPE_DURATION_MS = 400L
 
-    // ============================================================
-    // Shared sampling
-    // ============================================================
+    // ---------------------------------------------------------------
+    // Movement mode
+    // ---------------------------------------------------------------
 
-    data class CurveSample(val x: Float, val y: Float, val headingRad: Float)
+    enum class MovementMode {
+        /** Straight line, constant [IDLE_HEADING_RAD], uniform speed. */
+        TRANSLATE,
+        /** Quintic Hermite organic curve, tangent-following, easeInOutSine. */
+        FLY,
+    }
 
-    /**
-     * Reusable per-segment sampler that holds [PathMeasure] and working
-     * arrays so per-frame calls avoid allocating new objects.
-     */
-    class CurveSampler(path: Path) {
-        private val pm = PathMeasure(path, false)
-        private val pos = FloatArray(2)
-        private val tan = FloatArray(2)
-        val length get() = pm.length
+    // ---------------------------------------------------------------
+    // Public API
+    // ---------------------------------------------------------------
 
-        fun sample(distFraction: Float): CurveSample {
-            pm.getPosTan(distFraction * pm.length, pos, tan)
-            return CurveSample(pos[0], pos[1], atan2(tan[1], tan[0]))
+    data class FrameData(val x: Float, val y: Float, val headingRad: Float)
+
+    class Trajectory(
+        val mode: MovementMode,
+        val startX: Float,
+        val startY: Float,
+        val endX: Float,
+        val endY: Float,
+        val totalLen: Float,
+        val totalDurationMs: Long,
+        // FLY-only internals (null for TRANSLATE)
+        private val coeffs: FlyCoeffs?,
+        private val cumLen: FloatArray?,
+        private val arcSamples: Int,
+    ) {
+        /**
+         * Maps a distance fraction [0..1] to the corresponding position and
+         * raw tangent heading at that point along the trajectory.
+         *
+         * For TRANSLATE the heading is always [IDLE_HEADING_RAD].
+         * For FLY the heading is the raw tangent angle — callers must unwrap
+         * across frames via [PointerCurveMath.unwrapAngle].
+         */
+        fun sampleAtDistance(distFrac: Float): FrameData {
+            val f = distFrac.coerceIn(0f, 1f)
+            return when (mode) {
+                MovementMode.TRANSLATE -> {
+                    FrameData(
+                        x = startX + (endX - startX) * f,
+                        y = startY + (endY - startY) * f,
+                        headingRad = IDLE_HEADING_RAD,
+                    )
+                }
+                MovementMode.FLY -> {
+                    val c = coeffs
+                    if (c == null) { // tiny-dist fallback
+                        return FrameData(
+                            x = startX + (endX - startX) * f,
+                            y = startY + (endY - startY) * f,
+                            headingRad = IDLE_HEADING_RAD,
+                        )
+                    }
+                    val t = distanceToParam(f)
+                    val px = positionAt(c, t)
+                    val py = positionAtY(c, t)
+                    val vx = derivativeAt(c, t)
+                    val vy = derivativeAtY(c, t)
+                    FrameData(px, py, atan2(vy, vx))
+                }
+            }
+        }
+
+        /** Binary search through the arc-length table to map distance → t. */
+        private fun distanceToParam(distFrac: Float): Float {
+            val target = distFrac * totalLen
+            val cl = cumLen!!
+            var lo = 0
+            var hi = arcSamples
+            while (lo < hi) {
+                val mid = (lo + hi + 1) ushr 1
+                if (cl[mid] <= target) lo = mid else hi = mid - 1
+            }
+            if (lo >= arcSamples) return 1f
+            val segLen = cl[lo + 1] - cl[lo]
+            if (segLen < 1e-6f) return (lo + 1).toFloat() / arcSamples
+            val frac = (target - cl[lo]) / segLen
+            return (lo + frac) / arcSamples
         }
     }
 
-    /** Duration for travelling [arcLen] pixels using the shared speed profile. */
-    fun curveDurationMs(arcLen: Float): Long {
-        return (arcLen / (MAX_SPEED_PX_PER_S * AVG_SPEED_FRAC) * 1000f)
-            .toLong().coerceAtLeast(50L)
+    /**
+     * Build a trajectory from (startX,startY) to (endX,endY).
+     *
+     * [startHeadingRad] is the pointer's current heading (used as V0 direction
+     * in FLY mode so consecutive animations don't snap).
+     *
+     * [mode] selects the movement strategy:
+     * - [MovementMode.TRANSLATE]: straight line, constant [IDLE_HEADING_RAD],
+     *   uniform speed. [startHeadingRad] is ignored.
+     * - [MovementMode.FLY]: quintic Hermite curve. V0 direction follows
+     *   [startHeadingRad] for smooth departure; V1 direction is always
+     *   [IDLE_HEADING_RAD] (NW) so the pointer arrives naturally idle.
+     *
+     * [canvasW] and [canvasH] are used by FLY for candidate scoring
+     * (avoiding out-of-bounds curves).
+     */
+    fun buildTrajectory(
+        startX: Float,
+        startY: Float,
+        startHeadingRad: Float,
+        endX: Float,
+        endY: Float,
+        mode: MovementMode,
+        canvasW: Int,
+        canvasH: Int,
+    ): Trajectory = when (mode) {
+        MovementMode.TRANSLATE -> buildTranslate(startX, startY, endX, endY)
+        MovementMode.FLY -> buildFly(
+            startX, startY, startHeadingRad, endX, endY, canvasW, canvasH,
+        )
+    }
+
+    // ---------------------------------------------------------------
+    // Angle unwrapping
+    // ---------------------------------------------------------------
+
+    /**
+     * Unwraps [rawDeg] (in degrees) relative to [prevDeg] so the angle
+     * changes continuously without ±180° jumps.
+     */
+    fun unwrapAngle(rawDeg: Float, prevDeg: Float): Float {
+        var r = rawDeg
+        while (r - prevDeg > 180f) r -= 360f
+        while (r - prevDeg < -180f) r += 360f
+        return r
+    }
+
+    // ---------------------------------------------------------------
+    // Easing
+    // ---------------------------------------------------------------
+
+    /** Cosine ease-in-out: starts at 0, accelerates, then decelerates to 1. */
+    fun easeInOutSine(t: Float): Float =
+        0.5f - 0.5f * cos(Math.PI.toFloat() * t.coerceIn(0f, 1f))
+
+    // ================================================================
+    // Internals — TRANSLATE
+    // ================================================================
+
+    private const val TRANSLATE_SPEED_PX_S = 2000f
+    private const val MIN_DURATION_MS = 80L
+    private const val MAX_DURATION_MS = 3000L
+
+    private fun buildTranslate(
+        sx: Float, sy: Float, ex: Float, ey: Float,
+    ): Trajectory {
+        val dx = ex - sx
+        val dy = ey - sy
+        val dist = sqrt(dx * dx + dy * dy)
+        val dur = (dist / TRANSLATE_SPEED_PX_S * 1000f).toLong()
+            .coerceIn(MIN_DURATION_MS, MAX_DURATION_MS)
+        return Trajectory(
+            mode = MovementMode.TRANSLATE,
+            startX = sx, startY = sy,
+            endX = ex, endY = ey,
+            totalLen = dist, totalDurationMs = dur,
+            coeffs = null, cumLen = null, arcSamples = 0,
+        )
+    }
+
+    // ================================================================
+    // Internals — FLY (quintic Hermite + bump perturbation)
+    // ================================================================
+
+    private const val EPSILON_DIST = 2f
+    private const val ARC_SAMPLES = 512
+    private const val NOMINAL_SPEED_PX_S = 3000f
+    private const val SKEW = 0.42f
+    private const val BEND_FRAC = 0.14f
+    private const val MIN_SPEED_FRAC = 0.04f       // minSpeed > 0.04 * D
+    private const val MAX_ANGLE_STEP_DEG = 6f      // max consecutive angle step
+    private const val CANDIDATE_SAMPLES = 256       // for candidate scoring
+
+    private val IDLE_DIR_X = (-1.0 / sqrt(2.0)).toFloat()
+    private val IDLE_DIR_Y = (-1.0 / sqrt(2.0)).toFloat()
+
+    class FlyCoeffs(
+        val sx: Float, val sy: Float,
+        val v0x: Float, val v0y: Float,
+        val ax: Float, val ay: Float,
+        val bx: Float, val by: Float,
+        val cx: Float, val cy: Float,
+        val nx: Float, val ny: Float,
+        val bend: Float,
+    )
+
+    data class CandidateScore(
+        val minSpeed: Float,
+        val overflow: Float,
+        val maxAngleStep: Float,
+    )
+
+    private fun buildFly(
+        sx: Float, sy: Float,
+        startHeadingRad: Float,
+        ex: Float, ey: Float,
+        canvasW: Int, canvasH: Int,
+    ): Trajectory {
+        val dx = ex - sx
+        val dy = ey - sy
+        val dist = sqrt(dx * dx + dy * dy)
+
+        // Extremely short travel — skip curve, treat as tiny translate
+        if (dist < EPSILON_DIST) {
+            val dur = MIN_DURATION_MS
+            return Trajectory(
+                mode = MovementMode.FLY,
+                startX = sx, startY = sy,
+                endX = ex, endY = ey,
+                totalLen = dist, totalDurationMs = dur,
+                coeffs = null, cumLen = null, arcSamples = 0,
+            )
+        }
+
+        val d = minOf(canvasW.toFloat(), canvasH.toFloat())
+
+        // V0 follows current heading for smooth departure
+        val v0DirX = cos(startHeadingRad)
+        val v0DirY = sin(startHeadingRad)
+
+        val startMag = minOf(0.55f * dist, 0.60f * d).coerceAtLeast(0.12f * d)
+        val endMag = minOf(0.50f * dist, 0.55f * d).coerceAtLeast(0.11f * d)
+
+        val v0x = v0DirX * startMag
+        val v0y = v0DirY * startMag
+        val v1x = IDLE_DIR_X * endMag   // always arrive facing NW
+        val v1y = IDLE_DIR_Y * endMag
+
+        // Quintic Hermite coefficients
+        val ax = 10f * dx - 6f * v0x - 4f * v1x
+        val ay = 10f * dy - 6f * v0y - 4f * v1y
+        val bx = -15f * dx + 8f * v0x + 7f * v1x
+        val by = -15f * dy + 8f * v0y + 7f * v1y
+        val cx = 6f * dx - 3f * v0x - 3f * v1x
+        val cy = 6f * dy - 3f * v0y - 3f * v1y
+
+        // Chord normal
+        val chordLen = sqrt(dx * dx + dy * dy)
+        val chordNx = if (chordLen > 0f) -dy / chordLen else 1f
+        val chordNy = if (chordLen > 0f) dx / chordLen else 0f
+        val baseBend = minOf(BEND_FRAC * dist, 0.19f * d).coerceAtLeast(0.04f * d)
+
+        var best: Pair<FlyCoeffs, CandidateScore>? = null
+
+        for (dirSign in intArrayOf(1, -1)) {
+            val nx = chordNx * dirSign
+            val ny = chordNy * dirSign
+            val coeffs = FlyCoeffs(sx, sy, v0x, v0y, ax, ay, bx, by, cx, cy, nx, ny, baseBend)
+            val score = scoreCandidate(coeffs, canvasW, canvasH, d)
+            if (score.minSpeed <= MIN_SPEED_FRAC * d) continue // cusp risk
+            if (best == null ||
+                score.overflow < best.second.overflow - 1f ||
+                (abs(score.overflow - best.second.overflow) < 1f &&
+                        score.maxAngleStep < best.second.maxAngleStep)
+            ) {
+                best = coeffs to score
+            }
+        }
+
+        val chosen = best?.first ?: FlyCoeffs(
+            sx, sy, v0x, v0y, ax, ay, bx, by, cx, cy,
+            chordNx, chordNy, baseBend * 0.5f,
+        )
+
+        val cumLen = buildArcLengthTable(chosen)
+        val totalLen = cumLen[ARC_SAMPLES]
+        val dur = (totalLen / NOMINAL_SPEED_PX_S * 1000f).toLong()
+            .coerceIn(MIN_DURATION_MS, MAX_DURATION_MS)
+
+        return Trajectory(
+            mode = MovementMode.FLY,
+            startX = sx, startY = sy,
+            endX = ex, endY = ey,
+            totalLen = totalLen, totalDurationMs = dur,
+            coeffs = chosen, cumLen = cumLen, arcSamples = ARC_SAMPLES,
+        )
+    }
+
+    /** Evaluate a candidate curve by sampling [CANDIDATE_SAMPLES] points. */
+    private fun scoreCandidate(
+        c: FlyCoeffs, cw: Int, ch: Int, d: Float,
+    ): CandidateScore {
+        var minSpeed = Float.MAX_VALUE
+        var overflow = 0f
+        var maxAngleStep = 0f
+        var prevAngle = 0f
+        var first = true
+
+        val steps = CANDIDATE_SAMPLES
+        for (i in 0..steps) {
+            val t = i.toFloat() / steps
+            val vx = derivativeAt(c, t)
+            val vy = derivativeAtY(c, t)
+            val speed = sqrt(vx * vx + vy * vy)
+            if (speed < minSpeed) minSpeed = speed
+
+            // Out of bounds
+            val px = positionAt(c, t)
+            val py = positionAtY(c, t)
+            if (px < 0f) overflow -= px
+            else if (px > cw) overflow += px - cw
+            if (py < 0f) overflow -= py
+            else if (py > ch) overflow += py - ch
+
+            // Angle step
+            val angle = Math.toDegrees(atan2(vy.toDouble(), vx.toDouble())).toFloat()
+            if (!first) {
+                val step = angleUnwrappedDiff(angle, prevAngle)
+                if (step > maxAngleStep) maxAngleStep = step
+            }
+            prevAngle = angle
+            first = false
+        }
+
+        return CandidateScore(minSpeed, overflow, maxAngleStep)
+    }
+
+    /** Shortest angular distance between two degree values. */
+    private fun angleUnwrappedDiff(a: Float, b: Float): Float {
+        val diff = abs(a - b)
+        return if (diff > 180f) 360f - diff else diff
+    }
+
+    /** Build the cumulative arc-length table (ARC_SAMPLES + 1 entries). */
+    private fun buildArcLengthTable(c: FlyCoeffs): FloatArray {
+        val cl = FloatArray(ARC_SAMPLES + 1)
+        var px = c.sx
+        var py = c.sy
+        for (i in 1..ARC_SAMPLES) {
+            val t = i.toFloat() / ARC_SAMPLES
+            val x = positionAt(c, t)
+            val y = positionAtY(c, t)
+            val seg = sqrt((x - px) * (x - px) + (y - py) * (y - py))
+            cl[i] = cl[i - 1] + seg
+            px = x
+            py = y
+        }
+        return cl
+    }
+
+    // --- Analytic position & derivative ---
+    //    P(t)   = S + V0·t + A·t³ + B·t⁴ + C·t⁵ + normal·bend·bump(t)
+    //    P'(t)  = V0 + 3A·t² + 4B·t³ + 5C·t⁴ + normal·bend·bump'(t)
+
+    private fun positionAt(c: FlyCoeffs, t: Float): Float {
+        val t2 = t * t; val t3 = t2 * t; val t4 = t3 * t; val t5 = t4 * t
+        return c.sx + c.v0x * t + c.ax * t3 + c.bx * t4 + c.cx * t5 +
+                c.nx * c.bend * bump(t)
+    }
+
+    private fun positionAtY(c: FlyCoeffs, t: Float): Float {
+        val t2 = t * t; val t3 = t2 * t; val t4 = t3 * t; val t5 = t4 * t
+        return c.sy + c.v0y * t + c.ay * t3 + c.by * t4 + c.cy * t5 +
+                c.ny * c.bend * bump(t)
+    }
+
+    private fun derivativeAt(c: FlyCoeffs, t: Float): Float {
+        val t2 = t * t; val t3 = t2 * t; val t4 = t3 * t
+        return c.v0x + 3f * c.ax * t2 + 4f * c.bx * t3 + 5f * c.cx * t4 +
+                c.nx * c.bend * bumpDerivative(t)
+    }
+
+    private fun derivativeAtY(c: FlyCoeffs, t: Float): Float {
+        val t2 = t * t; val t3 = t2 * t; val t4 = t3 * t
+        return c.v0y + 3f * c.ay * t2 + 4f * c.by * t3 + 5f * c.cy * t4 +
+                c.ny * c.bend * bumpDerivative(t)
+    }
+
+    // --- Bump (侧向扰动) ---
+
+    /**
+     * Smooth perturbation that vanishes at both ends:
+     *   bump(t) = 16·t²·(1-t)² × (1 + skew·(2t-1))
+     */
+    private fun bump(t: Float): Float {
+        val g = 16f * t * t * (1f - t) * (1f - t)
+        val q = 1f + SKEW * (2f * t - 1f)
+        return g * q
+    }
+
+    /**
+     * Derivative of [bump]:
+     *   bump'(t) = g'(t)·q(t) + 2·skew·g(t)
+     *   where g'(t) = 32·t·(1-t)·(1-2t)
+     */
+    private fun bumpDerivative(t: Float): Float {
+        val g = 16f * t * t * (1f - t) * (1f - t)
+        val dg = 32f * t * (1f - t) * (1f - 2f * t)
+        val q = 1f + SKEW * (2f * t - 1f)
+        return dg * q + g * 2f * SKEW
     }
 }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/animation/PointerCurveMath.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/animation/PointerCurveMath.kt
@@ -270,28 +270,47 @@ object PointerCurveMath {
         val chordNy = if (chordLen > 0f) dx / chordLen else 0f
         val baseBend = minOf(BEND_FRAC * dist, 0.19f * d).coerceAtLeast(0.04f * d)
 
+        val minSpeedThreshold = MIN_SPEED_FRAC * d
+
+        // Try multiple bend scales × both directions. Pick the candidate with
+        // the lowest maxAngleStep (tightest curve), breaking ties by overflow.
         var best: Pair<FlyCoeffs, CandidateScore>? = null
 
-        for (dirSign in intArrayOf(1, -1)) {
-            val nx = chordNx * dirSign
-            val ny = chordNy * dirSign
-            val coeffs = FlyCoeffs(sx, sy, v0x, v0y, ax, ay, bx, by, cx, cy, nx, ny, baseBend)
-            val score = scoreCandidate(coeffs, canvasW, canvasH, d)
-            if (score.minSpeed <= MIN_SPEED_FRAC * d) continue // cusp risk
-            if (best == null ||
-                score.overflow < best.second.overflow - 1f ||
-                (abs(score.overflow - best.second.overflow) < 1f &&
-                        score.maxAngleStep < best.second.maxAngleStep)
-            ) {
-                best = coeffs to score
+        for (bendScale in floatArrayOf(1f, 0.6f, 0.3f, 0.15f)) {
+            for (dirSign in intArrayOf(1, -1)) {
+                val nx = chordNx * dirSign
+                val ny = chordNy * dirSign
+                val coeffs = FlyCoeffs(
+                    sx, sy, v0x, v0y, ax, ay, bx, by, cx, cy,
+                    nx, ny, baseBend * bendScale,
+                )
+                val score = scoreCandidate(coeffs, canvasW, canvasH, d)
+                // Hard reject: both cusp risk AND sharp turns
+                if (score.minSpeed <= minSpeedThreshold) continue
+                if (score.maxAngleStep > MAX_ANGLE_STEP_DEG) continue
+                if (best == null ||
+                    score.maxAngleStep < best.second.maxAngleStep - 0.1f ||
+                    (abs(score.maxAngleStep - best.second.maxAngleStep) < 0.1f &&
+                            score.overflow < best.second.overflow)
+                ) {
+                    best = coeffs to score
+                }
             }
         }
 
-        val chosen = best?.first ?: FlyCoeffs(
-            sx, sy, v0x, v0y, ax, ay, bx, by, cx, cy,
-            chordNx, chordNy, baseBend * 0.5f,
-        )
+        // No valid curve found — fall back to a short straight line so the
+        // pointer doesn't execute an unvalidated trajectory with sharp turns.
+        if (best == null) {
+            return Trajectory(
+                mode = MovementMode.FLY,
+                startX = sx, startY = sy,
+                endX = ex, endY = ey,
+                totalLen = dist, totalDurationMs = MIN_DURATION_MS,
+                coeffs = null, cumLen = null, arcSamples = 0,
+            )
+        }
 
+        val (chosen, _) = best
         val cumLen = buildArcLengthTable(chosen)
         val totalLen = cumLen[ARC_SAMPLES]
         val dur = (totalLen / NOMINAL_SPEED_PX_S * 1000f).toLong()

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/animation/PointerCurveMath.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/animation/PointerCurveMath.kt
@@ -301,11 +301,14 @@ object PointerCurveMath {
         // No valid curve found — fall back to a short straight line so the
         // pointer doesn't execute an unvalidated trajectory with sharp turns.
         if (best == null) {
+            val fallbackDurationMs =
+                (dist / NOMINAL_SPEED_PX_S * 1000f).toLong()
+                    .coerceIn(MIN_DURATION_MS, MAX_DURATION_MS)
             return Trajectory(
                 mode = MovementMode.FLY,
                 startX = sx, startY = sy,
                 endX = ex, endY = ey,
-                totalLen = dist, totalDurationMs = MIN_DURATION_MS,
+                totalLen = dist, totalDurationMs = fallbackDurationMs,
                 coeffs = null, cumLen = null, arcSamples = 0,
             )
         }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/AccessibilityController.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/AccessibilityController.kt
@@ -99,7 +99,7 @@ object AccessibilityController {
     }
 
     fun clearPointerOverlay() {
-        pointerOverlay?.hide()
+        pointerOverlay?.dispose()
         pointerOverlay = null
         pointerShown = false
     }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/IPointerOverlay.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/IPointerOverlay.kt
@@ -14,4 +14,7 @@ interface IPointerOverlay {
 
     /** Fade out and remove from window. Non-blocking. */
     fun hide()
+
+    /** Cancel all animations and remove the view from the window immediately. */
+    fun dispose()
 }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/IPointerOverlay.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/IPointerOverlay.kt
@@ -1,11 +1,13 @@
 package com.niki914.nexus.agentic.chat.agentic.accessibility
 
+import com.niki914.nexus.agentic.animation.PointerCurveMath.MovementMode
+
 interface IPointerOverlay {
     /** Fade in at [x],[y] with default idle heading. Non-blocking. */
     fun show(x: Float, y: Float)
 
-    /** Fly from current position to [x],[y]. Suspends until animation completes. */
-    suspend fun animateTo(x: Float, y: Float)
+    /** Fly from current position to [x],[y] using [mode]. Suspends until animation completes. */
+    suspend fun animateTo(x: Float, y: Float, mode: MovementMode = MovementMode.FLY)
 
     /** Fly to swipe start, then trace the swipe path. Suspends until both phases complete. */
     suspend fun showSwipe(sx: Float, sy: Float, ex: Float, ey: Float, duration: Long)

--- a/app/src/main/java/com/niki914/nexus/agentic/app/overlay/PointerOverlay.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/overlay/PointerOverlay.kt
@@ -26,7 +26,11 @@ class PointerOverlay : IPointerOverlay {
         private const val POINTER_SIZE_DP = 80
     }
 
-    // Android overlay infrastructure
+    // Android overlay infrastructure.
+    // The view is attached once in init() and stays in the window for its
+    // entire lifetime — we toggle visibility via alpha only. This avoids
+    // addView/removeView races where a re-attached view briefly renders at
+    // default alpha=1 before we can set it to 0.
     private var wm: WindowManager? = null
     private var view: ImageView? = null
     private var lp: WindowManager.LayoutParams? = null
@@ -46,10 +50,6 @@ class PointerOverlay : IPointerOverlay {
     // Tracks the unwrapped heading across frames to prevent ±180° jumps
     private var prevAngleDeg =
         Math.toDegrees(PointerCurveMath.IDLE_HEADING_RAD.toDouble()).toFloat()
-
-    // Guards against hide's withEndAction detaching the view after a
-    // subsequent show() has already re-enabled it.
-    private var hiding = false
 
     // ============================================================
     // Initialization
@@ -82,7 +82,16 @@ class PointerOverlay : IPointerOverlay {
             gravity = Gravity.TOP or Gravity.START
         }
 
-        view?.alpha = 0f  // start invisible, animate view alpha for fade
+        view?.alpha = 0f
+
+        // Attach once and keep in the window for the overlay's lifetime.
+        // Visibility is controlled exclusively via view alpha, so there is
+        // no addView/removeView race with the fade animation.
+        try {
+            wm!!.addView(view, lp)
+            attached = true
+        } catch (_: Exception) {
+        }
 
         grantOverlayPermission(ctx.packageName)
     }
@@ -105,11 +114,7 @@ class PointerOverlay : IPointerOverlay {
 
     override fun show(x: Float, y: Float) {
         handler.post {
-            hiding = false
-            // Cancel any running fade-out so the subsequent fade-in picks
-            // up from the current alpha (no flash).
             view?.animate()?.cancel()
-            attachIfNeeded()
             curX = x
             curY = y
             curHeading = PointerCurveMath.IDLE_HEADING_RAD
@@ -121,18 +126,16 @@ class PointerOverlay : IPointerOverlay {
 
     override fun hide() {
         handler.post {
-            hiding = true
             view?.animate()?.cancel()
-            view?.animate()?.alpha(0f)?.setDuration(FADE_DURATION_MS)?.withEndAction {
-                if (hiding) detach()
-            }?.start()
+            cancelAnim()
+            view?.animate()?.alpha(0f)?.setDuration(FADE_DURATION_MS)?.start()
         }
     }
 
     override suspend fun animateTo(
         x: Float, y: Float, mode: MovementMode,
     ) {
-        if (!attached || hiding) return
+        if (!attached) return
         cancelAnim()
         val t = PointerCurveMath.buildTrajectory(
             curX, curY, curHeading, x, y, mode, screenW, screenH,
@@ -143,7 +146,7 @@ class PointerOverlay : IPointerOverlay {
     override suspend fun showSwipe(
         sx: Float, sy: Float, ex: Float, ey: Float, duration: Long,
     ) {
-        if (!attached || hiding) return
+        if (!attached) return
         cancelAnim()
 
         // Phase 1: fly to swipe start (organic curve, tangent-following)
@@ -261,24 +264,6 @@ class PointerOverlay : IPointerOverlay {
     // ============================================================
     // Window management
     // ============================================================
-
-    private fun attachIfNeeded() {
-        if (attached || wm == null || view == null || lp == null) return
-        try {
-            wm!!.addView(view, lp)
-            attached = true
-        } catch (_: Exception) {
-        }
-    }
-
-    private fun detach() {
-        if (!attached) return
-        try {
-            wm?.removeView(view)
-        } catch (_: Exception) {
-        }
-        attached = false
-    }
 
     private fun applyTransform(x: Float, y: Float, headingRad: Float) {
         val p = lp ?: return

--- a/app/src/main/java/com/niki914/nexus/agentic/app/overlay/PointerOverlay.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/overlay/PointerOverlay.kt
@@ -84,14 +84,7 @@ class PointerOverlay : IPointerOverlay {
 
         view?.alpha = 0f
 
-        // Attach once and keep in the window for the overlay's lifetime.
-        // Visibility is controlled exclusively via view alpha, so there is
-        // no addView/removeView race with the fade animation.
-        try {
-            wm!!.addView(view, lp)
-            attached = true
-        } catch (_: Exception) {
-        }
+        tryAttach()
 
         grantOverlayPermission(ctx.packageName)
     }
@@ -115,6 +108,7 @@ class PointerOverlay : IPointerOverlay {
     override fun show(x: Float, y: Float) {
         handler.post {
             view?.animate()?.cancel()
+            tryAttach()
             curX = x
             curY = y
             curHeading = PointerCurveMath.IDLE_HEADING_RAD
@@ -129,6 +123,20 @@ class PointerOverlay : IPointerOverlay {
             view?.animate()?.cancel()
             cancelAnim()
             view?.animate()?.alpha(0f)?.setDuration(FADE_DURATION_MS)?.start()
+        }
+    }
+
+    override fun dispose() {
+        handler.post {
+            view?.animate()?.cancel()
+            cancelAnim()
+            if (attached) {
+                try {
+                    wm?.removeViewImmediate(view)
+                } catch (_: Exception) {
+                }
+                attached = false
+            }
         }
     }
 
@@ -264,6 +272,23 @@ class PointerOverlay : IPointerOverlay {
     // ============================================================
     // Window management
     // ============================================================
+
+    /**
+     * Idempotent attach — no-op if already in the window.
+     * Called from both [init] and [show] so that a late overlay-permission
+     * grant is picked up on the next show attempt.
+     *
+     * Callers must ensure [view.alpha] is 0 before the first successful
+     * attach so the pointer doesn't flash at default alpha=1.
+     */
+    private fun tryAttach() {
+        if (attached || wm == null || view == null || lp == null) return
+        try {
+            wm!!.addView(view, lp)
+            attached = true
+        } catch (_: Exception) {
+        }
+    }
 
     private fun applyTransform(x: Float, y: Float, headingRad: Float) {
         val p = lp ?: return

--- a/app/src/main/java/com/niki914/nexus/agentic/app/overlay/PointerOverlay.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/overlay/PointerOverlay.kt
@@ -47,6 +47,10 @@ class PointerOverlay : IPointerOverlay {
     private var prevAngleDeg =
         Math.toDegrees(PointerCurveMath.IDLE_HEADING_RAD.toDouble()).toFloat()
 
+    // Guards against hide's withEndAction detaching the view after a
+    // subsequent show() has already re-enabled it.
+    private var hiding = false
+
     // ============================================================
     // Initialization
     // ============================================================
@@ -101,6 +105,10 @@ class PointerOverlay : IPointerOverlay {
 
     override fun show(x: Float, y: Float) {
         handler.post {
+            hiding = false
+            // Cancel any running fade-out so the subsequent fade-in picks
+            // up from the current alpha (no flash).
+            view?.animate()?.cancel()
             attachIfNeeded()
             curX = x
             curY = y
@@ -113,8 +121,10 @@ class PointerOverlay : IPointerOverlay {
 
     override fun hide() {
         handler.post {
+            hiding = true
+            view?.animate()?.cancel()
             view?.animate()?.alpha(0f)?.setDuration(FADE_DURATION_MS)?.withEndAction {
-                detach()
+                if (hiding) detach()
             }?.start()
         }
     }
@@ -122,7 +132,7 @@ class PointerOverlay : IPointerOverlay {
     override suspend fun animateTo(
         x: Float, y: Float, mode: MovementMode,
     ) {
-        if (!attached) return
+        if (!attached || hiding) return
         cancelAnim()
         val t = PointerCurveMath.buildTrajectory(
             curX, curY, curHeading, x, y, mode, screenW, screenH,
@@ -133,7 +143,7 @@ class PointerOverlay : IPointerOverlay {
     override suspend fun showSwipe(
         sx: Float, sy: Float, ex: Float, ey: Float, duration: Long,
     ) {
-        if (!attached) return
+        if (!attached || hiding) return
         cancelAnim()
 
         // Phase 1: fly to swipe start (organic curve, tangent-following)

--- a/app/src/main/java/com/niki914/nexus/agentic/app/overlay/PointerOverlay.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/overlay/PointerOverlay.kt
@@ -278,12 +278,13 @@ class PointerOverlay : IPointerOverlay {
      * Called from both [init] and [show] so that a late overlay-permission
      * grant is picked up on the next show attempt.
      *
-     * Callers must ensure [view.alpha] is 0 before the first successful
-     * attach so the pointer doesn't flash at default alpha=1.
+     * Alpha is reset before every attach attempt so a view modified while
+     * detached can never flash at alpha=1 when permission becomes available.
      */
     private fun tryAttach() {
         if (attached || wm == null || view == null || lp == null) return
         try {
+            view!!.alpha = 0f
             wm!!.addView(view, lp)
             attached = true
         } catch (_: Exception) {

--- a/app/src/main/java/com/niki914/nexus/agentic/app/overlay/PointerOverlay.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/overlay/PointerOverlay.kt
@@ -4,7 +4,6 @@ import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.animation.ValueAnimator
 import android.content.Context
-import android.graphics.Path
 import android.graphics.PixelFormat
 import android.os.Build
 import android.os.Handler
@@ -14,6 +13,7 @@ import android.view.WindowManager
 import android.view.animation.LinearInterpolator
 import android.widget.ImageView
 import com.niki914.nexus.agentic.animation.PointerCurveMath
+import com.niki914.nexus.agentic.animation.PointerCurveMath.MovementMode
 import com.niki914.nexus.agentic.app.R
 import com.niki914.nexus.agentic.chat.agentic.accessibility.IPointerOverlay
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -43,8 +43,9 @@ class PointerOverlay : IPointerOverlay {
 
     private val handler = Handler(Looper.getMainLooper())
 
-    // Pre-computed speed lookup: time fraction (0..1) -> distance fraction (0..1)
-    private val speedLut: FloatArray by lazy { PointerCurveMath.buildSpeedLut() }
+    // Tracks the unwrapped heading across frames to prevent ±180° jumps
+    private var prevAngleDeg =
+        Math.toDegrees(PointerCurveMath.IDLE_HEADING_RAD.toDouble()).toFloat()
 
     // ============================================================
     // Initialization
@@ -104,7 +105,8 @@ class PointerOverlay : IPointerOverlay {
             curX = x
             curY = y
             curHeading = PointerCurveMath.IDLE_HEADING_RAD
-            applyTransform(x, y, PointerCurveMath.IDLE_HEADING_RAD)
+            prevAngleDeg = Math.toDegrees(curHeading.toDouble()).toFloat()
+            applyTransform(x, y, curHeading)
             view?.animate()?.alpha(1f)?.setDuration(FADE_DURATION_MS)?.start()
         }
     }
@@ -117,11 +119,15 @@ class PointerOverlay : IPointerOverlay {
         }
     }
 
-    override suspend fun animateTo(x: Float, y: Float) {
+    override suspend fun animateTo(
+        x: Float, y: Float, mode: MovementMode,
+    ) {
         if (!attached) return
         cancelAnim()
-        val path = PointerCurveMath.buildCurve(curX, curY, curHeading, x, y)
-        animatePath(path, x, y)
+        val t = PointerCurveMath.buildTrajectory(
+            curX, curY, curHeading, x, y, mode, screenW, screenH,
+        )
+        animateAlong(t)
     }
 
     override suspend fun showSwipe(
@@ -130,69 +136,84 @@ class PointerOverlay : IPointerOverlay {
         if (!attached) return
         cancelAnim()
 
-        // Phase 1: fly to swipe start
-        val path1 = PointerCurveMath.buildCurve(curX, curY, curHeading, sx, sy)
-        animatePath(path1, sx, sy)
+        // Phase 1: fly to swipe start (organic curve, tangent-following)
+        val fly = PointerCurveMath.buildTrajectory(
+            curX, curY, curHeading, sx, sy, MovementMode.FLY, screenW, screenH,
+        )
+        animateAlong(fly)
 
         // Brief pause so the pointer "lands" before the stroke
         delayOnMain(PointerCurveMath.SWIPE_GAP_MS)
 
-        // Phase 2: straight-line swipe trajectory
-        val path2 = Path().apply {
-            moveTo(sx, sy)
-            lineTo(ex, ey)
-        }
-        animatePathRaw(path2, ex, ey, fixedHeading = true, durationMs = duration)
+        // Phase 2: translate along swipe path (straight line, NW heading)
+        val swipe = PointerCurveMath.buildTrajectory(
+            sx, sy, curHeading, ex, ey, MovementMode.TRANSLATE, screenW, screenH,
+        )
+        // Override duration to match the requested swipe duration
+        animateAlongRaw(swipe, duration)
     }
 
     // ============================================================
     // Animation
     // ============================================================
 
-    private suspend fun animatePath(path: Path, toX: Float, toY: Float) {
-        animatePathRaw(path, toX, toY, fixedHeading = false)
+    /** Animate along [trajectory] using easeInOutSine (FLY) or linear (TRANSLATE). */
+    private suspend fun animateAlong(
+        trajectory: PointerCurveMath.Trajectory,
+    ) {
+        animateAlongRaw(trajectory, trajectory.totalDurationMs)
     }
 
     /**
-     * Drive a [ValueAnimator] along [path], ending at (toX,toY).
-     * When [fixedHeading] is true the pointer keeps its current angle (mouse-like);
-     * when false it rotates to follow the path tangent (fish-like).
+     * Drive a [ValueAnimator] along [trajectory] with an explicit [durationMs].
+     * Per-frame: ease → sample → unwrap heading → apply transform.
+     *
+     * The heading unwinding is continuous across consecutive animations
+     * (both within a showSwipe call and across separate animateTo calls)
+     * because [prevAngleDeg] persists across animation boundaries.
      */
-    private suspend fun animatePathRaw(
-        path: Path, toX: Float, toY: Float, fixedHeading: Boolean,
-        durationMs: Long? = null,
+    private suspend fun animateAlongRaw(
+        trajectory: PointerCurveMath.Trajectory,
+        durationMs: Long,
     ) {
-        val sampler = PointerCurveMath.CurveSampler(path)
-        val arcLen = sampler.length
-        if (arcLen <= 0f) return
+        if (trajectory.totalLen <= 0f) return
 
-        val duration = durationMs ?: PointerCurveMath.curveDurationMs(arcLen)
-        val startHeading = curHeading
+        val isFly = trajectory.mode == MovementMode.FLY
 
         suspendCancellableCoroutine<Unit> { cont ->
             val anim = ValueAnimator.ofFloat(0f, 1f).apply {
                 interpolator = LinearInterpolator()
-                this.duration = duration
+                duration = durationMs
                 addUpdateListener {
                     val timeFrac = it.animatedValue as Float
-                    val distFrac = PointerCurveMath.timeToDistance(timeFrac, speedLut)
-                    val sample = sampler.sample(distFrac)
-                    val h = if (fixedHeading) startHeading else sample.headingRad
+                    val distFrac = if (isFly) {
+                        PointerCurveMath.easeInOutSine(timeFrac)
+                    } else {
+                        timeFrac // linear for TRANSLATE
+                    }
+                    val frame = trajectory.sampleAtDistance(distFrac)
+                    val rawDeg = Math.toDegrees(frame.headingRad.toDouble()).toFloat()
+                    val unwrapped = PointerCurveMath.unwrapAngle(rawDeg, prevAngleDeg)
+                    prevAngleDeg = unwrapped
+                    val headingRad =
+                        Math.toRadians(unwrapped.toDouble()).toFloat()
                     handler.post {
-                        curX = sample.x
-                        curY = sample.y
-                        curHeading = h
-                        applyTransform(sample.x, sample.y, h)
+                        curX = frame.x
+                        curY = frame.y
+                        curHeading = headingRad
+                        applyTransform(frame.x, frame.y, headingRad)
                     }
                 }
                 addListener(object : AnimatorListenerAdapter() {
                     override fun onAnimationEnd(a: Animator) {
                         runningAnim = null
-                        val h = if (fixedHeading) startHeading else PointerCurveMath.IDLE_HEADING_RAD
-                        curX = toX
-                        curY = toY
-                        curHeading = h
-                        handler.post { applyTransform(toX, toY, h) }
+                        // Trajectory already ended at correct
+                        // position/heading on the last update frame
+                        curX = trajectory.endX
+                        curY = trajectory.endY
+                        handler.post {
+                            applyTransform(trajectory.endX, trajectory.endY, curHeading)
+                        }
                         if (cont.isActive) cont.resume(Unit)
                     }
 

--- a/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/content/StartupPageContent.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/content/StartupPageContent.kt
@@ -1,9 +1,7 @@
 package com.niki914.nexus.agentic.app.ui.nexus.content
 
-import android.graphics.Path
 import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.animation.core.Easing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -56,7 +54,6 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlin.math.atan2
 import kotlin.math.roundToInt
 
 private const val LETTERS = "NEXUS"
@@ -73,7 +70,6 @@ fun StartupPageContent(
     val density = LocalDensity.current
     val interactive = demoHasPlayed
     val scrollState = rememberScrollState()
-    val speedLut = remember { PointerCurveMath.buildSpeedLut() }
 
     var containerWidthPx by remember { mutableFloatStateOf(0f) }
     var containerHeightPx by remember { mutableFloatStateOf(0f) }
@@ -90,6 +86,11 @@ fun StartupPageContent(
     var cursorPosX by remember { mutableFloatStateOf(0f) }
     var cursorPosY by remember { mutableFloatStateOf(0f) }
     var cursorHeading by remember { mutableFloatStateOf(PointerCurveMath.IDLE_HEADING_RAD) }
+    var cursorPrevAngleDeg by remember {
+        mutableFloatStateOf(
+            Math.toDegrees(PointerCurveMath.IDLE_HEADING_RAD.toDouble()).toFloat()
+        )
+    }
     val buttonScale = remember { Animatable(1f) }
 
     // ---- Auto-demo animation (first visit only) ----
@@ -105,51 +106,33 @@ fun StartupPageContent(
             val centerY = h * 0.5f
             val lowerY = h * 0.72f
             val upperY = h * 0.28f
-            val pointerEasing = Easing { t -> PointerCurveMath.timeToDistance(t, speedLut) }
 
-            // Helper: bezier curve movement with heading rotation
-            suspend fun animateAlongCurve(toX: Float, toY: Float) {
-                val path = PointerCurveMath.buildCurve(
-                    cursorPosX, cursorPosY, cursorHeading, toX, toY,
-                )
-                val sampler = PointerCurveMath.CurveSampler(path)
-                val durMs = PointerCurveMath.curveDurationMs(sampler.length)
-                val durationNs = durMs * 1_000_000L
+            // Drives a pre-built trajectory frame by frame.
+            // Uses easeInOutSine for FLY, linear for TRANSLATE.
+            suspend fun animateAlong(
+                trajectory: PointerCurveMath.Trajectory,
+                durationMs: Long = trajectory.totalDurationMs,
+            ) {
+                val isFly = trajectory.mode == PointerCurveMath.MovementMode.FLY
+                val durNs = durationMs * 1_000_000L
                 val startTime = withFrameNanos { it }
                 while (true) {
                     val elapsed = withFrameNanos { it } - startTime
-                    val timeFrac = (elapsed.toFloat() / durationNs).coerceIn(0f, 1f)
-                    val distFrac = PointerCurveMath.timeToDistance(timeFrac, speedLut)
-                    val sample = sampler.sample(distFrac)
-                    cursorPosX = sample.x
-                    cursorPosY = sample.y
-                    cursorHeading = sample.headingRad
-                    if (timeFrac >= 1f) break
-                }
-            }
-
-            // Helper: straight-line swipe movement with fixed heading
-            suspend fun animateSwipe(toX: Float, toY: Float) {
-                val fromX = cursorPosX
-                val fromY = cursorPosY
-                val path = Path().apply {
-                    moveTo(fromX, fromY)
-                    lineTo(toX, toY)
-                }
-                val sampler = PointerCurveMath.CurveSampler(path)
-                val dx = toX - fromX
-                val dy = toY - fromY
-                val durMs = PointerCurveMath.DEMO_SWIPE_DURATION_MS
-                val durationNs = durMs * 1_000_000L
-                val startTime = withFrameNanos { it }
-                cursorHeading = atan2(dy, dx)
-                while (true) {
-                    val elapsed = withFrameNanos { it } - startTime
-                    val timeFrac = (elapsed.toFloat() / durationNs).coerceIn(0f, 1f)
-                    val distFrac = PointerCurveMath.timeToDistance(timeFrac, speedLut)
-                    val sample = sampler.sample(distFrac)
-                    cursorPosX = sample.x
-                    cursorPosY = sample.y
+                    val timeFrac = (elapsed.toFloat() / durNs).coerceIn(0f, 1f)
+                    val distFrac = if (isFly) {
+                        PointerCurveMath.easeInOutSine(timeFrac)
+                    } else {
+                        timeFrac
+                    }
+                    val frame = trajectory.sampleAtDistance(distFrac)
+                    val rawDeg = Math.toDegrees(frame.headingRad.toDouble()).toFloat()
+                    val unwrapped = PointerCurveMath.unwrapAngle(rawDeg, cursorPrevAngleDeg)
+                    cursorPrevAngleDeg = unwrapped
+                    val headingRad =
+                        Math.toRadians(unwrapped.toDouble()).toFloat()
+                    cursorPosX = frame.x
+                    cursorPosY = frame.y
+                    cursorHeading = headingRad
                     if (timeFrac >= 1f) break
                 }
             }
@@ -163,24 +146,46 @@ fun StartupPageContent(
             cursorAlpha.animateTo(1f, tween(300))
             delay(300)
 
-            // Phase 2: cursor moves down to lower area (bezier curve)
-            animateAlongCurve(centerX, lowerY)
+            // Phase 2: cursor flies down to lower area (organic curve)
+            val cw = containerWidthPx.toInt(); val ch = containerHeightPx.toInt()
+            animateAlong(
+                PointerCurveMath.buildTrajectory(
+                    cursorPosX, cursorPosY, cursorHeading,
+                    centerX, lowerY,
+                    PointerCurveMath.MovementMode.FLY, cw, ch,
+                )
+            )
             delay(PointerCurveMath.SWIPE_GAP_MS)
 
-            // Phase 3: swipe up (straight line, fixed heading), then list scrolls
+            // Phase 3: swipe up (straight line, NW heading), then list scrolls
             snapshotFlow { scrollState.maxValue }.first { it > 0 }
-            animateSwipe(centerX, upperY)
+            animateAlong(
+                PointerCurveMath.buildTrajectory(
+                    cursorPosX, cursorPosY, cursorHeading,
+                    centerX, upperY,
+                    PointerCurveMath.MovementMode.TRANSLATE, cw, ch,
+                ),
+                durationMs = PointerCurveMath.DEMO_SWIPE_DURATION_MS,
+            )
             scrollState.animateScrollTo(
                 scrollState.maxValue,
-                tween(1100, easing = pointerEasing),
+                tween(1100, easing = androidx.compose.animation.core.Easing {
+                    PointerCurveMath.easeInOutSine(it)
+                }),
             )
             delay(200)
 
             // Ensure button layout coordinates are ready
             snapshotFlow { buttonCenterX }.first { it > 0f }
 
-            // Phase 4: cursor flies to button (bezier curve)
-            animateAlongCurve(buttonCenterX, buttonCenterY)
+            // Phase 4: cursor flies to button (organic curve)
+            animateAlong(
+                PointerCurveMath.buildTrajectory(
+                    cursorPosX, cursorPosY, cursorHeading,
+                    buttonCenterX, buttonCenterY,
+                    PointerCurveMath.MovementMode.FLY, cw, ch,
+                )
+            )
 
             // Phase 5: press — scale down immediately
             coroutineScope {


### PR DESCRIPTION
## Summary
- Quintic Hermite spline-based pointer trajectory with smooth angle unwrapping to prevent ±180° heading jumps
- Fixed pointer overlay flash on hide by keeping the window attached for the overlay's lifetime — previously addView/removeView raced with the alpha fade, causing a re-attached view to briefly render at default alpha=1

## Test plan
- [ ] Pointer shows and hides without alpha flash/glitch
- [ ] Pointer movement between nodes follows smooth organic curves
- [ ] Pointer heading transitions continuously without abrupt 180° flips
- [ ] Swipe animation renders correctly (fly to start → swipe stroke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)