### PR TITLE
Replace blind delay_ms with two-phase UI stability detection

### DIFF
--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/AccessibilityController.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/AccessibilityController.kt
@@ -23,6 +23,7 @@ import com.niki914.nexus.agentic.chat.agentic.shell.TerminalCommandOutcome
 import com.niki914.nexus.agentic.chat.agentic.shell.TerminalOpenOutcome
 import com.niki914.nexus.agentic.chat.agentic.shell.TerminalSessionPool
 import com.niki914.nexus.xposed.api.util.ContextProvider
+import android.os.SystemClock
 import kotlinx.coroutines.delay
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
@@ -60,9 +61,9 @@ object AccessibilityController {
     var currentVersion: String = ""
         private set
 
-    /** Timestamp of the last TYPE_WINDOW_CONTENT_CHANGED event (ms, [System.currentTimeMillis]). */
+    /** Timestamp of the last UI-significant accessibility event (ms, [SystemClock.elapsedRealtime]). */
     @Volatile
-    var lastContentChangedTime: Long = 0L
+    var lastUiEventTime: Long = 0L
         private set
 
     /** Set by the app module before any screen-interaction calls. */
@@ -132,9 +133,9 @@ object AccessibilityController {
         nodeCache.clear()
     }
 
-    /** Called from [NexusAccessibilityService.onAccessibilityEvent] on TYPE_WINDOW_CONTENT_CHANGED. */
-    fun recordContentChanged() {
-        lastContentChangedTime = System.currentTimeMillis()
+    /** Called from [NexusAccessibilityService.onAccessibilityEvent] on UI-significant events. */
+    fun recordUiEvent() {
+        lastUiEventTime = SystemClock.elapsedRealtime()
     }
 
     fun clearPointerOverlay() {
@@ -339,29 +340,30 @@ object AccessibilityController {
     }
 
     /**
-     * Waits for the UI to settle after a write operation using two-phase detection:
+     * Waits for the UI to settle after a write operation using a unified
+     * event-idle + tree-hash detection loop:
      *
-     * **Phase 1 — event stream idle:** polls [lastContentChangedTime] until no
-     * TYPE_WINDOW_CONTENT_CHANGED event has been received for 300ms, with a minimum
-     * 200ms dwell to let post-action events arrive.
-     *
-     * **Phase 2 — tree hash stability:** captures the node cache twice, 50ms apart,
-     * and compares structural hashes. Both hashes must match for the tree to be
-     * considered stable.
+     * 1. Dwell at least 200ms to let post-action events arrive.
+     * 2. Sample the tree every 50ms and compare consecutive structural hashes.
+     * 3. Return when two consecutive hashes match, no accessibility event arrived
+     *    between the two samples, and the event stream has been idle for >= 300ms.
      *
      * Falls back to a forced capture (with a warning header) if [settleTimeoutMs]
-     * is exceeded in either phase.
+     * is exceeded.
      */
     suspend fun waitForStable(settleTimeoutMs: Long): Result<ScreenSnapshot> {
-        val startTime = System.currentTimeMillis()
+        val startTime = SystemClock.elapsedRealtime()
 
-        // Phase 1: wait for accessibility event stream to quiet down.
-        // Always dwell at least 200ms to let post-action events arrive.
-        val minPhase1End = startTime + 200
+        // Minimum 200ms dwell to let post-action events arrive.
+        delay(200L)
+
+        refreshNodeCache()
+        var previousHash = computeStructuralHash()
+        var previousSampleTime = SystemClock.elapsedRealtime()
+
         while (true) {
-            val now = System.currentTimeMillis()
-            val elapsed = now - startTime
-            if (elapsed >= settleTimeoutMs) {
+            val now = SystemClock.elapsedRealtime()
+            if (now - startTime >= settleTimeoutMs) {
                 return captureScreen().map { snapshot ->
                     snapshot.copy(yaml = buildString {
                         appendLine("# Note: settle timed out after ${settleTimeoutMs}ms")
@@ -369,36 +371,21 @@ object AccessibilityController {
                     })
                 }
             }
-            if (now >= minPhase1End) {
-                val idleDuration = now - lastContentChangedTime
-                if (idleDuration >= 300L) break
-            }
-            delay(50)
-        }
-
-        // Phase 2: tree structure must be identical across two samples.
-        refreshNodeCache()
-        var previousHash = computeStructuralHash()
-
-        while (true) {
-            val now = System.currentTimeMillis()
-            val elapsed = now - startTime
-            if (elapsed >= settleTimeoutMs) {
-                return captureScreen().map { snapshot ->
-                    snapshot.copy(yaml = buildString {
-                        appendLine("# Note: settle timed out after ${settleTimeoutMs}ms, tree may still be changing")
-                        append(snapshot.yaml)
-                    })
-                }
-            }
             delay(50)
             refreshNodeCache()
             val currentHash = computeStructuralHash()
-            if (currentHash == previousHash) break
-            previousHash = currentHash
-        }
+            val sampleTime = SystemClock.elapsedRealtime()
 
-        return captureScreen()
+            if (currentHash == previousHash
+                && lastUiEventTime <= previousSampleTime
+                && sampleTime - lastUiEventTime >= 300L
+            ) {
+                return captureScreen()
+            }
+
+            previousHash = currentHash
+            previousSampleTime = sampleTime
+        }
     }
 
     /**

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/AccessibilityController.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/AccessibilityController.kt
@@ -354,8 +354,11 @@ object AccessibilityController {
     suspend fun waitForStable(settleTimeoutMs: Long): Result<ScreenSnapshot> {
         val startTime = SystemClock.elapsedRealtime()
 
-        // Minimum 200ms dwell to let post-action events arrive.
-        delay(200L)
+        // Minimum 200ms dwell to let post-action events arrive, capped at remaining deadline.
+        val remaining = settleTimeoutMs - (SystemClock.elapsedRealtime() - startTime)
+        if (remaining > 0) {
+            delay(minOf(200L, remaining))
+        }
 
         refreshNodeCache()
         var previousHash = computeStructuralHash()

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/AccessibilityController.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/AccessibilityController.kt
@@ -60,6 +60,11 @@ object AccessibilityController {
     var currentVersion: String = ""
         private set
 
+    /** Timestamp of the last TYPE_WINDOW_CONTENT_CHANGED event (ms, [System.currentTimeMillis]). */
+    @Volatile
+    var lastContentChangedTime: Long = 0L
+        private set
+
     /** Set by the app module before any screen-interaction calls. */
     @Volatile
     var pointerOverlay: IPointerOverlay? = null
@@ -125,6 +130,11 @@ object AccessibilityController {
     fun clearService() {
         serviceInstance = null
         nodeCache.clear()
+    }
+
+    /** Called from [NexusAccessibilityService.onAccessibilityEvent] on TYPE_WINDOW_CONTENT_CHANGED. */
+    fun recordContentChanged() {
+        lastContentChangedTime = System.currentTimeMillis()
     }
 
     fun clearPointerOverlay() {
@@ -326,6 +336,98 @@ object AccessibilityController {
     suspend fun captureScreenAfterDelay(delayMs: Long): Result<ScreenSnapshot> {
         if (delayMs > 0) delay(delayMs)
         return captureScreen()
+    }
+
+    /**
+     * Waits for the UI to settle after a write operation using two-phase detection:
+     *
+     * **Phase 1 — event stream idle:** polls [lastContentChangedTime] until no
+     * TYPE_WINDOW_CONTENT_CHANGED event has been received for 300ms, with a minimum
+     * 200ms dwell to let post-action events arrive.
+     *
+     * **Phase 2 — tree hash stability:** captures the node cache twice, 50ms apart,
+     * and compares structural hashes. Both hashes must match for the tree to be
+     * considered stable.
+     *
+     * Falls back to a forced capture (with a warning header) if [settleTimeoutMs]
+     * is exceeded in either phase.
+     */
+    suspend fun waitForStable(settleTimeoutMs: Long): Result<ScreenSnapshot> {
+        val startTime = System.currentTimeMillis()
+
+        // Phase 1: wait for accessibility event stream to quiet down.
+        // Always dwell at least 200ms to let post-action events arrive.
+        val minPhase1End = startTime + 200
+        while (true) {
+            val now = System.currentTimeMillis()
+            val elapsed = now - startTime
+            if (elapsed >= settleTimeoutMs) {
+                return captureScreen().map { snapshot ->
+                    snapshot.copy(yaml = buildString {
+                        appendLine("# Note: settle timed out after ${settleTimeoutMs}ms")
+                        append(snapshot.yaml)
+                    })
+                }
+            }
+            if (now >= minPhase1End) {
+                val idleDuration = now - lastContentChangedTime
+                if (idleDuration >= 300L) break
+            }
+            delay(50)
+        }
+
+        // Phase 2: tree structure must be identical across two samples.
+        refreshNodeCache()
+        var previousHash = computeStructuralHash()
+
+        while (true) {
+            val now = System.currentTimeMillis()
+            val elapsed = now - startTime
+            if (elapsed >= settleTimeoutMs) {
+                return captureScreen().map { snapshot ->
+                    snapshot.copy(yaml = buildString {
+                        appendLine("# Note: settle timed out after ${settleTimeoutMs}ms, tree may still be changing")
+                        append(snapshot.yaml)
+                    })
+                }
+            }
+            delay(50)
+            refreshNodeCache()
+            val currentHash = computeStructuralHash()
+            if (currentHash == previousHash) break
+            previousHash = currentHash
+        }
+
+        return captureScreen()
+    }
+
+    /**
+     * Computes a version-independent structural hash of the current [nodeCache].
+     *
+     * The hash covers node count, per-node class name, bounds, text, content
+     * description, and key boolean flags — enough to detect meaningful tree
+     * changes without paying YAML serialization cost.
+     */
+    private fun computeStructuralHash(): Int {
+        var hash = nodeCache.size
+        nodeCache.entries.sortedBy { it.key }.forEach { (index, node) ->
+            hash = 31 * hash + index
+            hash = 31 * hash + (node.className?.toString().orEmpty().hashCode())
+            hash = 31 * hash + (node.text?.toString().orEmpty().hashCode())
+            hash = 31 * hash + (node.contentDescription?.toString().orEmpty().hashCode())
+            hash = 31 * hash + node.isClickable.hashCode()
+            hash = 31 * hash + node.isLongClickable.hashCode()
+            hash = 31 * hash + node.isEditable.hashCode()
+            hash = 31 * hash + node.isScrollable.hashCode()
+            hash = 31 * hash + node.isVisibleToUser.hashCode()
+            val rect = android.graphics.Rect()
+            node.getBoundsInScreen(rect)
+            hash = 31 * hash + rect.left
+            hash = 31 * hash + rect.top
+            hash = 31 * hash + rect.right
+            hash = 31 * hash + rect.bottom
+        }
+        return hash
     }
 
     /**

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationAccessibilityBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationAccessibilityBuiltin.kt
@@ -2,6 +2,7 @@ package com.niki914.nexus.agentic.chat.agentic.buildin.impl
 
 import com.niki914.nexus.agentic.chat.agentic.accessibility.AccessibilityController
 import com.niki914.nexus.agentic.chat.agentic.accessibility.NodeAction
+import com.niki914.nexus.agentic.chat.agentic.accessibility.ScreenSnapshot
 import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinToolRequest
 import com.niki914.nexus.agentic.chat.agentic.buildin.RawBuiltinTool
 import com.niki914.nexus.agentic.chat.agentic.buildin.ScreenOperationError
@@ -40,9 +41,10 @@ class ScreenOperationAccessibilityBuiltin : RawBuiltinTool() {
                 "wait_mode (default \"stable\"): \"stable\" detects when the UI actually settles " +
                 "(event idle + tree hash) and returns early — use for taps, scrolls, text input. " +
                 "\"delay\" does a blind fixed wait — use for search/refresh where data arrives " +
-                "asynchronously and the UI may appear stable before results load.\n" +
-                "wait_ms (default 5000): for \"stable\" this is the max deadline; for \"delay\" " +
-                "this is the fixed blind-wait duration.\n\n" +
+                "asynchronously and the UI may appear stable before results load. " +
+                "Must be \"stable\" or \"delay\".\n" +
+                "wait_ms (default 2000, max 60000): for \"stable\" this is the max deadline; " +
+                "for \"delay\" this is the fixed blind-wait duration.\n\n" +
                 "Tokens belong to exactly one snapshot — every read, search, and successful " +
                 "write operation produces a fresh version. Use only tokens from the most " +
                 "recently returned result."
@@ -70,11 +72,11 @@ class ScreenOperationAccessibilityBuiltin : RawBuiltinTool() {
             required = false
         }
         config.string("wait_mode") {
-            description = "\"stable\" (default): detect UI stability before capture, returns early if settled. \"delay\": blind fixed wait — use for search/refresh."
+            description = "\"stable\" (default): detect UI stability before capture, returns early if settled. \"delay\": blind fixed wait — use for search/refresh. Must be \"stable\" or \"delay\"."
             required = false
         }
         config.number("wait_ms") {
-            description = "Wait duration in ms, default 5000. For stable mode: max deadline. For delay mode: fixed sleep."
+            description = "Wait duration in ms, default 2000, max 60000. For stable mode: max deadline. For delay mode: fixed sleep."
             required = false
         }
     }
@@ -91,7 +93,8 @@ class ScreenOperationAccessibilityBuiltin : RawBuiltinTool() {
         return try {
             when (val op = args.operation) {
                 is ScreenOp.Read -> {
-                    AccessibilityController.captureScreen()
+                    val capture = captureAfterOptionalWait(args)
+                    capture
                         .fold(
                             onSuccess = { it.yaml },
                             onFailure = { e ->
@@ -121,6 +124,7 @@ class ScreenOperationAccessibilityBuiltin : RawBuiltinTool() {
                 )
 
                 is ScreenOp.Search -> {
+                    waitBeforeSearch(args)
                     AccessibilityController.searchNodes(op.keywords, op.matchMode, op.limit)
                         .fold(
                             onSuccess = { it },
@@ -170,6 +174,29 @@ class ScreenOperationAccessibilityBuiltin : RawBuiltinTool() {
                 errorJson("SERVICE_UNAVAILABLE", e.message ?: "Service unavailable")
             },
         )
+    }
+
+    /**
+     * Captures the screen, optionally waiting first when [ScreenOpArgs.hasExplicitWaitMode]
+     * is true. Without an explicit wait request, captures immediately (legacy read behavior).
+     */
+    private suspend fun captureAfterOptionalWait(args: ScreenOpArgs): Result<ScreenSnapshot> {
+        if (!args.hasExplicitWaitMode) return AccessibilityController.captureScreen()
+        return if (args.waitMode == "delay") {
+            AccessibilityController.captureScreenAfterDelay(args.waitMs)
+        } else {
+            AccessibilityController.waitForStable(args.waitMs)
+        }
+    }
+
+    /** Waits before a search when the agent explicitly requested it. */
+    private suspend fun waitBeforeSearch(args: ScreenOpArgs) {
+        if (!args.hasExplicitWaitMode) return
+        if (args.waitMode == "delay") {
+            AccessibilityController.captureScreenAfterDelay(args.waitMs)
+        } else {
+            AccessibilityController.waitForStable(args.waitMs)
+        }
     }
 
     private fun errorJson(code: String, message: String): String {

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationAccessibilityBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationAccessibilityBuiltin.kt
@@ -8,6 +8,7 @@ import com.niki914.nexus.agentic.chat.agentic.buildin.RawBuiltinTool
 import com.niki914.nexus.agentic.chat.agentic.buildin.ScreenOperationError
 import com.niki914.s3ss10n.LocalToolConfig
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
 
 /**
  * RawBuiltinTool for accessibility-service-based screen interaction.
@@ -43,8 +44,8 @@ class ScreenOperationAccessibilityBuiltin : RawBuiltinTool() {
                 "\"delay\" does a blind fixed wait — use for search/refresh where data arrives " +
                 "asynchronously and the UI may appear stable before results load. " +
                 "Must be \"stable\" or \"delay\".\n" +
-                "wait_ms (default 2000, max 60000): for \"stable\" this is the max deadline; " +
-                "for \"delay\" this is the fixed blind-wait duration.\n\n" +
+                "wait_ms: for \"stable\" the max deadline (default 2000, max 60000); " +
+                "for \"delay\" required (no default), the fixed blind-wait duration.\n\n" +
                 "Tokens belong to exactly one snapshot — every read, search, and successful " +
                 "write operation produces a fresh version. Use only tokens from the most " +
                 "recently returned result."
@@ -76,7 +77,7 @@ class ScreenOperationAccessibilityBuiltin : RawBuiltinTool() {
             required = false
         }
         config.number("wait_ms") {
-            description = "Wait duration in ms, default 2000, max 60000. For stable mode: max deadline. For delay mode: fixed sleep."
+            description = "Wait duration in ms. Stable mode: max deadline (default 2000, max 60000). Delay mode: required, fixed sleep (0-60000)."
             required = false
         }
     }
@@ -193,7 +194,7 @@ class ScreenOperationAccessibilityBuiltin : RawBuiltinTool() {
     private suspend fun waitBeforeSearch(args: ScreenOpArgs) {
         if (!args.hasExplicitWaitMode) return
         if (args.waitMode == "delay") {
-            AccessibilityController.captureScreenAfterDelay(args.waitMs)
+            delay(args.waitMs)
         } else {
             AccessibilityController.waitForStable(args.waitMs)
         }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationAccessibilityBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationAccessibilityBuiltin.kt
@@ -37,9 +37,15 @@ class ScreenOperationAccessibilityBuiltin : RawBuiltinTool() {
                 "Returns matched nodes with tokens + version header.\n\n" +
                 "If read returns root-only or empty tree: app likely uses non-native UI " +
                 "(Flutter/Unity/WebView) — stop, do not retry.\n\n" +
-                "delay_ms (default 1000): post-action wait before capture. Tokens belong to exactly " +
-                "one snapshot — every read, search, and successful write operation produces a fresh version. " +
-                "Use only tokens from the most recently returned result."
+                "wait_mode (default \"stable\"): \"stable\" detects when the UI actually settles " +
+                "(event idle + tree hash) and returns early — use for taps, scrolls, text input. " +
+                "\"delay\" does a blind fixed wait — use for search/refresh where data arrives " +
+                "asynchronously and the UI may appear stable before results load.\n" +
+                "wait_ms (default 5000): for \"stable\" this is the max deadline; for \"delay\" " +
+                "this is the fixed blind-wait duration.\n\n" +
+                "Tokens belong to exactly one snapshot — every read, search, and successful " +
+                "write operation produces a fresh version. Use only tokens from the most " +
+                "recently returned result."
 
     override fun configure(config: LocalToolConfig) {
         config.description = description
@@ -63,8 +69,12 @@ class ScreenOperationAccessibilityBuiltin : RawBuiltinTool() {
             description = "Max search results to return, default 10."
             required = false
         }
-        config.number("delay_ms") {
-            description = "Post-write-operation wait in ms before capturing the updated screen tree, default 1000."
+        config.string("wait_mode") {
+            description = "\"stable\" (default): detect UI stability before capture, returns early if settled. \"delay\": blind fixed wait — use for search/refresh."
+            required = false
+        }
+        config.number("wait_ms") {
+            description = "Wait duration in ms, default 5000. For stable mode: max deadline. For delay mode: fixed sleep."
             required = false
         }
     }
@@ -91,23 +101,23 @@ class ScreenOperationAccessibilityBuiltin : RawBuiltinTool() {
                 }
 
                 is ScreenOp.Tap -> executeNodeActionAndCapture(
-                    op.token, NodeAction.CLICK, null, args.delayMs
+                    op.token, NodeAction.CLICK, null, args.waitMode, args.waitMs
                 )
 
                 is ScreenOp.LongClick -> executeNodeActionAndCapture(
-                    op.token, NodeAction.LONG_CLICK, null, args.delayMs
+                    op.token, NodeAction.LONG_CLICK, null, args.waitMode, args.waitMs
                 )
 
                 is ScreenOp.ScrollForward -> executeNodeActionAndCapture(
-                    op.token, NodeAction.SCROLL_FORWARD, null, args.delayMs
+                    op.token, NodeAction.SCROLL_FORWARD, null, args.waitMode, args.waitMs
                 )
 
                 is ScreenOp.ScrollBackward -> executeNodeActionAndCapture(
-                    op.token, NodeAction.SCROLL_BACKWARD, null, args.delayMs
+                    op.token, NodeAction.SCROLL_BACKWARD, null, args.waitMode, args.waitMs
                 )
 
                 is ScreenOp.SetText -> executeNodeActionAndCapture(
-                    op.token, NodeAction.SET_TEXT, op.text, args.delayMs
+                    op.token, NodeAction.SET_TEXT, op.text, args.waitMode, args.waitMs
                 )
 
                 is ScreenOp.Search -> {
@@ -134,7 +144,7 @@ class ScreenOperationAccessibilityBuiltin : RawBuiltinTool() {
     }
 
     /**
-     * Executes a node action, then captures the updated screen after a delay.
+     * Executes a node action, then captures the updated screen according to [waitMode].
      *
      * Returns the YAML representation on success, or an error JSON string on failure.
      */
@@ -142,19 +152,24 @@ class ScreenOperationAccessibilityBuiltin : RawBuiltinTool() {
         token: String,
         action: NodeAction,
         text: String?,
-        delayMs: Long,
+        waitMode: String,
+        waitMs: Long,
     ): String {
         val actionResult = AccessibilityController.executeNodeAction(token, action, text)
         if (!actionResult.ok) {
             return errorJson(actionResult.code, actionResult.message)
         }
-        return AccessibilityController.captureScreenAfterDelay(delayMs)
-            .fold(
-                onSuccess = { it.yaml },
-                onFailure = { e ->
-                    errorJson("SERVICE_UNAVAILABLE", e.message ?: "Service unavailable")
-                },
-            )
+        val capture = if (waitMode == "delay") {
+            AccessibilityController.captureScreenAfterDelay(waitMs)
+        } else {
+            AccessibilityController.waitForStable(waitMs)
+        }
+        return capture.fold(
+            onSuccess = { it.yaml },
+            onFailure = { e ->
+                errorJson("SERVICE_UNAVAILABLE", e.message ?: "Service unavailable")
+            },
+        )
     }
 
     private fun errorJson(code: String, message: String): String {

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationArgs.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationArgs.kt
@@ -36,7 +36,8 @@ sealed class ScreenOp {
 data class ScreenOpArgs(
     val operation: ScreenOp,
     val waitMode: String = "stable",
-    val waitMs: Long = 5000,
+    val waitMs: Long = 2000,
+    val hasExplicitWaitMode: Boolean = false,
 )
 
 fun parseArguments(argumentsJson: String): Result<ScreenOpArgs> {
@@ -63,11 +64,29 @@ fun parseArguments(argumentsJson: String): Result<ScreenOpArgs> {
         )
 
     // Backward compat: old delay_ms field maps to wait_mode "delay"
+    val hasExplicitWaitMode = obj.contains("wait_mode") || obj.contains("delay_ms")
+    val hasExplicitWaitMs = obj.contains("wait_ms") || obj.contains("delay_ms")
     val waitMode = obj["wait_mode"]?.jsonPrimitive?.contentOrNull
         ?: if (obj.contains("delay_ms")) "delay" else "stable"
     val waitMs = obj["wait_ms"]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull()?.toLong()
         ?: obj["delay_ms"]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull()?.toLong()
-        ?: 5000L
+
+    if (waitMode != "stable" && waitMode != "delay") {
+        return Result.failure(
+            IllegalArgumentException("wait_mode must be 'stable' or 'delay', got '$waitMode'")
+        )
+    }
+    if (waitMs != null && (waitMs < 0 || waitMs > 60_000)) {
+        return Result.failure(
+            IllegalArgumentException("wait_ms must be in range 0..60000, got $waitMs")
+        )
+    }
+    if (waitMode == "delay" && !hasExplicitWaitMs) {
+        return Result.failure(
+            IllegalArgumentException("wait_ms is required when wait_mode is 'delay'")
+        )
+    }
+    val finalWaitMs = waitMs ?: 2000L
 
     val operation = when (operationName) {
         "read" -> ScreenOp.Read
@@ -181,5 +200,5 @@ fun parseArguments(argumentsJson: String): Result<ScreenOpArgs> {
         )
     }
 
-    return Result.success(ScreenOpArgs(operation, waitMode, waitMs))
+    return Result.success(ScreenOpArgs(operation, waitMode, finalWaitMs, hasExplicitWaitMode))
 }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationArgs.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationArgs.kt
@@ -35,7 +35,8 @@ sealed class ScreenOp {
 
 data class ScreenOpArgs(
     val operation: ScreenOp,
-    val delayMs: Long = 1000,
+    val waitMode: String = "stable",
+    val waitMs: Long = 5000,
 )
 
 fun parseArguments(argumentsJson: String): Result<ScreenOpArgs> {
@@ -61,7 +62,12 @@ fun parseArguments(argumentsJson: String): Result<ScreenOpArgs> {
             IllegalArgumentException("Missing required field: operation.")
         )
 
-    val delayMs = obj["delay_ms"]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull()?.toLong() ?: 1000L
+    // Backward compat: old delay_ms field maps to wait_mode "delay"
+    val waitMode = obj["wait_mode"]?.jsonPrimitive?.contentOrNull
+        ?: if (obj.contains("delay_ms")) "delay" else "stable"
+    val waitMs = obj["wait_ms"]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull()?.toLong()
+        ?: obj["delay_ms"]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull()?.toLong()
+        ?: 5000L
 
     val operation = when (operationName) {
         "read" -> ScreenOp.Read
@@ -175,5 +181,5 @@ fun parseArguments(argumentsJson: String): Result<ScreenOpArgs> {
         )
     }
 
-    return Result.success(ScreenOpArgs(operation, delayMs))
+    return Result.success(ScreenOpArgs(operation, waitMode, waitMs))
 }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationArgs.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationArgs.kt
@@ -65,11 +65,28 @@ fun parseArguments(argumentsJson: String): Result<ScreenOpArgs> {
 
     // Backward compat: old delay_ms field maps to wait_mode "delay"
     val hasExplicitWaitMode = obj.contains("wait_mode") || obj.contains("delay_ms")
-    val hasExplicitWaitMs = obj.contains("wait_ms") || obj.contains("delay_ms")
+    val waitMsField = obj["wait_ms"]?.jsonPrimitive?.contentOrNull
+    val delayMsField = obj["delay_ms"]?.jsonPrimitive?.contentOrNull
+    val hasExplicitWaitMs = waitMsField != null || delayMsField != null
     val waitMode = obj["wait_mode"]?.jsonPrimitive?.contentOrNull
-        ?: if (obj.contains("delay_ms")) "delay" else "stable"
-    val waitMs = obj["wait_ms"]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull()?.toLong()
-        ?: obj["delay_ms"]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull()?.toLong()
+        ?: if (delayMsField != null) "delay" else "stable"
+    val waitMs: Long? = when {
+        waitMsField != null -> {
+            val parsed = waitMsField.toDoubleOrNull()?.toLong()
+            if (parsed == null) return Result.failure(
+                IllegalArgumentException("wait_ms must be a number, got '$waitMsField'")
+            )
+            parsed
+        }
+        delayMsField != null -> {
+            val parsed = delayMsField.toDoubleOrNull()?.toLong()
+            if (parsed == null) return Result.failure(
+                IllegalArgumentException("delay_ms must be a number, got '$delayMsField'")
+            )
+            parsed
+        }
+        else -> null
+    }
 
     if (waitMode != "stable" && waitMode != "delay") {
         return Result.failure(

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationShellBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationShellBuiltin.kt
@@ -69,11 +69,11 @@ class ScreenOperationShellBuiltin : RawBuiltinTool() {
             required = false
         }
         config.string("wait_mode") {
-            description = "\"stable\" (default): detect UI stability before capture, returns early if settled. \"delay\": blind fixed wait — use for search/refresh."
+            description = "\"stable\" (default): detect UI stability before capture, returns early if settled. \"delay\": blind fixed wait — use for search/refresh. Must be \"stable\" or \"delay\"."
             required = false
         }
         config.number("wait_ms") {
-            description = "Wait duration in ms, default 5000. For stable mode: max deadline. For delay mode: fixed sleep."
+            description = "Wait duration in ms, default 2000, max 60000. For stable mode: max deadline. For delay mode: fixed sleep."
             required = false
         }
     }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationShellBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationShellBuiltin.kt
@@ -28,7 +28,7 @@ class ScreenOperationShellBuiltin : RawBuiltinTool() {
                 "Key codes: BACK=4, HOME=3, RECENTS=187, NOTIFICATIONS=83, QUICK_SETTINGS=84.\n\n" +
                 "wait_mode (default \"stable\"): \"stable\" auto-detects UI stability before capture. " +
                 "\"delay\" does a blind fixed wait — use for search/refresh. " +
-                "wait_ms (default 5000): deadline for stable, fixed sleep for delay."
+                "wait_ms (default 2000): deadline for stable, required for delay."
 
     override fun configure(config: LocalToolConfig) {
         config.description = description
@@ -73,7 +73,7 @@ class ScreenOperationShellBuiltin : RawBuiltinTool() {
             required = false
         }
         config.number("wait_ms") {
-            description = "Wait duration in ms, default 2000, max 60000. For stable mode: max deadline. For delay mode: fixed sleep."
+            description = "Wait duration in ms. Stable mode: max deadline (default 2000, max 60000). Delay mode: required, fixed sleep (0-60000)."
             required = false
         }
     }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationShellBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationShellBuiltin.kt
@@ -26,7 +26,9 @@ class ScreenOperationShellBuiltin : RawBuiltinTool() {
                 "Coordinates MUST come from the most recently returned screen tree — never " +
                 "hallucinate. Every successful write op auto-captures the updated tree.\n\n" +
                 "Key codes: BACK=4, HOME=3, RECENTS=187, NOTIFICATIONS=83, QUICK_SETTINGS=84.\n\n" +
-                "delay_ms (default 1000): post-action wait before capture."
+                "wait_mode (default \"stable\"): \"stable\" auto-detects UI stability before capture. " +
+                "\"delay\" does a blind fixed wait — use for search/refresh. " +
+                "wait_ms (default 5000): deadline for stable, fixed sleep for delay."
 
     override fun configure(config: LocalToolConfig) {
         config.description = description
@@ -66,8 +68,12 @@ class ScreenOperationShellBuiltin : RawBuiltinTool() {
             description = "Android key code: BACK=4, HOME=3, RECENTS=187, NOTIFICATIONS=83, QUICK_SETTINGS=84."
             required = false
         }
-        config.number("delay_ms") {
-            description = "Post-write-operation wait in ms before capturing the updated screen tree, default 1000."
+        config.string("wait_mode") {
+            description = "\"stable\" (default): detect UI stability before capture, returns early if settled. \"delay\": blind fixed wait — use for search/refresh."
+            required = false
+        }
+        config.number("wait_ms") {
+            description = "Wait duration in ms, default 5000. For stable mode: max deadline. For delay mode: fixed sleep."
             required = false
         }
     }
@@ -83,21 +89,21 @@ class ScreenOperationShellBuiltin : RawBuiltinTool() {
 
         return try {
             when (val op = args.operation) {
-                is ScreenOp.ShellTap -> executeShellAndCapture(args.delayMs) {
+                is ScreenOp.ShellTap -> executeShellAndCapture(args.waitMode, args.waitMs) {
                     AccessibilityController.executeShellTap(op.x, op.y)
                 }
 
-                is ScreenOp.ShellLongClick -> executeShellAndCapture(args.delayMs) {
+                is ScreenOp.ShellLongClick -> executeShellAndCapture(args.waitMode, args.waitMs) {
                     AccessibilityController.executeShellLongClick(op.x, op.y)
                 }
 
-                is ScreenOp.ShellSwipe -> executeShellAndCapture(args.delayMs) {
+                is ScreenOp.ShellSwipe -> executeShellAndCapture(args.waitMode, args.waitMs) {
                     AccessibilityController.executeShellSwipe(
                         op.startX, op.startY, op.endX, op.endY, op.duration
                     )
                 }
 
-                is ScreenOp.ShellKey -> executeShellAndCapture(args.delayMs) {
+                is ScreenOp.ShellKey -> executeShellAndCapture(args.waitMode, args.waitMs) {
                     AccessibilityController.executeKeyEvent(op.code)
                 }
 
@@ -115,25 +121,30 @@ class ScreenOperationShellBuiltin : RawBuiltinTool() {
     }
 
     /**
-     * Executes a shell operation, then captures the updated screen after a delay.
+     * Executes a shell operation, then captures the updated screen according to [waitMode].
      *
      * Returns the YAML representation on success, or an error JSON string on failure.
      */
     private suspend fun executeShellAndCapture(
-        delayMs: Long,
+        waitMode: String,
+        waitMs: Long,
         executor: suspend () -> BuiltinToolResult,
     ): String {
         val result = executor()
         if (!result.ok) {
             return errorJson(result.code, result.message)
         }
-        return AccessibilityController.captureScreenAfterDelay(delayMs)
-            .fold(
-                onSuccess = { it.yaml },
-                onFailure = { e ->
-                    errorJson("SERVICE_UNAVAILABLE", e.message ?: "Service unavailable")
-                },
-            )
+        val capture = if (waitMode == "delay") {
+            AccessibilityController.captureScreenAfterDelay(waitMs)
+        } else {
+            AccessibilityController.waitForStable(waitMs)
+        }
+        return capture.fold(
+            onSuccess = { it.yaml },
+            onFailure = { e ->
+                errorJson("SERVICE_UNAVAILABLE", e.message ?: "Service unavailable")
+            },
+        )
     }
 
     private fun errorJson(code: String, message: String): String {

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationArgsTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationArgsTest.kt
@@ -13,7 +13,7 @@ class ScreenOperationArgsTest {
         val args = result.getOrThrow()
         assertTrue(args.operation is ScreenOp.Read)
         assertEquals("stable", args.waitMode)
-        assertEquals(5000L, args.waitMs)
+        assertEquals(2000L, args.waitMs)
     }
 
     @Test
@@ -68,7 +68,7 @@ class ScreenOperationArgsTest {
         assertTrue(args.operation is ScreenOp.Tap)
         assertEquals("a3f2_42", (args.operation as ScreenOp.Tap).token)
         assertEquals("stable", args.waitMode)
-        assertEquals(5000L, args.waitMs)
+        assertEquals(2000L, args.waitMs)
     }
 
     @Test

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationArgsTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationArgsTest.kt
@@ -183,6 +183,60 @@ class ScreenOperationArgsTest {
     }
 
     @Test
+    fun parse_invalidWaitMode_fails() {
+        val result = parseArguments("""{"operation": "read", "wait_mode": "instant"}""")
+        assertTrue(result.isFailure)
+        assertTrue(
+            result.exceptionOrNull()?.message?.contains("wait_mode must be 'stable' or 'delay'") == true
+        )
+    }
+
+    @Test
+    fun parse_delayWithoutWaitMs_fails() {
+        val result = parseArguments("""{"operation": "read", "wait_mode": "delay"}""")
+        assertTrue(result.isFailure)
+        assertTrue(
+            result.exceptionOrNull()?.message?.contains("wait_ms is required when wait_mode is 'delay'") == true
+        )
+    }
+
+    @Test
+    fun parse_nonNumericWaitMs_fails() {
+        val result = parseArguments("""{"operation": "read", "wait_ms": "abc"}""")
+        assertTrue(result.isFailure)
+        assertTrue(
+            result.exceptionOrNull()?.message?.contains("wait_ms must be a number") == true
+        )
+    }
+
+    @Test
+    fun parse_nonNumericDelayMs_fails() {
+        val result = parseArguments("""{"operation": "read", "delay_ms": "abc"}""")
+        assertTrue(result.isFailure)
+        assertTrue(
+            result.exceptionOrNull()?.message?.contains("delay_ms must be a number") == true
+        )
+    }
+
+    @Test
+    fun parse_waitMsExceedsMax_fails() {
+        val result = parseArguments("""{"operation": "read", "wait_ms": 99999}""")
+        assertTrue(result.isFailure)
+        assertTrue(
+            result.exceptionOrNull()?.message?.contains("wait_ms must be in range 0..60000") == true
+        )
+    }
+
+    @Test
+    fun parse_waitMsNegative_fails() {
+        val result = parseArguments("""{"operation": "read", "wait_ms": -1}""")
+        assertTrue(result.isFailure)
+        assertTrue(
+            result.exceptionOrNull()?.message?.contains("wait_ms must be in range 0..60000") == true
+        )
+    }
+
+    @Test
     fun parse_shellTapMissingX_fails() {
         val result = parseArguments("""{"operation": "tap", "y": 200}""")
         assertTrue(result.isFailure)

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationArgsTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationArgsTest.kt
@@ -7,21 +7,57 @@ import org.junit.Test
 class ScreenOperationArgsTest {
 
     @Test
-    fun parse_read_defaultDelay() {
+    fun parse_read_defaultWaitMode() {
         val result = parseArguments("""{"operation": "read"}""")
         assertTrue(result.isSuccess)
         val args = result.getOrThrow()
         assertTrue(args.operation is ScreenOp.Read)
-        assertEquals(1000L, args.delayMs)
+        assertEquals("stable", args.waitMode)
+        assertEquals(5000L, args.waitMs)
     }
 
     @Test
-    fun parse_read_customDelay() {
+    fun parse_read_explicitStable() {
+        val result = parseArguments(
+            """{"operation": "read", "wait_mode": "stable", "wait_ms": 3000}"""
+        )
+        assertTrue(result.isSuccess)
+        val args = result.getOrThrow()
+        assertEquals("stable", args.waitMode)
+        assertEquals(3000L, args.waitMs)
+    }
+
+    @Test
+    fun parse_read_delayMode() {
+        val result = parseArguments(
+            """{"operation": "read", "wait_mode": "delay", "wait_ms": 3000}"""
+        )
+        assertTrue(result.isSuccess)
+        val args = result.getOrThrow()
+        assertEquals("delay", args.waitMode)
+        assertEquals(3000L, args.waitMs)
+    }
+
+    @Test
+    fun parse_backwardCompat_delayMs() {
         val result = parseArguments("""{"operation": "read", "delay_ms": 1000}""")
         assertTrue(result.isSuccess)
         val args = result.getOrThrow()
-        assertTrue(args.operation is ScreenOp.Read)
-        assertEquals(1000L, args.delayMs)
+        // Old delay_ms field maps to wait_mode "delay"
+        assertEquals("delay", args.waitMode)
+        assertEquals(1000L, args.waitMs)
+    }
+
+    @Test
+    fun parse_backwardCompat_delayMsWithWaitMode() {
+        // When both old and new params are present, wait_mode wins
+        val result = parseArguments(
+            """{"operation": "tap", "token": "x_1", "delay_ms": 2000, "wait_mode": "stable"}"""
+        )
+        assertTrue(result.isSuccess)
+        val args = result.getOrThrow()
+        assertEquals("stable", args.waitMode)
+        assertEquals(2000L, args.waitMs)
     }
 
     @Test
@@ -31,7 +67,8 @@ class ScreenOperationArgsTest {
         val args = result.getOrThrow()
         assertTrue(args.operation is ScreenOp.Tap)
         assertEquals("a3f2_42", (args.operation as ScreenOp.Tap).token)
-        assertEquals(1000L, args.delayMs)
+        assertEquals("stable", args.waitMode)
+        assertEquals(5000L, args.waitMs)
     }
 
     @Test

--- a/app/src/main/java/com/niki914/nexus/agentic/mod/feat/NexusAccessibilityService.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/mod/feat/NexusAccessibilityService.kt
@@ -22,7 +22,9 @@ class NexusAccessibilityService : AccessibilityService(), IAccessibility {
     }
 
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
-        // no-op
+        if (event?.eventType == AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED) {
+            AccessibilityController.recordContentChanged()
+        }
     }
 
     override fun onInterrupt() {

--- a/app/src/main/java/com/niki914/nexus/agentic/mod/feat/NexusAccessibilityService.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/mod/feat/NexusAccessibilityService.kt
@@ -22,8 +22,14 @@ class NexusAccessibilityService : AccessibilityService(), IAccessibility {
     }
 
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
-        if (event?.eventType == AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED) {
-            AccessibilityController.recordContentChanged()
+        val type = event?.eventType ?: return
+        if (type == AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED
+            || type == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED
+            || type == AccessibilityEvent.TYPE_WINDOWS_CHANGED
+            || type == AccessibilityEvent.TYPE_VIEW_SCROLLED
+            || type == AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED
+        ) {
+            AccessibilityController.recordUiEvent()
         }
     }
 


### PR DESCRIPTION
## Summary
- Replaces blind `delay_ms` with automatic UI stability detection via `wait_mode`/`wait_ms`
- Default mode is `"stable"`: two-phase detection (accessibility event idle + tree hash stability) with early return
- `"delay"` mode retained for search/refresh scenarios where async data may arrive after UI appears stable
- Backward-compatible: old `delay_ms` field maps to `wait_mode: "delay"` automatically

## How it works
1. `NexusAccessibilityService.onAccessibilityEvent` records timestamp of each `TYPE_WINDOW_CONTENT_CHANGED` event
2. Phase 1: wait until 300ms of event silence (minimum 200ms dwell to let post-action events arrive)
3. Phase 2: dump tree hash twice 50ms apart — must be identical
4. Falls back to forced capture with a warning header if `wait_ms` deadline is exceeded

## Test plan
- [x] Unit tests pass (all `ScreenOperationArgsTest` cases updated for new schema)
- [ ] On-device: tap/scroll/set_text with default stable mode — verify early return
- [ ] On-device: search with `wait_mode: "delay", wait_ms: 3000` — verify blind wait
- [ ] On-device: backward compat — old `delay_ms` calls still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)