### PR TITLE
Add #!tool-result text protocol for Screen Operation tools

### DIFF
--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/AccessibilityController.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/AccessibilityController.kt
@@ -19,6 +19,7 @@ import com.niki914.nexus.agentic.chat.agentic.accessibility.AccessibilityControl
 import com.niki914.nexus.agentic.chat.agentic.accessibility.AccessibilityController.refreshNodeCache
 import com.niki914.nexus.agentic.chat.agentic.accessibility.AccessibilityController.serviceInstance
 import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinToolResult
+import com.niki914.nexus.agentic.chat.agentic.buildin.ScreenOperationError
 import com.niki914.nexus.agentic.chat.agentic.shell.TerminalCommandOutcome
 import com.niki914.nexus.agentic.chat.agentic.shell.TerminalOpenOutcome
 import com.niki914.nexus.agentic.chat.agentic.shell.TerminalSessionPool
@@ -120,6 +121,7 @@ object AccessibilityController {
         val stdout: String,
         val stderr: String,
         val shellAvailable: Boolean = true,
+        val errorCode: String? = null,
     ) {
         val success: Boolean get() = exitCode == 0
     }
@@ -798,7 +800,8 @@ object AccessibilityController {
         }
         if (!result.success) {
             return BuiltinToolResult.failure(
-                "SHELL_FAILED", "Shell tap at ($x, $y) failed: ${result.stderr}"
+                result.errorCode ?: ScreenOperationError.SHELL_FAILED.code,
+                "Shell tap at ($x, $y) failed: ${result.stderr}",
             )
         }
         return BuiltinToolResult.success("shell tap at ($x, $y)")
@@ -821,7 +824,8 @@ object AccessibilityController {
         }
         if (!result.success) {
             return BuiltinToolResult.failure(
-                "SHELL_FAILED", "Shell long click at ($x, $y) failed: ${result.stderr}"
+                result.errorCode ?: ScreenOperationError.SHELL_FAILED.code,
+                "Shell long click at ($x, $y) failed: ${result.stderr}",
             )
         }
         return BuiltinToolResult.success("shell long click at ($x, $y)")
@@ -850,7 +854,8 @@ object AccessibilityController {
         }
         if (!result.success) {
             return BuiltinToolResult.failure(
-                "SHELL_FAILED", "Shell swipe from ($startX,$startY) to ($endX,$endY) failed: ${result.stderr}"
+                result.errorCode ?: ScreenOperationError.SHELL_FAILED.code,
+                "Shell swipe from ($startX,$startY) to ($endX,$endY) failed: ${result.stderr}",
             )
         }
         return BuiltinToolResult.success("shell swipe from ($startX,$startY) to ($endX,$endY)")
@@ -911,7 +916,8 @@ object AccessibilityController {
         }
         if (!result.success) {
             return BuiltinToolResult.failure(
-                "SHELL_FAILED", "Shell keyevent $keyCode failed: ${result.stderr}"
+                result.errorCode ?: ScreenOperationError.SHELL_FAILED.code,
+                "Shell keyevent $keyCode failed: ${result.stderr}",
             )
         }
         return BuiltinToolResult.success("shell keyevent $keyCode performed")
@@ -937,6 +943,7 @@ object AccessibilityController {
                     -1,
                     outcome.result.stdout.toByteArray().decodeToString().trim(),
                     "Command timed out",
+                    errorCode = ScreenOperationError.SHELL_TIMEOUT.code,
                 )
             }
             is TerminalCommandOutcome.Failure -> {
@@ -945,7 +952,10 @@ object AccessibilityController {
             }
             is TerminalCommandOutcome.SessionNotFound -> {
                 resetShellSession()
-                ShellResult(-1, "", "Shell session lost")
+                ShellResult(
+                    -1, "", "Shell session lost",
+                    errorCode = ScreenOperationError.SHELL_SESSION_LOST.code,
+                )
             }
             is TerminalCommandOutcome.Busy -> {
                 ShellResult(-1, "", "Shell session busy")

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/AccessibilityController.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/AccessibilityController.kt
@@ -684,7 +684,7 @@ object AccessibilityController {
                 }
                 if (!result.success) {
                     return BuiltinToolResult.failure(
-                        "SHELL_FAILED",
+                        result.errorCode ?: ScreenOperationError.SHELL_FAILED.code,
                         "Shell ${if (action == NodeAction.LONG_CLICK) "long tap" else "tap"} failed: ${result.stderr}",
                     )
                 }
@@ -696,7 +696,8 @@ object AccessibilityController {
                 val result = runShellCommand("input swipe $cx $cy $cx ${cy - 200} 300")
                 if (!result.success) {
                     return BuiltinToolResult.failure(
-                        "SHELL_FAILED", "Shell scroll forward failed: ${result.stderr}"
+                        result.errorCode ?: ScreenOperationError.SHELL_FAILED.code,
+                        "Shell scroll forward failed: ${result.stderr}",
                     )
                 }
                 BuiltinToolResult.success("shell scroll forward at ($cx, $cy)")
@@ -706,7 +707,8 @@ object AccessibilityController {
                 val result = runShellCommand("input swipe $cx $cy $cx ${cy + 200} 300")
                 if (!result.success) {
                     return BuiltinToolResult.failure(
-                        "SHELL_FAILED", "Shell scroll backward failed: ${result.stderr}"
+                        result.errorCode ?: ScreenOperationError.SHELL_FAILED.code,
+                        "Shell scroll backward failed: ${result.stderr}",
                     )
                 }
                 BuiltinToolResult.success("shell scroll backward at ($cx, $cy)")

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/ScreenOperationError.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/ScreenOperationError.kt
@@ -1,8 +1,5 @@
 package com.niki914.nexus.agentic.chat.agentic.buildin
 
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-
 enum class ScreenOperationError(val code: String) {
     INVALID_ARGUMENTS_JSON("INVALID_ARGUMENTS_JSON"),
     INVALID_OPERATION("INVALID_OPERATION"),
@@ -21,33 +18,6 @@ enum class ScreenOperationError(val code: String) {
     INTERNAL_ERROR("INTERNAL_ERROR"),
     SEARCH_FAILED("SEARCH_FAILED"),
     KEY_EVENT_FAILED("KEY_EVENT_FAILED"),
+    CAPTURE_FAILED_AFTER_ACTION("CAPTURE_FAILED_AFTER_ACTION"),
     ;
-
-    fun toJsonString(message: String): String {
-        return JsonObject(
-            mapOf(
-                "error" to JsonObject(
-                    mapOf(
-                        "code" to JsonPrimitive(code),
-                        "message" to JsonPrimitive(message),
-                    )
-                ),
-            )
-        ).toString()
-    }
-
-    companion object {
-        fun errorJson(code: String, message: String): String {
-            return JsonObject(
-                mapOf(
-                    "error" to JsonObject(
-                        mapOf(
-                            "code" to JsonPrimitive(code),
-                            "message" to JsonPrimitive(message),
-                        )
-                    ),
-                )
-            ).toString()
-        }
-    }
 }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/TextResultBuiltinTool.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/TextResultBuiltinTool.kt
@@ -1,0 +1,45 @@
+package com.niki914.nexus.agentic.chat.agentic.buildin
+
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Abstract base class for text-protocol tools.
+ *
+ * Subclasses implement [invokeText] to produce a [TextToolResult]. The base class
+ * handles encoding via [TextToolResultCodec.encode] and wraps unexpected exceptions
+ * into `UNKNOWN_ERROR` failure results. [CancellationException] is re-thrown unmodified.
+ *
+ * Because [TextResultBuiltinTool] extends [RawBuiltinTool], it satisfies
+ * the [RawJsonBuiltinTool] contract — [BuiltinToolExecutor] needs no changes.
+ */
+abstract class TextResultBuiltinTool : RawBuiltinTool() {
+
+    /**
+     * Produces a typed [TextToolResult] for the given [request].
+     *
+     * This is the single method subclasses must implement. The result will be
+     * automatically encoded by [invokeRaw] using [TextToolResultCodec.encode].
+     */
+    protected abstract suspend fun invokeText(request: BuiltinToolRequest): TextToolResult
+
+    /**
+     * Final override that orchestrates: [invokeText] -> [TextToolResult] -> encode.
+     *
+     * - If [invokeText] returns normally, the result is encoded and returned.
+     * - If [invokeText] throws a [CancellationException], it is re-thrown.
+     * - Any other [Throwable] is caught and encoded as an `UNKNOWN_ERROR` failure.
+     */
+    final override suspend fun invokeRaw(request: BuiltinToolRequest): String =
+        try {
+            TextToolResultCodec.encode(invokeText(request))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (t: Throwable) {
+            TextToolResultCodec.encode(
+                TextToolResult.failure(
+                    code = "UNKNOWN_ERROR",
+                    message = t.message ?: "Tool execution failed.",
+                )
+            )
+        }
+}

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/TextToolResult.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/TextToolResult.kt
@@ -1,0 +1,17 @@
+package com.niki914.nexus.agentic.chat.agentic.buildin
+
+data class TextToolResult(
+    val status: Status,
+    val payload: String,
+    val code: String? = null,
+    val message: String? = null,
+) {
+    enum class Status { Success, Failure }
+
+    companion object {
+        fun success(payload: String): TextToolResult = TextToolResult(Status.Success, payload)
+
+        fun failure(code: String, message: String, payload: String = ""): TextToolResult =
+            TextToolResult(Status.Failure, payload, code, message)
+    }
+}

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/TextToolResultCodec.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/TextToolResultCodec.kt
@@ -1,0 +1,184 @@
+package com.niki914.nexus.agentic.chat.agentic.buildin
+
+import com.niki914.nexus.agentic.chat.agentic.buildin.TextToolResult.Status
+import java.nio.charset.StandardCharsets
+
+object TextToolResultCodec {
+
+    const val CODE_MALFORMED = "MALFORMED_TOOL_RESULT"
+    private const val MAX_HEADER_LINES = 16
+    private const val MAX_HEADER_BYTES = 4096
+
+    /**
+     * Encodes a [TextToolResult] into the text protocol format:
+     * ```
+     * #!tool-result
+     * #!status: success|failure
+     * #!code: ERROR_CODE       (failure only, optional)
+     * #!message: Human message  (failure only, optional)
+     *
+     * <payload>
+     * ```
+     *
+     * Rules:
+     * - Header lines start with "#!"
+     * - One blank line separates header from payload
+     * - message newlines/carriage-returns/tabs are folded to spaces
+     * - Empty optional fields are NOT emitted
+     * - Payload is preserved verbatim (no trim, re-indent, or escaping)
+     * - If the encoded header exceeds 4096 UTF-8 bytes, the message field
+     *   is progressively truncated (with "…" appended) until the
+     *   header fits. This guarantees encode() output is always decodable
+     *   by decode().
+     */
+    fun encode(result: TextToolResult): String {
+        return encodeHeader(result) + "\n\n" + result.payload
+    }
+
+    /**
+     * Attempts to decode a text protocol result.
+     *
+     * @return [TextToolResult] if the first line is exactly "#!tool-result" AND
+     *         the header is parseable. Returns null if the first line does not match
+     *         (caller should fall back to other classifiers).
+     *
+     * Returns [TextToolResult] with status=Failure + code=MALFORMED_TOOL_RESULT if:
+     * - Header exceeds 16 lines or 4096 UTF-8 bytes
+     * - "status" field is missing, invalid, or duplicated
+     * - Any header field name is duplicated
+     */
+    fun decode(raw: String): TextToolResult? {
+        // Step 1: Check sentinel
+        val firstNewline = raw.indexOf('\n')
+        if (firstNewline == -1) return null
+        val sentinel = raw.substring(0, firstNewline)
+        if (sentinel != "#!tool-result") return null
+
+        val rest = raw.substring(firstNewline + 1)
+
+        // Step 2: Find blank line separator
+        val sepIndex = rest.indexOf("\n\n")
+        if (sepIndex == -1) {
+            return malformed(raw, "Missing blank line separator between header and payload")
+        }
+
+        val headerSection = rest.substring(0, sepIndex)
+        val payload = rest.substring(sepIndex + 2)
+
+        // Step 3: Validate header size
+        val headerLines = headerSection.split("\n")
+        if (headerLines.size > MAX_HEADER_LINES) {
+            return malformed(raw, "Header exceeds $MAX_HEADER_LINES lines")
+        }
+        if (headerSection.toByteArray(StandardCharsets.UTF_8).size > MAX_HEADER_BYTES) {
+            return malformed(raw, "Header exceeds $MAX_HEADER_BYTES bytes")
+        }
+
+        // Step 4: Parse header fields
+        val parseResult = parseHeader(headerLines)
+        if (parseResult == null) {
+            return malformed(raw, "Invalid header format")
+        }
+
+        val fields = parseResult
+
+        // Step 5: Validate status
+        val statusStr = fields["status"]
+            ?: return malformed(raw, "Missing status field")
+        val status = when (statusStr.lowercase()) {
+            "success" -> Status.Success
+            "failure" -> Status.Failure
+            else -> return malformed(raw, "Invalid status value: $statusStr")
+        }
+
+        // Step 6: Extract known fields; unknown fields are ignored
+        val code = fields["code"]
+        val message = fields["message"]
+
+        return TextToolResult(status, payload, code, message)
+    }
+
+    /**
+     * Encodes the header portion: sentinel line plus all header fields.
+     * Message newlines/carriage-returns/tabs are folded to spaces.
+     * If the encoded header exceeds [MAX_HEADER_BYTES], the message field is
+     * progressively truncated with "…" appended until it fits.
+     */
+    private fun encodeHeader(result: TextToolResult): String {
+        val lines = mutableListOf(
+            "#!tool-result",
+            "#!status: ${result.status.name.lowercase()}",
+        )
+        if (result.status == Status.Failure) {
+            if (!result.code.isNullOrEmpty()) {
+                lines.add("#!code: ${result.code}")
+            }
+            if (!result.message.isNullOrEmpty()) {
+                val folded = result.message!!
+                    .replace("\r\n", " ")
+                    .replace('\r', ' ')
+                    .replace('\n', ' ')
+                    .replace('\t', ' ')
+                lines.add(truncateMessage(lines, folded))
+            }
+        }
+        return lines.joinToString("\n")
+    }
+
+    /**
+     * Truncates the message value so that the total header (lines joined
+     * with "\n") does not exceed [MAX_HEADER_BYTES] UTF-8 bytes.
+     * Characters are removed one at a time from the right, with "…"
+     * appended, until the limit is satisfied.
+     */
+    internal fun truncateMessage(prefixLines: List<String>, message: String): String {
+        val ellipsis = "…"
+
+        // First try without truncation (no ellipsis when the full message fits)
+        val fullLine = "#!message: $message"
+        val testLines = prefixLines + fullLine
+        if (testLines.joinToString("\n").toByteArray(StandardCharsets.UTF_8).size <= MAX_HEADER_BYTES) {
+            return fullLine
+        }
+
+        // Progressive truncation: remove last character and append ellipsis
+        // The loop always terminates: eventually the message is empty, displayMsg
+        // becomes "…" (3 UTF-8 bytes), and the header prefix is well under 4096.
+        var truncated = message
+        while (true) {
+            truncated = truncated.substring(0, truncated.length - 1)
+            val displayMsg = "$truncated$ellipsis"
+            val line = "#!message: $displayMsg"
+            val test = prefixLines + line
+            if (test.joinToString("\n").toByteArray(StandardCharsets.UTF_8).size <= MAX_HEADER_BYTES) {
+                return line
+            }
+        }
+    }
+
+    /**
+     * Parses header lines (after sentinel, before blank line separator)
+     * into a map of field key to field value.
+     *
+     * Returns null if any line is not in "#!key: value" format, or if a key
+     * is empty, or if a key is duplicated.
+     */
+    private fun parseHeader(lines: List<String>): Map<String, String>? {
+        val fields = mutableMapOf<String, String>()
+        for (line in lines) {
+            if (!line.startsWith("#!")) return null
+            val content = line.removePrefix("#!")
+            val sep = content.indexOf(": ")
+            if (sep == -1) return null
+            val key = content.substring(0, sep).trim()
+            val value = content.substring(sep + 2).trim()
+            if (key.isEmpty() || fields.containsKey(key)) return null
+            fields[key] = value
+        }
+        return fields
+    }
+
+    private fun malformed(raw: String, reason: String): TextToolResult {
+        return TextToolResult(Status.Failure, raw, CODE_MALFORMED)
+    }
+}

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/TextToolResultCodec.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/TextToolResultCodec.kt
@@ -179,6 +179,6 @@ object TextToolResultCodec {
     }
 
     private fun malformed(raw: String, reason: String): TextToolResult {
-        return TextToolResult(Status.Failure, raw, CODE_MALFORMED)
+        return TextToolResult(Status.Failure, raw, CODE_MALFORMED, reason)
     }
 }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationAccessibilityBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationAccessibilityBuiltin.kt
@@ -4,20 +4,25 @@ import com.niki914.nexus.agentic.chat.agentic.accessibility.AccessibilityControl
 import com.niki914.nexus.agentic.chat.agentic.accessibility.NodeAction
 import com.niki914.nexus.agentic.chat.agentic.accessibility.ScreenSnapshot
 import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinToolRequest
-import com.niki914.nexus.agentic.chat.agentic.buildin.RawBuiltinTool
+import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinToolResult
 import com.niki914.nexus.agentic.chat.agentic.buildin.ScreenOperationError
+import com.niki914.nexus.agentic.chat.agentic.buildin.TextResultBuiltinTool
+import com.niki914.nexus.agentic.chat.agentic.buildin.TextToolResult
 import com.niki914.s3ss10n.LocalToolConfig
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 
 /**
- * RawBuiltinTool for accessibility-service-based screen interaction.
+ * TextResultBuiltinTool for accessibility-service-based screen interaction.
  *
  * Supports read, tap, long_click, scroll_forward, scroll_backward, set_text
  * (all node-based via token), and search. Every successful write operation auto-captures
  * the updated screen tree after execution.
+ *
+ * Every result uses the #!tool-result protocol. Check #!status first.
+ * If #!status: failure and the payload contains a fresh YAML tree, use the new tokens
+ * directly to retry. Only call read if the failure result has no payload.
  */
-class ScreenOperationAccessibilityBuiltin : RawBuiltinTool() {
+class ScreenOperationAccessibilityBuiltin : TextResultBuiltinTool() {
     override val name = "screen_operation_accessibility"
     override val defaultEnabled = true
     override val description: String =
@@ -48,7 +53,11 @@ class ScreenOperationAccessibilityBuiltin : RawBuiltinTool() {
                 "for \"delay\" required (no default), the fixed blind-wait duration.\n\n" +
                 "Tokens belong to exactly one snapshot — every read, search, and successful " +
                 "write operation produces a fresh version. Use only tokens from the most " +
-                "recently returned result."
+                "recently returned result.\n\n" +
+                "Every result uses the #!tool-result protocol. Check #!status first. " +
+                "If #!status: failure and the payload contains a fresh YAML tree, " +
+                "use the new tokens directly to retry. Only call read if the failure " +
+                "result has no payload."
 
     override fun configure(config: LocalToolConfig) {
         config.description = description
@@ -82,76 +91,80 @@ class ScreenOperationAccessibilityBuiltin : RawBuiltinTool() {
         }
     }
 
-    override suspend fun invokeRaw(request: BuiltinToolRequest): String {
+    override suspend fun invokeText(request: BuiltinToolRequest): TextToolResult {
         AccessibilityController.ensurePointerShown()
 
         val args = parseArguments(request.argumentsJson).getOrElse { error ->
             val msg = error.message ?: "Invalid arguments JSON"
-            val code = if (msg.startsWith("Unknown operation")) "INVALID_OPERATION" else "INVALID_ARGUMENTS_JSON"
-            return errorJson(code, msg)
+            val code = if (msg.startsWith("Unknown operation")) ScreenOperationError.INVALID_OPERATION.code else ScreenOperationError.INVALID_ARGUMENTS_JSON.code
+            return TextToolResult.failure(code, msg)
         }
 
-        return try {
-            when (val op = args.operation) {
-                is ScreenOp.Read -> {
-                    val capture = captureAfterOptionalWait(args)
-                    capture
-                        .fold(
-                            onSuccess = { it.yaml },
-                            onFailure = { e ->
-                                errorJson("SERVICE_UNAVAILABLE", e.message ?: "Service unavailable")
-                            },
+        return when (val op = args.operation) {
+            is ScreenOp.Read -> {
+                val capture = captureAfterOptionalWait(args)
+                capture.fold(
+                    onSuccess = { TextToolResult.success(it.yaml) },
+                    onFailure = { e ->
+                        TextToolResult.failure(
+                            ScreenOperationError.SERVICE_UNAVAILABLE.code,
+                            e.message ?: "Service unavailable",
                         )
-                }
-
-                is ScreenOp.Tap -> executeNodeActionAndCapture(
-                    op.token, NodeAction.CLICK, null, args.waitMode, args.waitMs
-                )
-
-                is ScreenOp.LongClick -> executeNodeActionAndCapture(
-                    op.token, NodeAction.LONG_CLICK, null, args.waitMode, args.waitMs
-                )
-
-                is ScreenOp.ScrollForward -> executeNodeActionAndCapture(
-                    op.token, NodeAction.SCROLL_FORWARD, null, args.waitMode, args.waitMs
-                )
-
-                is ScreenOp.ScrollBackward -> executeNodeActionAndCapture(
-                    op.token, NodeAction.SCROLL_BACKWARD, null, args.waitMode, args.waitMs
-                )
-
-                is ScreenOp.SetText -> executeNodeActionAndCapture(
-                    op.token, NodeAction.SET_TEXT, op.text, args.waitMode, args.waitMs
-                )
-
-                is ScreenOp.Search -> {
-                    waitBeforeSearch(args)
-                    AccessibilityController.searchNodes(op.keywords, op.matchMode, op.limit)
-                        .fold(
-                            onSuccess = { it },
-                            onFailure = { e ->
-                                errorJson("SEARCH_FAILED", e.message ?: "Search failed")
-                            },
-                        )
-                }
-
-                else -> errorJson(
-                    "INVALID_OPERATION",
-                    "Operation '${op::class.simpleName}' not supported by " +
-                            "screen_operation_accessibility. Use screen_operation_shell for " +
-                            "shell-based operations."
+                    },
                 )
             }
-        } catch (throwable: Throwable) {
-            if (throwable is CancellationException) throw throwable
-            errorJson("INTERNAL_ERROR", throwable.message ?: "Unknown internal error")
+
+            is ScreenOp.Tap -> executeNodeActionAndCapture(
+                op.token, NodeAction.CLICK, null, args.waitMode, args.waitMs,
+            )
+
+            is ScreenOp.LongClick -> executeNodeActionAndCapture(
+                op.token, NodeAction.LONG_CLICK, null, args.waitMode, args.waitMs,
+            )
+
+            is ScreenOp.ScrollForward -> executeNodeActionAndCapture(
+                op.token, NodeAction.SCROLL_FORWARD, null, args.waitMode, args.waitMs,
+            )
+
+            is ScreenOp.ScrollBackward -> executeNodeActionAndCapture(
+                op.token, NodeAction.SCROLL_BACKWARD, null, args.waitMode, args.waitMs,
+            )
+
+            is ScreenOp.SetText -> executeNodeActionAndCapture(
+                op.token, NodeAction.SET_TEXT, op.text, args.waitMode, args.waitMs,
+            )
+
+            is ScreenOp.Search -> {
+                waitBeforeSearch(args)
+                AccessibilityController.searchNodes(op.keywords, op.matchMode, op.limit)
+                    .fold(
+                        onSuccess = { TextToolResult.success(it) },
+                        onFailure = { e ->
+                            TextToolResult.failure(
+                                ScreenOperationError.SEARCH_FAILED.code,
+                                e.message ?: "Search failed",
+                            )
+                        },
+                    )
+            }
+
+            else -> TextToolResult.failure(
+                code = ScreenOperationError.INVALID_OPERATION.code,
+                message = "Operation '${op::class.simpleName}' not supported by " +
+                    "screen_operation_accessibility. Use screen_operation_shell for " +
+                    "shell-based operations.",
+            )
         }
     }
 
     /**
      * Executes a node action, then captures the updated screen according to [waitMode].
      *
-     * Returns the YAML representation on success, or an error JSON string on failure.
+     * When the action itself fails, the screen is captured to provide a fresh tree
+     * for the LLM to retry with, instead of returning a bare error.
+     *
+     * Returns a [TextToolResult] — success with the YAML tree, or failure with
+     * an optional payload.
      */
     private suspend fun executeNodeActionAndCapture(
         token: String,
@@ -159,10 +172,11 @@ class ScreenOperationAccessibilityBuiltin : RawBuiltinTool() {
         text: String?,
         waitMode: String,
         waitMs: Long,
-    ): String {
+    ): TextToolResult {
         val actionResult = AccessibilityController.executeNodeAction(token, action, text)
         if (!actionResult.ok) {
-            return errorJson(actionResult.code, actionResult.message)
+            val captureResult = AccessibilityController.captureScreen()
+            return assembleActionResult(actionResult, captureResult)
         }
         val capture = if (waitMode == "delay") {
             AccessibilityController.captureScreenAfterDelay(waitMs)
@@ -170,9 +184,14 @@ class ScreenOperationAccessibilityBuiltin : RawBuiltinTool() {
             AccessibilityController.waitForStable(waitMs)
         }
         return capture.fold(
-            onSuccess = { it.yaml },
+            onSuccess = { snapshot -> TextToolResult.success(snapshot.yaml) },
             onFailure = { e ->
-                errorJson("SERVICE_UNAVAILABLE", e.message ?: "Service unavailable")
+                TextToolResult.failure(
+                    code = ScreenOperationError.CAPTURE_FAILED_AFTER_ACTION.code,
+                    message = "The action may have succeeded, but the updated screen tree " +
+                        "could not be captured. Read the screen before deciding whether to " +
+                        "retry the action.",
+                )
             },
         )
     }
@@ -198,9 +217,5 @@ class ScreenOperationAccessibilityBuiltin : RawBuiltinTool() {
         } else {
             AccessibilityController.waitForStable(args.waitMs)
         }
-    }
-
-    private fun errorJson(code: String, message: String): String {
-        return ScreenOperationError.errorJson(code, message)
     }
 }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationAccessibilityBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationAccessibilityBuiltin.kt
@@ -54,10 +54,9 @@ class ScreenOperationAccessibilityBuiltin : TextResultBuiltinTool() {
                 "Tokens belong to exactly one snapshot — every read, search, and successful " +
                 "write operation produces a fresh version. Use only tokens from the most " +
                 "recently returned result.\n\n" +
-                "Every result uses the #!tool-result protocol. Check #!status first. " +
-                "If #!status: failure and the payload contains a fresh YAML tree, " +
-                "use the new tokens directly to retry. Only call read if the failure " +
-                "result has no payload."
+                "Every result uses the #!tool-result protocol " +
+                "(#!status, #!code, #!message, then payload). " +
+                "See SKILL.md for failure recovery rules."
 
     override fun configure(config: LocalToolConfig) {
         config.description = description

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationAccessibilityBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationAccessibilityBuiltin.kt
@@ -18,9 +18,8 @@ import kotlinx.coroutines.delay
  * (all node-based via token), and search. Every successful write operation auto-captures
  * the updated screen tree after execution.
  *
- * Every result uses the #!tool-result protocol. Check #!status first.
- * If #!status: failure and the payload contains a fresh YAML tree, use the new tokens
- * directly to retry. Only call read if the failure result has no payload.
+ * Every result uses the #!tool-result protocol.
+ * See the Phone Use skill for failure recovery rules.
  */
 class ScreenOperationAccessibilityBuiltin : TextResultBuiltinTool() {
     override val name = "screen_operation_accessibility"
@@ -56,7 +55,7 @@ class ScreenOperationAccessibilityBuiltin : TextResultBuiltinTool() {
                 "recently returned result.\n\n" +
                 "Every result uses the #!tool-result protocol " +
                 "(#!status, #!code, #!message, then payload). " +
-                "See SKILL.md for failure recovery rules."
+                "See the Phone Use skill for failure recovery rules."
 
     override fun configure(config: LocalToolConfig) {
         config.description = description

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationHelpers.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationHelpers.kt
@@ -1,0 +1,54 @@
+package com.niki914.nexus.agentic.chat.agentic.buildin.impl
+
+import com.niki914.nexus.agentic.chat.agentic.accessibility.ScreenSnapshot
+import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinToolResult
+import com.niki914.nexus.agentic.chat.agentic.buildin.TextToolResult
+
+/**
+ * Assembles a [TextToolResult] after a node/shell action fails and a screen capture
+ * is attempted.
+ *
+ * - If the capture succeeds, the original error message is **overridden** with a
+ *   unified hint telling the LLM to retry using the fresh tree's tokens instead
+ *   of calling read. The original error [code] is preserved.
+ * - If the capture also fails, [failureWithCaptureError] combines both error messages.
+ *
+ * This is a pure function (no Android dependencies), making it directly testable.
+ */
+internal fun assembleActionResult(
+    actionResult: BuiltinToolResult,
+    captureResult: Result<ScreenSnapshot>,
+): TextToolResult {
+    return captureResult.fold(
+        onSuccess = { snapshot ->
+            TextToolResult.failure(
+                code = actionResult.code,
+                message = "The action failed: ${actionResult.message}. " +
+                    "A fresh screen tree is included below — " +
+                    "retry using its tokens without calling read.",
+                payload = snapshot.yaml,
+            )
+        },
+        onFailure = { e ->
+            failureWithCaptureError(actionResult.code, actionResult.message, e)
+        },
+    )
+}
+
+/**
+ * Creates a [TextToolResult] failure when both the action and the subsequent
+ * screen capture have failed. The original action [code] is preserved, and the
+ * [message] combines the action's error with the capture error.
+ */
+internal fun failureWithCaptureError(
+    code: String,
+    actionMessage: String,
+    captureError: Throwable,
+): TextToolResult = TextToolResult.failure(
+    code = code,
+    message = buildString {
+        append(actionMessage)
+        append(". Latest screen tree capture failed: ")
+        append(captureError.message ?: "unknown error")
+    },
+)

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationHelpers.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationHelpers.kt
@@ -15,7 +15,7 @@ import com.niki914.nexus.agentic.chat.agentic.buildin.TextToolResult
  *   the action may have partially executed; the hint warns the LLM to inspect the
  *   tree and NOT blindly retry.
  * - All other codes: the action was definitely not executed; the hint tells the LLM
- *   to retry using the fresh tree's tokens.
+ *   to inspect the included tree and retry.
  *
  * If the capture also fails, [failureWithCaptureError] combines both error messages.
  */
@@ -32,7 +32,7 @@ internal fun assembleActionResult(
                         "Do NOT retry the same action unless the screen confirms " +
                         "it did not execute."
                 else ->
-                    "retry using its tokens without calling read."
+                    "inspect the included tree and retry without calling read."
             }
             TextToolResult.failure(
                 code = actionResult.code,

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationHelpers.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationHelpers.kt
@@ -2,18 +2,22 @@ package com.niki914.nexus.agentic.chat.agentic.buildin.impl
 
 import com.niki914.nexus.agentic.chat.agentic.accessibility.ScreenSnapshot
 import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinToolResult
+import com.niki914.nexus.agentic.chat.agentic.buildin.ScreenOperationError
 import com.niki914.nexus.agentic.chat.agentic.buildin.TextToolResult
 
 /**
  * Assembles a [TextToolResult] after a node/shell action fails and a screen capture
  * is attempted.
  *
- * - If the capture succeeds, the original error message is **overridden** with a
- *   unified hint telling the LLM to retry using the fresh tree's tokens instead
- *   of calling read. The original error [code] is preserved.
- * - If the capture also fails, [failureWithCaptureError] combines both error messages.
+ * If the capture succeeds, the result includes the fresh tree as payload and a
+ * retry hint that varies by error code:
+ * - [ScreenOperationError.SHELL_TIMEOUT], [ScreenOperationError.SHELL_SESSION_LOST]:
+ *   the action may have partially executed; the hint warns the LLM to inspect the
+ *   tree and NOT blindly retry.
+ * - All other codes: the action was definitely not executed; the hint tells the LLM
+ *   to retry using the fresh tree's tokens.
  *
- * This is a pure function (no Android dependencies), making it directly testable.
+ * If the capture also fails, [failureWithCaptureError] combines both error messages.
  */
 internal fun assembleActionResult(
     actionResult: BuiltinToolResult,
@@ -21,11 +25,19 @@ internal fun assembleActionResult(
 ): TextToolResult {
     return captureResult.fold(
         onSuccess = { snapshot ->
+            val retryHint = when (actionResult.code) {
+                ScreenOperationError.SHELL_TIMEOUT.code,
+                ScreenOperationError.SHELL_SESSION_LOST.code ->
+                    "inspect the tree to determine whether the action took effect. " +
+                        "Do NOT retry the same action unless the screen confirms " +
+                        "it did not execute."
+                else ->
+                    "retry using its tokens without calling read."
+            }
             TextToolResult.failure(
                 code = actionResult.code,
                 message = "The action failed: ${actionResult.message}. " +
-                    "A fresh screen tree is included below — " +
-                    "retry using its tokens without calling read.",
+                    "A fresh screen tree is included below — $retryHint",
                 payload = snapshot.yaml,
             )
         },

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationShellBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationShellBuiltin.kt
@@ -3,20 +3,24 @@ package com.niki914.nexus.agentic.chat.agentic.buildin.impl
 import com.niki914.nexus.agentic.chat.agentic.accessibility.AccessibilityController
 import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinToolRequest
 import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinToolResult
-import com.niki914.nexus.agentic.chat.agentic.buildin.RawBuiltinTool
 import com.niki914.nexus.agentic.chat.agentic.buildin.ScreenOperationError
+import com.niki914.nexus.agentic.chat.agentic.buildin.TextResultBuiltinTool
+import com.niki914.nexus.agentic.chat.agentic.buildin.TextToolResult
 import com.niki914.s3ss10n.LocalToolConfig
-import kotlinx.coroutines.CancellationException
 
 /**
- * RawBuiltinTool for shell-based screen interaction.
+ * TextResultBuiltinTool for shell-based screen interaction.
  *
  * FALLBACK method — prefer [ScreenOperationAccessibilityBuiltin] when possible.
  * Supports tap, long_click, swipe, key (all coordinate-based). Coordinates MUST
- * come from the most recently returned screen tree. Every successful write operation auto-captures the updated
- * screen tree via accessibility after execution.
+ * come from the most recently returned screen tree. Every successful write operation
+ * auto-captures the updated screen tree via accessibility after execution.
+ *
+ * Every result uses the #!tool-result protocol. Check #!status first.
+ * If #!status: failure and the payload contains a fresh YAML tree, use the new tokens
+ * directly to retry. Only call read if the failure result has no payload.
  */
-class ScreenOperationShellBuiltin : RawBuiltinTool() {
+class ScreenOperationShellBuiltin : TextResultBuiltinTool() {
     override val name = "screen_operation_shell"
     override val defaultEnabled = true
     override val description: String =
@@ -28,7 +32,11 @@ class ScreenOperationShellBuiltin : RawBuiltinTool() {
                 "Key codes: BACK=4, HOME=3, RECENTS=187, NOTIFICATIONS=83, QUICK_SETTINGS=84.\n\n" +
                 "wait_mode (default \"stable\"): \"stable\" auto-detects UI stability before capture. " +
                 "\"delay\" does a blind fixed wait — use for search/refresh. " +
-                "wait_ms (default 2000): deadline for stable, required for delay."
+                "wait_ms (default 2000): deadline for stable, required for delay.\n\n" +
+                "Every result uses the #!tool-result protocol. Check #!status first. " +
+                "If #!status: failure and the payload contains a fresh YAML tree, " +
+                "use the new tokens directly to retry. Only call read if the failure " +
+                "result has no payload."
 
     override fun configure(config: LocalToolConfig) {
         config.description = description
@@ -78,61 +86,73 @@ class ScreenOperationShellBuiltin : RawBuiltinTool() {
         }
     }
 
-    override suspend fun invokeRaw(request: BuiltinToolRequest): String {
+    override suspend fun invokeText(request: BuiltinToolRequest): TextToolResult {
         AccessibilityController.ensurePointerShown()
 
         val args = parseArguments(request.argumentsJson).getOrElse { error ->
             val msg = error.message ?: "Invalid arguments JSON"
-            val code = if (msg.startsWith("Unknown operation")) "INVALID_OPERATION" else "INVALID_ARGUMENTS_JSON"
-            return errorJson(code, msg)
+            val code = if (msg.startsWith("Unknown operation")) ScreenOperationError.INVALID_OPERATION.code else ScreenOperationError.INVALID_ARGUMENTS_JSON.code
+            return TextToolResult.failure(code, msg)
         }
 
-        return try {
-            when (val op = args.operation) {
-                is ScreenOp.ShellTap -> executeShellAndCapture(args.waitMode, args.waitMs) {
-                    AccessibilityController.executeShellTap(op.x, op.y)
-                }
+        return when (val op = args.operation) {
+            is ScreenOp.ShellTap -> executeShellAndCapture(args.waitMode, args.waitMs) {
+                AccessibilityController.executeShellTap(op.x, op.y)
+            }
 
-                is ScreenOp.ShellLongClick -> executeShellAndCapture(args.waitMode, args.waitMs) {
-                    AccessibilityController.executeShellLongClick(op.x, op.y)
-                }
+            is ScreenOp.ShellLongClick -> executeShellAndCapture(args.waitMode, args.waitMs) {
+                AccessibilityController.executeShellLongClick(op.x, op.y)
+            }
 
-                is ScreenOp.ShellSwipe -> executeShellAndCapture(args.waitMode, args.waitMs) {
-                    AccessibilityController.executeShellSwipe(
-                        op.startX, op.startY, op.endX, op.endY, op.duration
-                    )
-                }
-
-                is ScreenOp.ShellKey -> executeShellAndCapture(args.waitMode, args.waitMs) {
-                    AccessibilityController.executeKeyEvent(op.code)
-                }
-
-                else -> errorJson(
-                    "INVALID_OPERATION",
-                    "Operation '${op::class.simpleName}' not supported by " +
-                            "screen_operation_shell. Use screen_operation_accessibility for " +
-                            "node-based operations."
+            is ScreenOp.ShellSwipe -> executeShellAndCapture(args.waitMode, args.waitMs) {
+                AccessibilityController.executeShellSwipe(
+                    op.startX, op.startY, op.endX, op.endY, op.duration,
                 )
             }
-        } catch (throwable: Throwable) {
-            if (throwable is CancellationException) throw throwable
-            errorJson("INTERNAL_ERROR", throwable.message ?: "Unknown internal error")
+
+            is ScreenOp.ShellKey -> executeShellAndCapture(args.waitMode, args.waitMs) {
+                AccessibilityController.executeKeyEvent(op.code)
+            }
+
+            else -> TextToolResult.failure(
+                code = ScreenOperationError.INVALID_OPERATION.code,
+                message = "Operation '${op::class.simpleName}' not supported by " +
+                    "screen_operation_shell. Use screen_operation_accessibility for " +
+                    "node-based operations.",
+            )
         }
     }
 
     /**
      * Executes a shell operation, then captures the updated screen according to [waitMode].
      *
-     * Returns the YAML representation on success, or an error JSON string on failure.
+     * When the shell operation itself fails, the screen is captured to provide a fresh
+     * tree for the LLM to retry with. For [SHELL_TIMEOUT] and [SHELL_SESSION_LOST] codes
+     * the action may have partially executed, so the message notes this uncertainty.
+     *
+     * Returns a [TextToolResult] — success with the YAML tree, or failure with
+     * an optional payload.
      */
     private suspend fun executeShellAndCapture(
         waitMode: String,
         waitMs: Long,
         executor: suspend () -> BuiltinToolResult,
-    ): String {
+    ): TextToolResult {
         val result = executor()
         if (!result.ok) {
-            return errorJson(result.code, result.message)
+            val captureResult = AccessibilityController.captureScreen()
+            val enhanced = when (result.code) {
+                ScreenOperationError.SHELL_TIMEOUT.code,
+                ScreenOperationError.SHELL_SESSION_LOST.code -> {
+                    result.copy(
+                        message = "The shell command may have partially executed before the " +
+                            "timeout/session loss. Read the screen to determine the actual " +
+                            "state before deciding whether to retry.",
+                    )
+                }
+                else -> result
+            }
+            return assembleActionResult(enhanced, captureResult)
         }
         val capture = if (waitMode == "delay") {
             AccessibilityController.captureScreenAfterDelay(waitMs)
@@ -140,14 +160,15 @@ class ScreenOperationShellBuiltin : RawBuiltinTool() {
             AccessibilityController.waitForStable(waitMs)
         }
         return capture.fold(
-            onSuccess = { it.yaml },
+            onSuccess = { snapshot -> TextToolResult.success(snapshot.yaml) },
             onFailure = { e ->
-                errorJson("SERVICE_UNAVAILABLE", e.message ?: "Service unavailable")
+                TextToolResult.failure(
+                    code = ScreenOperationError.CAPTURE_FAILED_AFTER_ACTION.code,
+                    message = "The shell action may have succeeded, but the updated screen " +
+                        "tree could not be captured. Read the screen before deciding whether " +
+                        "to retry the action.",
+                )
             },
         )
-    }
-
-    private fun errorJson(code: String, message: String): String {
-        return ScreenOperationError.errorJson(code, message)
     }
 }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationShellBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationShellBuiltin.kt
@@ -16,9 +16,8 @@ import com.niki914.s3ss10n.LocalToolConfig
  * come from the most recently returned screen tree. Every successful write operation
  * auto-captures the updated screen tree via accessibility after execution.
  *
- * Every result uses the #!tool-result protocol. Check #!status first.
- * If #!status: failure and the payload contains a fresh YAML tree, use the new tokens
- * directly to retry. Only call read if the failure result has no payload.
+ * Every result uses the #!tool-result protocol.
+ * See the Phone Use skill for failure recovery rules.
  */
 class ScreenOperationShellBuiltin : TextResultBuiltinTool() {
     override val name = "screen_operation_shell"
@@ -35,7 +34,7 @@ class ScreenOperationShellBuiltin : TextResultBuiltinTool() {
                 "wait_ms (default 2000): deadline for stable, required for delay.\n\n" +
                 "Every result uses the #!tool-result protocol " +
                 "(#!status, #!code, #!message, then payload). " +
-                "See SKILL.md for failure recovery rules."
+                "See the Phone Use skill for failure recovery rules."
 
     override fun configure(config: LocalToolConfig) {
         config.description = description
@@ -145,8 +144,8 @@ class ScreenOperationShellBuiltin : TextResultBuiltinTool() {
                 ScreenOperationError.SHELL_SESSION_LOST.code -> {
                     result.copy(
                         message = "The shell command may have partially executed before the " +
-                            "timeout/session loss. Read the screen to determine the actual " +
-                            "state before deciding whether to retry.",
+                            "timeout/session loss. Inspect the included tree to determine the " +
+                            "actual state before deciding whether to retry.",
                     )
                 }
                 else -> result

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationShellBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationShellBuiltin.kt
@@ -33,10 +33,9 @@ class ScreenOperationShellBuiltin : TextResultBuiltinTool() {
                 "wait_mode (default \"stable\"): \"stable\" auto-detects UI stability before capture. " +
                 "\"delay\" does a blind fixed wait — use for search/refresh. " +
                 "wait_ms (default 2000): deadline for stable, required for delay.\n\n" +
-                "Every result uses the #!tool-result protocol. Check #!status first. " +
-                "If #!status: failure and the payload contains a fresh YAML tree, " +
-                "use the new tokens directly to retry. Only call read if the failure " +
-                "result has no payload."
+                "Every result uses the #!tool-result protocol " +
+                "(#!status, #!code, #!message, then payload). " +
+                "See SKILL.md for failure recovery rules."
 
     override fun configure(config: LocalToolConfig) {
         config.description = description

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/stream/LlmStreamEventMapper.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/stream/LlmStreamEventMapper.kt
@@ -3,6 +3,7 @@ package com.niki914.nexus.agentic.chat.agentic.stream
 import com.niki914.nexus.agentic.chat.LlmStreamEvent
 import com.niki914.nexus.agentic.chat.ToolCallKind
 import com.niki914.nexus.agentic.chat.ToolCallStatus
+import com.niki914.nexus.agentic.chat.agentic.buildin.TextToolResult
 import com.niki914.s3ss10n.SessionEvent
 import com.niki914.s3ss10n.ToolCallKind as SessionToolCallKind
 
@@ -28,9 +29,15 @@ object LlmStreamEventMapper {
             is SessionEvent.ToolRunning -> LlmStreamEvent.ToolRunning(event.toToolCallStatus())
             is SessionEvent.ToolSucceeded -> {
                 val call = event.toToolCallStatus()
-                val failureMessage = LocalToolResultClassifier.failureMessage(event.resultJson)
-                if (failureMessage != null) {
-                    LlmStreamEvent.ToolFailed(call = call, message = failureMessage)
+                val parsed = ParsedToolResult.decode(
+                    raw = event.resultJson,
+                    toolName = event.toolName,
+                )
+                if (parsed.status == TextToolResult.Status.Failure) {
+                    LlmStreamEvent.ToolFailed(
+                        call = call,
+                        message = parsed.message ?: parsed.code ?: "Tool failed.",
+                    )
                 } else {
                     LlmStreamEvent.ToolSucceeded(
                         call = call,

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/stream/LocalToolResultClassifier.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/stream/LocalToolResultClassifier.kt
@@ -160,36 +160,4 @@ object LocalToolResultClassifier {
             parsed.message ?: parsed.code ?: "Tool failed."
         } else null
     }
-
-    // Private helpers retained for backward compatibility.
-    // They are no longer called by failureMessage() but remain in place.
-
-    private fun parseJsonObject(value: String): JsonObject? {
-        return runCatching { Json.parseToJsonElement(value) as? JsonObject }.getOrNull()
-    }
-
-    private fun JsonObject.structuredErrorMessage(): String? {
-        val error = this["error"] as? JsonObject ?: return null
-        val code = error["code"]
-            ?.jsonPrimitive
-            ?.contentOrNull
-            ?.takeIf { it.isNotBlank() }
-            ?: return null
-        return error["message"]
-            ?.jsonPrimitive
-            ?.contentOrNull
-            ?.takeIf { it.isNotBlank() }
-            ?: code
-    }
-
-    private fun JsonObject.nonZeroExitMessage(exitCode: Int): String {
-        return statusMessage() ?: "Command completed with non-zero exit code $exitCode."
-    }
-
-    private fun JsonObject.statusMessage(): String? {
-        return listOf("stderr", "message", "code")
-            .firstNotNullOfOrNull { key ->
-                this[key]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
-            }
-    }
 }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/stream/LocalToolResultClassifier.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/stream/LocalToolResultClassifier.kt
@@ -1,35 +1,168 @@
 package com.niki914.nexus.agentic.chat.agentic.stream
 
+import com.niki914.nexus.agentic.chat.agentic.buildin.TextToolResult
+import com.niki914.nexus.agentic.chat.agentic.buildin.TextToolResultCodec
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
 
-object LocalToolResultClassifier {
-    fun failureMessage(resultJson: String?): String? {
-        val result = resultJson
-            ?.takeIf { it.isNotBlank() }
-            ?.let(::parseJsonObject)
-            ?: return null
+/**
+ * Parses a JSON string into a [JsonObject], returning null on failure.
+ * File-level helper used by [ParsedToolResult.decode].
+ */
+private fun parseJsonObject(value: String): JsonObject? {
+    return runCatching { Json.parseToJsonElement(value) as? JsonObject }.getOrNull()
+}
 
-        result.structuredErrorMessage()?.let { return it }
+/**
+ * Unified parsed representation of a tool result, combining text-protocol,
+ * JSON-structured, and legacy text formats.
+ */
+data class ParsedToolResult(
+    val status: TextToolResult.Status,
+    val code: String?,
+    val message: String?,
+    val payload: String,
+    val protocol: Protocol,
+) {
+    enum class Protocol { TextProtocol, JsonStructured, LegacyText }
 
-        val explicitOk = result["ok"]?.jsonPrimitive?.booleanOrNull
-        if (explicitOk == false) {
-            return result.statusMessage() ?: "Tool returned ok=false."
+    companion object {
+        private val TEXT_RESULT_TOOL_NAMES = setOf(
+            "screen_operation_accessibility",
+            "screen_operation_shell",
+        )
+
+        /**
+         * Unified decoder for all tool result formats.
+         *
+         * Resolution order:
+         * 1. Text protocol — only if [toolName] is in [TEXT_RESULT_TOOL_NAMES].
+         *    Delegates to [TextToolResultCodec.decode].
+         * 2. JSON structured error (error.code / ok=false / non-zero exit_code).
+         * 3. Legacy text — treated as success.
+         */
+        fun decode(raw: String?, toolName: String? = null): ParsedToolResult {
+            val text = raw?.takeIf { it.isNotBlank() }
+                ?: return ParsedToolResult(
+                    status = TextToolResult.Status.Success, code = null, message = null,
+                    payload = "", protocol = Protocol.LegacyText,
+                )
+
+            // Step 1: Text protocol — ONLY for whitelisted tools
+            if (toolName in TEXT_RESULT_TOOL_NAMES) {
+                val textResult = TextToolResultCodec.decode(text)
+                if (textResult != null) {
+                    return ParsedToolResult(
+                        status = textResult.status,
+                        code = textResult.code,
+                        message = textResult.message,
+                        payload = textResult.payload,
+                        protocol = Protocol.TextProtocol,
+                    )
+                }
+            }
+
+            // Step 2: JSON structured error
+            val json = parseJsonObject(text)
+            if (json != null) {
+                // Check for structured error: {"error": {"code": "...", "message": "..."}}
+                val error = json["error"] as? JsonObject
+                val errorCode = error?.get("code")
+                    ?.jsonPrimitive
+                    ?.contentOrNull
+                    ?.takeIf { it.isNotBlank() }
+                if (errorCode != null) {
+                    val errorMessage = error["message"]
+                        ?.jsonPrimitive
+                        ?.contentOrNull
+                        ?.takeIf { it.isNotBlank() }
+                    return ParsedToolResult(
+                        status = TextToolResult.Status.Failure,
+                        code = errorCode,
+                        message = errorMessage ?: errorCode,
+                        payload = text,
+                        protocol = Protocol.JsonStructured,
+                    )
+                }
+
+                // Check for ok=false
+                val ok = json["ok"]?.jsonPrimitive?.booleanOrNull
+                if (ok == false) {
+                    val statusMsg = listOf("stderr", "message", "code")
+                        .firstNotNullOfOrNull { key ->
+                            json[key]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+                        }
+                    return ParsedToolResult(
+                        status = TextToolResult.Status.Failure,
+                        code = "OK_FALSE",
+                        message = statusMsg ?: "Tool returned ok=false.",
+                        payload = text,
+                        protocol = Protocol.JsonStructured,
+                    )
+                }
+
+                // Check for non-zero exit_code
+                val exitCode = json["exit_code"]
+                    ?.jsonPrimitive
+                    ?.contentOrNull
+                    ?.toIntOrNull()
+                if (exitCode != null && exitCode != 0) {
+                    val exitMsg = listOf("stderr", "message", "code")
+                        .firstNotNullOfOrNull { key ->
+                            json[key]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+                        }
+                    return ParsedToolResult(
+                        status = TextToolResult.Status.Failure,
+                        code = "EXIT_CODE_$exitCode",
+                        message = exitMsg ?: "Command completed with non-zero exit code $exitCode.",
+                        payload = text,
+                        protocol = Protocol.JsonStructured,
+                    )
+                }
+
+                // JSON but no error indicators → success
+                return ParsedToolResult(
+                    status = TextToolResult.Status.Success, code = null, message = null,
+                    payload = text, protocol = Protocol.JsonStructured,
+                )
+            }
+
+            // Step 3: Legacy text/YAML → success
+            return ParsedToolResult(
+                status = TextToolResult.Status.Success, code = null, message = null,
+                payload = text, protocol = Protocol.LegacyText,
+            )
         }
-
-        val exitCode = result["exit_code"]
-            ?.jsonPrimitive
-            ?.contentOrNull
-            ?.toIntOrNull()
-        if (exitCode != null && exitCode != 0) {
-            return result.nonZeroExitMessage(exitCode)
-        }
-
-        return null
     }
+}
+
+/**
+ * Classifier that determines whether a tool result string represents a failure.
+ *
+ * The existing [failureMessage] method is preserved for backward compatibility.
+ * It delegates to [ParsedToolResult.decode] without a [toolName] parameter,
+ * matching the old behavior (JSON-only parsing, no text-protocol step).
+ */
+object LocalToolResultClassifier {
+    /**
+     * Returns a failure message if [resultJson] indicates a tool failure,
+     * or null if the result is successful.
+     *
+     * This method preserves the original behavior: it only parses JSON-structured
+     * results and does not attempt text-protocol parsing.
+     */
+    fun failureMessage(resultJson: String?): String? {
+        val parsed = ParsedToolResult.decode(resultJson)
+        return if (parsed.status == TextToolResult.Status.Failure) {
+            parsed.message ?: parsed.code ?: "Tool failed."
+        } else null
+    }
+
+    // Private helpers retained for backward compatibility.
+    // They are no longer called by failureMessage() but remain in place.
 
     private fun parseJsonObject(value: String): JsonObject? {
         return runCatching { Json.parseToJsonElement(value) as? JsonObject }.getOrNull()

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/buildin/TextResultBuiltinToolTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/buildin/TextResultBuiltinToolTest.kt
@@ -1,0 +1,55 @@
+package com.niki914.nexus.agentic.chat.agentic.buildin
+
+import com.niki914.s3ss10n.LocalToolConfig
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TextResultBuiltinToolTest {
+
+    @Test
+    fun invokeTextReturnsSuccess_invokeRawReturnsEncodedToolResultString() = runTest {
+        val tool = object : TextResultBuiltinTool() {
+            override val name: String = "test_tool"
+            override fun configure(config: LocalToolConfig) = Unit
+            override suspend fun invokeText(request: BuiltinToolRequest): TextToolResult =
+                TextToolResult.success("test payload")
+        }
+
+        val result = tool.invokeRaw(BuiltinToolRequest("test_tool", "{}"))
+
+        assertTrue(result.startsWith("#!tool-result"))
+        assertTrue(result.contains("#!status: success"))
+        assertTrue(result.contains("test payload"))
+    }
+
+    @Test
+    fun invokeTextThrowsRuntimeException_invokeRawReturnsUnknownErrorFailure() = runTest {
+        val tool = object : TextResultBuiltinTool() {
+            override val name: String = "test_tool"
+            override fun configure(config: LocalToolConfig) = Unit
+            override suspend fun invokeText(request: BuiltinToolRequest): TextToolResult =
+                throw RuntimeException("something went wrong")
+        }
+
+        val result = tool.invokeRaw(BuiltinToolRequest("test_tool", "{}"))
+
+        assertTrue(result.startsWith("#!tool-result"))
+        assertTrue(result.contains("#!status: failure"))
+        assertTrue(result.contains("#!code: UNKNOWN_ERROR"))
+        assertTrue(result.contains("something went wrong"))
+    }
+
+    @Test(expected = CancellationException::class)
+    fun invokeTextThrowsCancellationException_invokeRawRethrows() = runTest {
+        val tool = object : TextResultBuiltinTool() {
+            override val name: String = "test_tool"
+            override fun configure(config: LocalToolConfig) = Unit
+            override suspend fun invokeText(request: BuiltinToolRequest): TextToolResult =
+                throw CancellationException("cancelled")
+        }
+
+        tool.invokeRaw(BuiltinToolRequest("test_tool", "{}"))
+    }
+}

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/buildin/TextToolResultCodecTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/buildin/TextToolResultCodecTest.kt
@@ -1,0 +1,232 @@
+package com.niki914.nexus.agentic.chat.agentic.buildin
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.charset.StandardCharsets
+
+class TextToolResultCodecTest {
+
+    // -----------------------------------------------------------------------
+    // Encode
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `encode success with YAML payload`() {
+        val result = TextToolResult.success("node1:\n  token: abc_1\n  text: Hello")
+        val encoded = TextToolResultCodec.encode(result)
+        val expected = "#!tool-result\n#!status: success\n\nnode1:\n  token: abc_1\n  text: Hello"
+        assertEquals(expected, encoded)
+    }
+
+    @Test
+    fun `encode failure with code and message`() {
+        val result = TextToolResult.failure("VERSION_MISMATCH", "Token is stale")
+        val encoded = TextToolResultCodec.encode(result)
+        val expected = "#!tool-result\n#!status: failure\n#!code: VERSION_MISMATCH\n#!message: Token is stale\n\n"
+        assertEquals(expected, encoded)
+    }
+
+    @Test
+    fun `encode failure without payload`() {
+        val result = TextToolResult.failure("ERR", "msg")
+        val encoded = TextToolResultCodec.encode(result)
+        val expected = "#!tool-result\n#!status: failure\n#!code: ERR\n#!message: msg\n\n"
+        assertEquals(expected, encoded)
+    }
+
+    @Test
+    fun `encode message folding for newlines carriage returns and tabs`() {
+        val result = TextToolResult.failure("ERR", "line1\nline2\rtab\there")
+        val encoded = TextToolResultCodec.encode(result)
+        val expected = "#!tool-result\n#!status: failure\n#!code: ERR\n#!message: line1 line2 tab here\n\n"
+        assertEquals(expected, encoded)
+    }
+
+    @Test
+    fun `encode super long message truncated header under 4096 bytes`() {
+        val longMsg = "a".repeat(4050)
+        val result = TextToolResult.failure("ERR", longMsg)
+        val encoded = TextToolResultCodec.encode(result)
+
+        val blankLineIdx = encoded.indexOf("\n\n")
+        val header = encoded.substring(0, blankLineIdx)
+        val headerBytes = header.toByteArray(StandardCharsets.UTF_8).size
+        assertTrue(
+            "Header must be ≤ 4096 UTF-8 bytes, was $headerBytes",
+            headerBytes <= 4096,
+        )
+
+        // Verify truncated message ends with ellipsis
+        val messageLine = encoded.lines().first { it.startsWith("#!message: ") }
+        val message = messageLine.removePrefix("#!message: ")
+        assertTrue("Truncated message must end with …", message.endsWith("…"))
+        assertTrue("Truncated message must be shorter than original", message.length < 4050)
+    }
+
+    // -----------------------------------------------------------------------
+    // Decode
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `decode success result`() {
+        val raw = "#!tool-result\n#!status: success\n\nnode1:\n  token: abc_1"
+        val decoded = TextToolResultCodec.decode(raw)
+        assertNotNull(decoded)
+        assertEquals(TextToolResult.Status.Success, decoded!!.status)
+        assertEquals("node1:\n  token: abc_1", decoded.payload)
+        assertNull(decoded.code)
+        assertNull(decoded.message)
+    }
+
+    @Test
+    fun `decode failure with code message and yaml`() {
+        val raw = "#!tool-result\n#!status: failure\n#!code: VERSION_MISMATCH\n#!message: Token stale\n\nyaml: content"
+        val decoded = TextToolResultCodec.decode(raw)
+        assertNotNull(decoded)
+        assertEquals(TextToolResult.Status.Failure, decoded!!.status)
+        assertEquals("yaml: content", decoded.payload)
+        assertEquals("VERSION_MISMATCH", decoded.code)
+        assertEquals("Token stale", decoded.message)
+    }
+
+    @Test
+    fun `decode null on non-protocol first line`() {
+        assertNull(TextToolResultCodec.decode("random text"))
+        assertNull(TextToolResultCodec.decode("{\"error\":{\"code\":\"X\"}}"))
+        assertNull(TextToolResultCodec.decode(""))
+        assertNull(TextToolResultCodec.decode("#!other: value"))
+    }
+
+    @Test
+    fun `decode MALFORMED on missing blank line separator`() {
+        val raw = "#!tool-result\n#!status: success\ncontent without blank line"
+        val decoded = TextToolResultCodec.decode(raw)
+        assertNotNull(decoded)
+        assertEquals(TextToolResult.Status.Failure, decoded!!.status)
+        assertEquals(TextToolResultCodec.CODE_MALFORMED, decoded.code)
+    }
+
+    @Test
+    fun `decode MALFORMED on non hashbang line in header`() {
+        val raw = "#!tool-result\nbadline\n\npayload"
+        val decoded = TextToolResultCodec.decode(raw)
+        assertNotNull(decoded)
+        assertEquals(TextToolResult.Status.Failure, decoded!!.status)
+        assertEquals(TextToolResultCodec.CODE_MALFORMED, decoded.code)
+    }
+
+    @Test
+    fun `decode MALFORMED on invalid header line format no colon space`() {
+        val raw = "#!tool-result\n#!badformat\n\npayload"
+        val decoded = TextToolResultCodec.decode(raw)
+        assertNotNull(decoded)
+        assertEquals(TextToolResult.Status.Failure, decoded!!.status)
+        assertEquals(TextToolResultCodec.CODE_MALFORMED, decoded.code)
+    }
+
+    @Test
+    fun `decode MALFORMED on missing status`() {
+        val raw = "#!tool-result\n#!code: X\n\npayload"
+        val decoded = TextToolResultCodec.decode(raw)
+        assertNotNull(decoded)
+        assertEquals(TextToolResult.Status.Failure, decoded!!.status)
+        assertEquals(TextToolResultCodec.CODE_MALFORMED, decoded.code)
+    }
+
+    @Test
+    fun `decode MALFORMED on duplicate status field`() {
+        val raw = "#!tool-result\n#!status: success\n#!status: failure\n\npayload"
+        val decoded = TextToolResultCodec.decode(raw)
+        assertNotNull(decoded)
+        assertEquals(TextToolResult.Status.Failure, decoded!!.status)
+        assertEquals(TextToolResultCodec.CODE_MALFORMED, decoded.code)
+    }
+
+    @Test
+    fun `decode MALFORMED on invalid status value`() {
+        val raw = "#!tool-result\n#!status: maybe\n\npayload"
+        val decoded = TextToolResultCodec.decode(raw)
+        assertNotNull(decoded)
+        assertEquals(TextToolResult.Status.Failure, decoded!!.status)
+        assertEquals(TextToolResultCodec.CODE_MALFORMED, decoded.code)
+    }
+
+    @Test
+    fun `decode MALFORMED on header exceeding 16 lines`() {
+        val headerLines = (1..17).joinToString("\n") { "#!field$it: value" }
+        val raw = "#!tool-result\n$headerLines\n\npayload"
+        val decoded = TextToolResultCodec.decode(raw)
+        assertNotNull(decoded)
+        assertEquals(TextToolResult.Status.Failure, decoded!!.status)
+        assertEquals(TextToolResultCodec.CODE_MALFORMED, decoded.code)
+    }
+
+    @Test
+    fun `decode MALFORMED on header exceeding 4096 bytes`() {
+        val largeMsg = "x".repeat(4100)
+        val raw = "#!tool-result\n#!status: failure\n#!message: $largeMsg\n\npayload"
+        val decoded = TextToolResultCodec.decode(raw)
+        assertNotNull(decoded)
+        assertEquals(TextToolResult.Status.Failure, decoded!!.status)
+        assertEquals(TextToolResultCodec.CODE_MALFORMED, decoded.code)
+    }
+
+    @Test
+    fun `decode with unknown header field succeeds`() {
+        val raw = "#!tool-result\n#!status: success\n#!unknown_key: somevalue\n\npayload"
+        val decoded = TextToolResultCodec.decode(raw)
+        assertNotNull(decoded)
+        assertEquals(TextToolResult.Status.Success, decoded!!.status)
+        assertEquals("payload", decoded.payload)
+        assertNull(decoded.code)
+        assertNull(decoded.message)
+    }
+
+    // -----------------------------------------------------------------------
+    // Roundtrip
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `roundtrip encode decode success`() {
+        val original = TextToolResult.success("some yaml content")
+        val encoded = TextToolResultCodec.encode(original)
+        val decoded = TextToolResultCodec.decode(encoded)
+        assertNotNull(decoded)
+        assertEquals(original.status, decoded!!.status)
+        assertEquals(original.payload, decoded.payload)
+        assertEquals(original.code, decoded.code)
+        assertEquals(original.message, decoded.message)
+    }
+
+    @Test
+    fun `roundtrip encode decode failure with code message and payload`() {
+        val original = TextToolResult.failure("ERR_CODE", "Something went wrong", "yaml payload")
+        val encoded = TextToolResultCodec.encode(original)
+        val decoded = TextToolResultCodec.decode(encoded)
+        assertNotNull(decoded)
+        assertEquals(original.status, decoded!!.status)
+        assertEquals("yaml payload", decoded.payload)
+        assertEquals("ERR_CODE", decoded.code)
+        assertEquals("Something went wrong", decoded.message)
+    }
+
+    @Test
+    fun `roundtrip encode decode truncated message idempotent`() {
+        val longMsg = "a".repeat(4050)
+        val original = TextToolResult.failure("ERR", longMsg)
+        val encoded = TextToolResultCodec.encode(original)
+        val decoded = TextToolResultCodec.decode(encoded)
+        assertNotNull(decoded)
+        assertEquals(TextToolResult.Status.Failure, decoded!!.status)
+        assertEquals("ERR", decoded.code)
+        assertNotNull(decoded.message)
+        assertTrue("Truncated message must end with …", decoded.message!!.endsWith("…"))
+
+        // Re-encode the decoded result; output must be identical
+        val reEncoded = TextToolResultCodec.encode(decoded)
+        assertEquals("Re-encode of decoded truncation must be idempotent", encoded, reEncoded)
+    }
+}

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/buildin/TextToolResultCodecTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/buildin/TextToolResultCodecTest.kt
@@ -107,6 +107,8 @@ class TextToolResultCodecTest {
         assertNotNull(decoded)
         assertEquals(TextToolResult.Status.Failure, decoded!!.status)
         assertEquals(TextToolResultCodec.CODE_MALFORMED, decoded.code)
+        assertNotNull(decoded.message)
+        assertTrue(decoded.message!!.contains("blank line"))
     }
 
     @Test

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationAccessibilityBuiltinTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationAccessibilityBuiltinTest.kt
@@ -1,0 +1,72 @@
+package com.niki914.nexus.agentic.chat.agentic.buildin.impl
+
+import com.niki914.nexus.agentic.chat.agentic.accessibility.ScreenSnapshot
+import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinToolResult
+import com.niki914.nexus.agentic.chat.agentic.buildin.TextToolResult
+import kotlinx.serialization.json.JsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ScreenOperationAccessibilityBuiltinTest {
+
+    @Test
+    fun `assembleActionResult with action failure and capture success returns failure with overridden message and yaml payload`() {
+        val actionResult = BuiltinToolResult(
+            ok = false,
+            code = "VERSION_MISMATCH",
+            message = "Token expired, read the screen first to get a fresh token",
+            hint = "",
+            fieldErrors = emptyMap(),
+            data = JsonObject(emptyMap()),
+        )
+        val captureResult = Result.success(ScreenSnapshot("some yaml tree", "v2", 5))
+
+        val result = assembleActionResult(actionResult, captureResult)
+
+        assertEquals(TextToolResult.Status.Failure, result.status)
+        assertEquals("VERSION_MISMATCH", result.code)
+        assertNotNull(result.message)
+        val msg = result.message!!
+        assertTrue(
+            "message should contain 'fresh screen tree' but was: $msg",
+            msg.contains("fresh screen tree"),
+        )
+        assertTrue(
+            "message should NOT contain 're-read' but was: $msg",
+            !msg.contains("re-read"),
+        )
+        assertTrue(
+            "message should NOT contain 'read or search' but was: $msg",
+            !msg.contains("read or search"),
+        )
+        assertEquals("some yaml tree", result.payload)
+    }
+
+    @Test
+    fun `assembleActionResult with action failure and capture failure returns failure with combined error messages`() {
+        val actionResult = BuiltinToolResult(
+            ok = false,
+            code = "NODE_NOT_FOUND",
+            message = "Node 42 not found",
+            hint = "",
+            fieldErrors = emptyMap(),
+            data = JsonObject(emptyMap()),
+        )
+        val captureError = RuntimeException("Accessibility service disconnected")
+        val captureResult = Result.failure<ScreenSnapshot>(captureError)
+
+        val result = assembleActionResult(actionResult, captureResult)
+
+        assertEquals(TextToolResult.Status.Failure, result.status)
+        assertEquals("NODE_NOT_FOUND", result.code)
+        assertNotNull(result.message)
+        val msg = result.message!!
+        assertTrue("message should contain action error", msg.contains("Node 42 not found"))
+        assertTrue(
+            "message should contain capture error",
+            msg.contains("Accessibility service disconnected"),
+        )
+    }
+}

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationAccessibilityBuiltinTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationAccessibilityBuiltinTest.kt
@@ -2,6 +2,7 @@ package com.niki914.nexus.agentic.chat.agentic.buildin.impl
 
 import com.niki914.nexus.agentic.chat.agentic.accessibility.ScreenSnapshot
 import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinToolResult
+import com.niki914.nexus.agentic.chat.agentic.buildin.ScreenOperationError
 import com.niki914.nexus.agentic.chat.agentic.buildin.TextToolResult
 import kotlinx.serialization.json.JsonObject
 import org.junit.Assert.assertEquals
@@ -40,6 +41,58 @@ class ScreenOperationAccessibilityBuiltinTest {
         assertTrue(
             "message should NOT contain 'read or search' but was: $msg",
             !msg.contains("read or search"),
+        )
+        assertEquals("some yaml tree", result.payload)
+    }
+
+    @Test
+    fun `assembleActionResult with SHELL_TIMEOUT warns not to blindly retry`() {
+        val actionResult = BuiltinToolResult(
+            ok = false,
+            code = ScreenOperationError.SHELL_TIMEOUT.code,
+            message = "Shell command timed out after 5000ms",
+            hint = "",
+            fieldErrors = emptyMap(),
+            data = JsonObject(emptyMap()),
+        )
+        val captureResult = Result.success(ScreenSnapshot("some yaml tree", "v2", 5))
+
+        val result = assembleActionResult(actionResult, captureResult)
+
+        assertEquals(TextToolResult.Status.Failure, result.status)
+        assertEquals(ScreenOperationError.SHELL_TIMEOUT.code, result.code)
+        val msg = result.message!!
+        assertTrue(
+            "message should warn against blind retry but was: $msg",
+            msg.contains("Do NOT retry") || msg.contains("do not blindly retry"),
+        )
+        assertTrue(
+            "message should mention inspecting the tree but was: $msg",
+            msg.contains("inspect the tree"),
+        )
+        assertEquals("some yaml tree", result.payload)
+    }
+
+    @Test
+    fun `assembleActionResult with SHELL_SESSION_LOST warns not to blindly retry`() {
+        val actionResult = BuiltinToolResult(
+            ok = false,
+            code = ScreenOperationError.SHELL_SESSION_LOST.code,
+            message = "Shell session lost",
+            hint = "",
+            fieldErrors = emptyMap(),
+            data = JsonObject(emptyMap()),
+        )
+        val captureResult = Result.success(ScreenSnapshot("some yaml tree", "v2", 5))
+
+        val result = assembleActionResult(actionResult, captureResult)
+
+        assertEquals(TextToolResult.Status.Failure, result.status)
+        assertEquals(ScreenOperationError.SHELL_SESSION_LOST.code, result.code)
+        val msg = result.message!!
+        assertTrue(
+            "message should warn against blind retry but was: $msg",
+            msg.contains("Do NOT retry") || msg.contains("do not blindly retry"),
         )
         assertEquals("some yaml tree", result.payload)
     }

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/stream/LlmStreamEventMapperTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/stream/LlmStreamEventMapperTest.kt
@@ -1,0 +1,44 @@
+package com.niki914.nexus.agentic.chat.agentic.stream
+
+import com.niki914.nexus.agentic.chat.LlmStreamEvent
+import com.niki914.s3ss10n.SessionEvent
+import com.niki914.s3ss10n.ToolCallKind
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LlmStreamEventMapperTest {
+
+    @Test
+    fun `ToolSucceeded with failure envelope and whitelisted toolName returns ToolFailed`() {
+        val failureResult =
+            "#!tool-result\n#!status: failure\n#!code: VERSION_MISMATCH\n#!message: Token expired\n\nsome payload"
+
+        val event = SessionEvent.ToolSucceeded(
+            callId = "call1",
+            toolName = "screen_operation_accessibility",
+            kind = ToolCallKind.Local,
+            resultJson = failureResult,
+        )
+
+        val result = LlmStreamEventMapper.map(event, StringBuilder(), 0L, "default error")
+        assertTrue(result is LlmStreamEvent.ToolFailed)
+        assertEquals("Token expired", (result as LlmStreamEvent.ToolFailed).message)
+    }
+
+    @Test
+    fun `ToolSucceeded with success envelope and whitelisted toolName returns ToolSucceeded`() {
+        val successResult = "#!tool-result\n#!status: success\n\ntree yaml content"
+
+        val event = SessionEvent.ToolSucceeded(
+            callId = "call2",
+            toolName = "screen_operation_accessibility",
+            kind = ToolCallKind.Local,
+            resultJson = successResult,
+        )
+
+        val result = LlmStreamEventMapper.map(event, StringBuilder(), 0L, "default error")
+        assertTrue(result is LlmStreamEvent.ToolSucceeded)
+        assertEquals(successResult, (result as LlmStreamEvent.ToolSucceeded).outputText)
+    }
+}

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/stream/LocalToolResultClassifierTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/stream/LocalToolResultClassifierTest.kt
@@ -1,0 +1,106 @@
+package com.niki914.nexus.agentic.chat.agentic.stream
+
+import com.niki914.nexus.agentic.chat.agentic.buildin.TextToolResult
+import com.niki914.nexus.agentic.chat.agentic.buildin.TextToolResultCodec
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class LocalToolResultClassifierTest {
+
+    // ── Text protocol (whitelisted toolName) ──────────────────────────────
+
+    @Test
+    fun decode_successProtocol_whitelistedTool_returnsSuccessTextProtocol() {
+        val encoded = TextToolResultCodec.encode(TextToolResult.success("yaml tree"))
+        val parsed = ParsedToolResult.decode(encoded, "screen_operation_accessibility")
+
+        assertEquals(TextToolResult.Status.Success, parsed.status)
+        assertEquals(ParsedToolResult.Protocol.TextProtocol, parsed.protocol)
+        assertEquals("yaml tree", parsed.payload)
+    }
+
+    @Test
+    fun decode_failureProtocol_whitelistedTool_returnsFailureTextProtocol() {
+        val encoded = TextToolResultCodec.encode(
+            TextToolResult.failure("VERSION_MISMATCH", "token expired")
+        )
+        val parsed = ParsedToolResult.decode(encoded, "screen_operation_shell")
+
+        assertEquals(TextToolResult.Status.Failure, parsed.status)
+        assertEquals(ParsedToolResult.Protocol.TextProtocol, parsed.protocol)
+        assertEquals("VERSION_MISMATCH", parsed.code)
+        assertEquals("token expired", parsed.message)
+    }
+
+    @Test
+    fun decode_malformedProtocol_whitelistedTool_returnsFailureMalformed() {
+        // Missing blank line separator after header
+        val raw = "#!tool-result\n#!status: failure\nno blank line separator"
+        val parsed = ParsedToolResult.decode(raw, "screen_operation_accessibility")
+
+        assertEquals(TextToolResult.Status.Failure, parsed.status)
+        assertEquals(ParsedToolResult.Protocol.TextProtocol, parsed.protocol)
+        assertEquals("MALFORMED_TOOL_RESULT", parsed.code)
+    }
+
+    // ── Protocol first line but non-whitelisted tool ──────────────────────
+
+    @Test
+    fun decode_protocolFirstLine_nonWhitelistedTool_skipsProtocol() {
+        // Input starts with "#!tool-result" but tool is "terminal" — not whitelisted
+        val raw = "#!tool-result\n#!status: failure\n#!code: X\n\npayload"
+        val parsed = ParsedToolResult.decode(raw, "terminal")
+
+        // terminal is not in TEXT_RESULT_TOOL_NAMES → protocol step skipped
+        // Not valid JSON → falls through to LegacyText success
+        assertEquals(TextToolResult.Status.Success, parsed.status)
+        assertEquals(ParsedToolResult.Protocol.LegacyText, parsed.protocol)
+        assertEquals(raw, parsed.payload)
+    }
+
+    // ── JSON structured error (regression) ────────────────────────────────
+
+    @Test
+    fun decode_jsonError_returnsFailureJsonStructured() {
+        val raw = """{"error":{"code":"SESSION_NOT_FOUND","message":"Call open first"}}"""
+        val parsed = ParsedToolResult.decode(raw, null)
+
+        assertEquals(TextToolResult.Status.Failure, parsed.status)
+        assertEquals(ParsedToolResult.Protocol.JsonStructured, parsed.protocol)
+        assertEquals("SESSION_NOT_FOUND", parsed.code)
+        assertEquals("Call open first", parsed.message)
+    }
+
+    // ── Plain YAML / legacy text ──────────────────────────────────────────
+
+    @Test
+    fun decode_plainYaml_returnsSuccessLegacyText() {
+        val raw = "content:\n  key: value\n"
+        val parsed = ParsedToolResult.decode(raw, "screen_operation_accessibility")
+
+        assertEquals(TextToolResult.Status.Success, parsed.status)
+        assertEquals(ParsedToolResult.Protocol.LegacyText, parsed.protocol)
+        assertEquals(raw, parsed.payload)
+    }
+
+    // ── failureMessage regression ─────────────────────────────────────────
+
+    @Test
+    fun failureMessage_jsonError_returnsNonNull() {
+        val msg = LocalToolResultClassifier.failureMessage(
+            """{"error":{"code":"X","message":"Y"}}"""
+        )
+        assertEquals("Y", msg)
+    }
+
+    @Test
+    fun failureMessage_null_returnsNull() {
+        assertNull(LocalToolResultClassifier.failureMessage(null))
+    }
+
+    @Test
+    fun failureMessage_blank_returnsNull() {
+        assertNull(LocalToolResultClassifier.failureMessage(""))
+    }
+}

--- a/app/src/main/assets/skills/phone-use/SKILL.md
+++ b/app/src/main/assets/skills/phone-use/SKILL.md
@@ -103,7 +103,7 @@ However, **re-read explicitly** after `launch_app` or whenever you need a fresh 
 Every result uses the `#!tool-result` protocol. Check `#!status` first:
 - **Success:** the payload is the updated tree — use its tokens/coordinates directly.
 - **Failure with payload:** the action was not executed or its outcome is uncertain. Inspect the tree, derive fresh tokens/coordinates. Retry only when the error indicates the action was definitely not executed. `SHELL_TIMEOUT` and `SHELL_SESSION_LOST` mean the action may have partially executed — verify via the tree, do NOT blindly retry.
-- **Failure without payload:** for validation errors (`INVALID_ARGUMENTS_JSON`, `INVALID_OPERATION`, `INVALID_ARGUMENTS`, `SEARCH_FAILED`), correct the arguments directly. For `CAPTURE_FAILED_AFTER_ACTION`, the action may have succeeded — `read` before deciding.
+- **Failure without payload:** for validation errors (`INVALID_ARGUMENTS_JSON`, `INVALID_OPERATION`, `INVALID_ARGUMENTS`), correct the arguments directly. For `SEARCH_FAILED`, the accessibility tree could not be searched — check the message; retry after `read` if the service is available. For `CAPTURE_FAILED_AFTER_ACTION`, the action may have succeeded — `read` before deciding.
 
 **Scrolling lists — use `screen_operation_shell(operation: "swipe", ...)`**, not `scroll_forward`/`scroll_backward`. Accessibility scroll actions have app-defined step sizes. Shell swipe gives direct control over the swipe coordinates.
 

--- a/app/src/main/assets/skills/phone-use/SKILL.md
+++ b/app/src/main/assets/skills/phone-use/SKILL.md
@@ -100,7 +100,10 @@ All write operations (tap, scroll, swipe, key) now return the updated screen tre
 
 However, **re-read explicitly** after `launch_app` or whenever you need a fresh view after external state changes. Tokens are versioned — every read, search, and successful write operation produces a fresh version. Never reuse tokens from an older snapshot.
 
-All write operations now use the `#!tool-result` protocol. Check `#!status` first — if it says `failure` but the payload contains a fresh YAML tree, retry using the new tokens directly without calling `read`. Only call `read` when a failure result has no YAML payload (the tree could not be captured). If the error code is `CAPTURE_FAILED_AFTER_ACTION`, do NOT blindly retry the same action — the action may have already taken effect; read the screen first to determine the current state.
+Every result uses the `#!tool-result` protocol. Check `#!status` first:
+- **Success:** the payload is the updated tree — use its tokens/coordinates directly.
+- **Failure with payload:** the action was not executed or its outcome is uncertain. Inspect the tree, derive fresh tokens/coordinates. Retry only when the error indicates the action was definitely not executed. `SHELL_TIMEOUT` and `SHELL_SESSION_LOST` mean the action may have partially executed — verify via the tree, do NOT blindly retry.
+- **Failure without payload:** for validation errors (`INVALID_ARGUMENTS_JSON`, `INVALID_OPERATION`, `INVALID_ARGUMENTS`, `SEARCH_FAILED`), correct the arguments directly. For `CAPTURE_FAILED_AFTER_ACTION`, the action may have succeeded — `read` before deciding.
 
 **Scrolling lists — use `screen_operation_shell(operation: "swipe", ...)`**, not `scroll_forward`/`scroll_backward`. Accessibility scroll actions have app-defined step sizes. Shell swipe gives direct control over the swipe coordinates.
 

--- a/app/src/main/assets/skills/phone-use/SKILL.md
+++ b/app/src/main/assets/skills/phone-use/SKILL.md
@@ -98,7 +98,9 @@ For actions that don't target a single labeled node (e.g., swipe-to-refresh, dra
 
 All write operations (tap, scroll, swipe, key) now return the updated screen tree automatically. Use this returned YAML for the next action — no explicit `read` needed.
 
-However, **re-read explicitly** after `launch_app`, after an operation's result is an error, or whenever you need a fresh view after external state changes. Tokens are versioned — every read, search, and successful write operation produces a fresh version. Never reuse tokens from an older snapshot.
+However, **re-read explicitly** after `launch_app` or whenever you need a fresh view after external state changes. Tokens are versioned — every read, search, and successful write operation produces a fresh version. Never reuse tokens from an older snapshot.
+
+All write operations now use the `#!tool-result` protocol. Check `#!status` first — if it says `failure` but the payload contains a fresh YAML tree, retry using the new tokens directly without calling `read`. Only call `read` when a failure result has no YAML payload (the tree could not be captured). If the error code is `CAPTURE_FAILED_AFTER_ACTION`, do NOT blindly retry the same action — the action may have already taken effect; read the screen first to determine the current state.
 
 **Scrolling lists — use `screen_operation_shell(operation: "swipe", ...)`**, not `scroll_forward`/`scroll_backward`. Accessibility scroll actions have app-defined step sizes. Shell swipe gives direct control over the swipe coordinates.
 

--- a/app/src/main/java/com/niki914/nexus/agentic/app/conversation/ConversationFormatter.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/conversation/ConversationFormatter.kt
@@ -4,7 +4,8 @@ import com.niki914.nexus.agentic.app.ui.nexus.model.HomeChatBlock
 import com.niki914.nexus.agentic.app.ui.nexus.model.HomeChatTurn
 import com.niki914.nexus.agentic.app.ui.nexus.model.HomeToolState
 import com.niki914.nexus.agentic.app.ui.nexus.model.HomeToolStatus
-import com.niki914.nexus.agentic.chat.agentic.stream.LocalToolResultClassifier
+import com.niki914.nexus.agentic.chat.agentic.buildin.TextToolResult
+import com.niki914.nexus.agentic.chat.agentic.stream.ParsedToolResult
 import com.niki914.s3ss10n.ChatTurn
 
 object ConversationFormatter {
@@ -61,7 +62,10 @@ object ConversationFormatter {
                     val updated = target.updateToolState(
                         callId = turn.callId,
                         toolName = turn.toolName,
-                        state = if (LocalToolResultClassifier.failureMessage(turn.resultJson) == null) {
+                        state = if (ParsedToolResult.decode(
+                            raw = turn.resultJson,
+                            toolName = turn.toolName,
+                        ).status == TextToolResult.Status.Success) {
                             HomeToolState.Succeeded
                         } else {
                             HomeToolState.Failed

--- a/app/src/test/java/com/niki914/nexus/agentic/app/conversation/ConversationFormatterTest.kt
+++ b/app/src/test/java/com/niki914/nexus/agentic/app/conversation/ConversationFormatterTest.kt
@@ -9,6 +9,52 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class ConversationFormatterTest {
+
+    @Test
+    fun toHomeTurns_restoresFailureFromTextProtocolResult() {
+        val turns = ConversationFormatter.toHomeTurns(
+            listOf(
+                ChatTurn.User("question"),
+                ChatTurn.Assistant(
+                    content = "let me tap",
+                    toolCalls = listOf(
+                        ToolCallSpec("c1", "screen_operation_accessibility", "{}"),
+                    ),
+                ),
+                ChatTurn.ToolResult(
+                    callId = "c1",
+                    toolName = "screen_operation_accessibility",
+                    resultJson = "#!tool-result\n#!status: failure\n#!code: VERSION_MISMATCH\n#!message: Token expired\n\nsome yaml",
+                ),
+            ),
+        )
+
+        val toolBlock = turns.single().blocks.last() as HomeChatBlock.Tool
+        assertEquals(HomeToolState.Failed, toolBlock.status.state)
+    }
+
+    @Test
+    fun toHomeTurns_restoresSuccessFromTextProtocolResult() {
+        val turns = ConversationFormatter.toHomeTurns(
+            listOf(
+                ChatTurn.User("question"),
+                ChatTurn.Assistant(
+                    content = "result",
+                    toolCalls = listOf(
+                        ToolCallSpec("c2", "screen_operation_accessibility", "{}"),
+                    ),
+                ),
+                ChatTurn.ToolResult(
+                    callId = "c2",
+                    toolName = "screen_operation_accessibility",
+                    resultJson = "#!tool-result\n#!status: success\n\ntree yaml",
+                ),
+            ),
+        )
+
+        val toolBlock = turns.single().blocks.last() as HomeChatBlock.Tool
+        assertEquals(HomeToolState.Succeeded, toolBlock.status.state)
+    }
     @Test
     fun previewFromText_trimsAndKeepsEmptyOrShortText() {
         assertEquals("", ConversationFormatter.previewFromText("   "))


### PR DESCRIPTION
## Summary
- Introduce `TextResultBuiltinTool` abstract class extending `RawBuiltinTool` — `invokeRaw()` is `final`, orchestrating `invokeText()` → `TextToolResultCodec.encode()`. `BuiltinToolExecutor` needs zero changes.
- Screen operations (accessibility + shell) now return the latest YAML view tree even on action failure, eliminating an extra read round-trip for LLM retry.
- `ParsedToolResult.decode(raw, toolName)` provides unified three-step decoding (text protocol → JSON structured → legacy), scoped to Screen tools via `TEXT_RESULT_TOOL_NAMES` whitelist. Non-Screen tools (terminal, SSH) are unaffected.
- `assembleActionResult` pure function overrides old "re-read" error messages when tree capture succeeds, guiding the LLM to use included tokens directly.

## Test plan
- [x] `./gradlew :agent-runtime:compileDebugKotlin` — BUILD SUCCESSFUL
- [x] `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL
- [x] All new/existing unit tests pass (Codec, abstract class, classifier, Mapper, Formatter, assembleActionResult)

🤖 Generated with [Claude Code](https://claude.com/claude-code)