### PR TITLE
Fix tool state machine: finalize interrupted tools, persist history on stop

### DIFF
--- a/app/src/main/java/com/niki914/nexus/agentic/app/conversation/ConversationFormatter.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/conversation/ConversationFormatter.kt
@@ -93,7 +93,7 @@ object ConversationFormatter {
                 HomeToolStatus(
                     callId = toolCall.callId,
                     name = toolCall.toolName,
-                    state = HomeToolState.Succeeded,
+                    state = HomeToolState.Failed,
                 ),
             )
         }
@@ -118,7 +118,8 @@ object ConversationFormatter {
     }
 
     private fun HomeToolStatus.matchesTool(callId: String, toolName: String): Boolean {
-        return this.callId == callId || (this.callId.isNullOrBlank() && name == toolName)
+        if (this.callId != null) return this.callId == callId
+        return name == toolName
     }
 
     private fun MutableList<HomeChatTurn>.replaceLastOrAdd(turn: HomeChatTurn) {

--- a/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/content/HomeChatComponents.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/content/HomeChatComponents.kt
@@ -302,7 +302,7 @@ fun ToolStatusPill(
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                    text = status.state.label(),
+                    text = status.label(),
                     style = MaterialTheme.typography.labelMedium,
                     color = contentColor,
                     maxLines = 1,
@@ -443,10 +443,13 @@ private fun ToolStatusIndicator(
 }
 
 @Composable
-private fun HomeToolState.label(): String = when (this) {
+private fun HomeToolStatus.label(): String = when (state) {
     HomeToolState.Running -> stringResource(R.string.ui_tool_status_running)
     HomeToolState.Succeeded -> stringResource(R.string.ui_tool_status_success)
-    HomeToolState.Failed -> stringResource(R.string.ui_tool_status_failed)
+    HomeToolState.Failed -> when (failedReason) {
+        "Interrupted by user" -> stringResource(R.string.ui_tool_status_failed_reason_interrupted)
+        else -> stringResource(R.string.ui_tool_status_failed)
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/model/HomeChatState.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/model/HomeChatState.kt
@@ -247,8 +247,11 @@ class HomeChatViewModel internal constructor(
         streamJob?.cancel()
         streamJob = null
         finalizeRunningTools()
-        persistCurrentHistoryIfAny()
-        updateState { copy(isGenerating = false) }
+        try {
+            persistCurrentHistoryIfAny()
+        } finally {
+            updateState { copy(isGenerating = false) }
+        }
     }
 
     private fun startNewConversation() {
@@ -585,9 +588,7 @@ class HomeChatViewModel internal constructor(
         label: String,
         state: HomeToolState,
     ): HomeChatTurn {
-        val index = blocks.indexOfLast { block ->
-            block is HomeChatBlock.Tool && block.status.matchesTool(callId, label)
-        }
+        val index = findToolBlockIndex(callId, label)
         if (index == -1) {
             return appendTool(callId, label, state)
         }
@@ -604,11 +605,16 @@ class HomeChatViewModel internal constructor(
         )
     }
 
-    private fun HomeToolStatus.matchesTool(callId: String?, label: String): Boolean {
-        if (callId != null && this.callId != null) {
-            return this.callId == callId
+    private fun HomeChatTurn.findToolBlockIndex(callId: String?, label: String): Int {
+        if (callId != null) {
+            val exactMatch = blocks.indexOfLast { block ->
+                block is HomeChatBlock.Tool && block.status.callId == callId
+            }
+            if (exactMatch != -1) return exactMatch
         }
-        return name == label
+        return blocks.indexOfLast { block ->
+            block is HomeChatBlock.Tool && block.status.callId == null && block.status.name == label
+        }
     }
 
     private fun List<HomeChatTurn>.nextTurnId(): Long {

--- a/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/model/HomeChatState.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/model/HomeChatState.kt
@@ -73,6 +73,7 @@ data class HomeToolStatus(
     val callId: String? = null,
     val name: String,
     val state: HomeToolState,
+    val failedReason: String? = null,
 )
 
 sealed interface HomeChatBlock {
@@ -245,6 +246,8 @@ class HomeChatViewModel internal constructor(
         runtime.stopCurrentRound(keepCurrentTurn = true)
         streamJob?.cancel()
         streamJob = null
+        finalizeRunningTools()
+        persistCurrentHistoryIfAny()
         updateState { copy(isGenerating = false) }
     }
 
@@ -307,15 +310,7 @@ class HomeChatViewModel internal constructor(
                 updateTurn(turnId) {
                     it.appendFinalText(event.fullText)
                 }
-                val completedConversationId = currentConversationId
-                val completedHistory = if (completedConversationId != null) {
-                    runtime.getHistory()
-                } else {
-                    emptyList()
-                }
-                if (completedConversationId != null) {
-                    persistCompletedHistory(completedConversationId, completedHistory)
-                }
+                persistCurrentHistoryIfAny()
                 updateState { copy(isGenerating = false) }
             }
         }
@@ -363,6 +358,39 @@ class HomeChatViewModel internal constructor(
         conversations.saveHistory(conversationId = conversationId, history = history)
         if (currentConversationId == conversationId) {
             conversations.setLastOpenedConversationId(conversationId)
+        }
+    }
+
+    private suspend fun persistCurrentHistoryIfAny() {
+        val conversationId = currentConversationId ?: return
+        val history = runtime.getHistory()
+        if (history.isEmpty()) return
+        persistCompletedHistory(conversationId, history)
+    }
+
+    private fun finalizeRunningTools() {
+        val currentTurns = currentState.turns
+        if (currentTurns.isEmpty()) return
+        val lastTurn = currentTurns.last()
+        val hasRunning = lastTurn.blocks.any { block ->
+            block is HomeChatBlock.Tool && block.status.state == HomeToolState.Running
+        }
+        if (!hasRunning) return
+        updateTurn(lastTurn.id) { turn ->
+            turn.copy(
+                blocks = turn.blocks.map { block ->
+                    if (block is HomeChatBlock.Tool && block.status.state == HomeToolState.Running) {
+                        HomeChatBlock.Tool(
+                            block.status.copy(
+                                state = HomeToolState.Failed,
+                                failedReason = FAILED_REASON_INTERRUPTED,
+                            ),
+                        )
+                    } else {
+                        block
+                    }
+                },
+            )
         }
     }
 
@@ -577,11 +605,10 @@ class HomeChatViewModel internal constructor(
     }
 
     private fun HomeToolStatus.matchesTool(callId: String?, label: String): Boolean {
-        return if (callId != null || this.callId != null) {
-            this.callId == callId
-        } else {
-            name == label
+        if (callId != null && this.callId != null) {
+            return this.callId == callId
         }
+        return name == label
     }
 
     private fun List<HomeChatTurn>.nextTurnId(): Long {
@@ -604,5 +631,9 @@ class HomeChatViewModel internal constructor(
         is LlmStreamEvent.ToolFailed -> "ToolFailed"
         is LlmStreamEvent.Error -> "Error"
         is LlmStreamEvent.Completed -> "Completed"
+    }
+
+    companion object {
+        internal const val FAILED_REASON_INTERRUPTED = "Interrupted by user"
     }
 }

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -48,6 +48,7 @@
     <string name="ui_tool_status_running">執行中</string>
     <string name="ui_tool_status_success">成功</string>
     <string name="ui_tool_status_failed">失敗</string>
+    <string name="ui_tool_status_failed_reason_interrupted">用戶中斷</string>
     <plurals name="ui_home_used_tools">
         <item quantity="other">已使用 %1$d 個工具</item>
     </plurals>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -48,6 +48,7 @@
     <string name="ui_tool_status_running">Running</string>
     <string name="ui_tool_status_success">Success</string>
     <string name="ui_tool_status_failed">Failed</string>
+    <string name="ui_tool_status_failed_reason_interrupted">Interrupted</string>
     <plurals name="ui_home_used_tools">
         <item quantity="one">Used %1$d Tool</item>
         <item quantity="other">Used %1$d Tools</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,6 +48,7 @@
     <string name="ui_tool_status_running">执行中</string>
     <string name="ui_tool_status_success">成功</string>
     <string name="ui_tool_status_failed">失败</string>
+    <string name="ui_tool_status_failed_reason_interrupted">用户中断</string>
     <plurals name="ui_home_used_tools">
         <item quantity="other">已使用 %1$d 个工具</item>
     </plurals>

--- a/app/src/test/java/com/niki914/nexus/agentic/app/ui/nexus/model/HomeChatControllerTest.kt
+++ b/app/src/test/java/com/niki914/nexus/agentic/app/ui/nexus/model/HomeChatControllerTest.kt
@@ -287,6 +287,80 @@ class HomeChatViewModelTest {
     }
 
     @Test
+    fun stopGenerating_finalizesRunningToolsToFailedWithInterruptedReason() = runTest {
+        val conversations = FakeHomeConversationStore()
+        val viewModel = HomeChatViewModel(
+            conversations = conversations,
+            runtime = FakeHomeChatRuntime(stream = {
+                flow {
+                    emit(LlmStreamEvent.RoundStarted)
+                    emit(LlmStreamEvent.ToolRunning(ToolCallStatus(name = "search", label = "Search")))
+                    emit(LlmStreamEvent.ToolRunning(ToolCallStatus(callId = "c1", name = "calc", label = "Calc")))
+                    awaitCancellation()
+                }
+            }),
+        )
+
+        viewModel.sendIntent(HomeChatIntent.InputChanged("hello"))
+        runCurrent()
+        viewModel.sendIntent(HomeChatIntent.Send)
+        runCurrent()
+        viewModel.sendIntent(HomeChatIntent.StopGenerating)
+        runCurrent()
+
+        val state = viewModel.uiStateFlow.value
+        assertFalse(state.isGenerating)
+        val toolBlocks = state.turns.single().blocks.filterIsInstance<HomeChatBlock.Tool>()
+        assertEquals(2, toolBlocks.size)
+        toolBlocks.forEach { tool ->
+            assertEquals(HomeToolState.Failed, tool.status.state)
+            assertEquals(
+                HomeChatViewModel.FAILED_REASON_INTERRUPTED,
+                tool.status.failedReason,
+            )
+        }
+
+        viewModel.sendIntent(HomeChatIntent.NewConversation)
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun stopGenerating_persistsCurrentHistory() = runTest {
+        val conversations = FakeHomeConversationStore()
+        var stopCalled = false
+        val viewModel = HomeChatViewModel(
+            conversations = conversations,
+            runtime = FakeHomeChatRuntime(
+                stream = {
+                    flow {
+                        emit(LlmStreamEvent.RoundStarted)
+                        emit(LlmStreamEvent.TextDelta(delta = "partial", fullText = "partial"))
+                        awaitCancellation()
+                    }
+                },
+                getHistory = { listOf(ChatTurn.User("hello"), ChatTurn.Assistant("partial")) },
+                stopCurrentRound = { stopCalled = true },
+            ),
+        )
+
+        viewModel.sendIntent(HomeChatIntent.InputChanged("hello"))
+        runCurrent()
+        viewModel.sendIntent(HomeChatIntent.Send)
+        runCurrent()
+        viewModel.sendIntent(HomeChatIntent.StopGenerating)
+        advanceUntilIdle()
+
+        assertTrue(stopCalled)
+        val conversationId = conversations.lastOpenedConversationId()
+        assertTrue(conversationId.isNotBlank())
+        val record = conversations.getConversation(conversationId)!!
+        assertEquals(2, record.history.size)
+
+        viewModel.sendIntent(HomeChatIntent.NewConversation)
+        advanceUntilIdle()
+    }
+
+    @Test
     fun completed_persistsRuntimeHistoryAndLastOpenedConversationId() = runTest {
         val history = listOf(
             ChatTurn.User("hello"),

--- a/app/src/test/java/com/niki914/nexus/agentic/app/ui/nexus/model/HomeChatControllerTest.kt
+++ b/app/src/test/java/com/niki914/nexus/agentic/app/ui/nexus/model/HomeChatControllerTest.kt
@@ -361,6 +361,79 @@ class HomeChatViewModelTest {
     }
 
     @Test
+    fun stopGenerating_clearsIsGeneratingEvenWhenPersistFails() = runTest {
+        val conversations = ThrowingSaveConversationStore()
+        var stopCalled = false
+        val viewModel = HomeChatViewModel(
+            conversations = conversations,
+            runtime = FakeHomeChatRuntime(
+                stream = {
+                    flow {
+                        emit(LlmStreamEvent.RoundStarted)
+                        emit(LlmStreamEvent.TextDelta(delta = "partial", fullText = "partial"))
+                        awaitCancellation()
+                    }
+                },
+                getHistory = { listOf(ChatTurn.User("hello"), ChatTurn.Assistant("partial")) },
+                stopCurrentRound = { stopCalled = true },
+            ),
+        )
+
+        viewModel.sendIntent(HomeChatIntent.InputChanged("hello"))
+        runCurrent()
+        viewModel.sendIntent(HomeChatIntent.Send)
+        runCurrent()
+        viewModel.sendIntent(HomeChatIntent.StopGenerating)
+        advanceUntilIdle()
+
+        assertTrue(stopCalled)
+        assertFalse(viewModel.uiStateFlow.value.isGenerating)
+
+        viewModel.sendIntent(HomeChatIntent.InputChanged("next"))
+        runCurrent()
+        viewModel.sendIntent(HomeChatIntent.Send)
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiStateFlow.value.isGenerating)
+
+        viewModel.sendIntent(HomeChatIntent.NewConversation)
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun updateTool_matchesCorrectBlockWithMixedCallIds() = runTest {
+        val conversations = FakeHomeConversationStore()
+        val viewModel = HomeChatViewModel(
+            conversations = conversations,
+            runtime = FakeHomeChatRuntime(stream = {
+                flowOf(
+                    LlmStreamEvent.RoundStarted,
+                    LlmStreamEvent.ToolRunning(ToolCallStatus(name = "search", label = "Search")),
+                    LlmStreamEvent.ToolRunning(ToolCallStatus(callId = "c1", name = "search", label = "Search")),
+                    LlmStreamEvent.ToolSucceeded(ToolCallStatus(callId = "c1", name = "search", label = "Search")),
+                    LlmStreamEvent.Completed(fullText = ""),
+                )
+            }),
+        )
+
+        viewModel.sendIntent(HomeChatIntent.InputChanged("hello"))
+        runCurrent()
+        viewModel.sendIntent(HomeChatIntent.Send)
+        advanceUntilIdle()
+
+        val toolBlocks =
+            viewModel.uiStateFlow.value.turns.single().blocks.filterIsInstance<HomeChatBlock.Tool>()
+        assertEquals(2, toolBlocks.size)
+        val nullCallId = toolBlocks.first { it.status.callId == null }
+        val hasCallId = toolBlocks.first { it.status.callId == "c1" }
+        assertEquals(HomeToolState.Running, nullCallId.status.state)
+        assertEquals(HomeToolState.Succeeded, hasCallId.status.state)
+
+        viewModel.sendIntent(HomeChatIntent.NewConversation)
+        advanceUntilIdle()
+    }
+
+    @Test
     fun completed_persistsRuntimeHistoryAndLastOpenedConversationId() = runTest {
         val history = listOf(
             ChatTurn.User("hello"),
@@ -532,7 +605,7 @@ private class FakeHomeChatRuntime(
     override suspend fun replaceHistory(history: List<ChatTurn>) = replaceHistory.invoke(history)
 }
 
-private class FakeHomeConversationStore : HomeConversationStore {
+private open class FakeHomeConversationStore : HomeConversationStore {
     private val records = linkedMapOf<String, ConversationRecord>()
     private var nextId = 0
     private var lastOpenedId = ""
@@ -605,6 +678,12 @@ private class FakeHomeConversationStore : HomeConversationStore {
 
     fun listConversations(): List<ConversationSummary> {
         return records.values.map { it.summary }.sortedByDescending { it.updatedAt }
+    }
+}
+
+private class ThrowingSaveConversationStore : FakeHomeConversationStore() {
+    override suspend fun saveHistory(conversationId: String, history: List<ChatTurn>) {
+        throw RuntimeException("Save failed")
     }
 }
 


### PR DESCRIPTION
## Summary
- **stopGenerating()** now finalizes `Running` tools to `Failed("Interrupted by user")` instead of leaving them orphaned forever
- **ConversationFormatter** now defaults orphaned tools (no ToolResult) to `Failed` instead of `Succeeded` on history restore
- **History persists on stop** (not just on `Completed`), fixing cold-start with empty conversations
- **Fixed `matchesTool()`** null callId matching to prevent duplicate tool blocks

## Changes
| File | Change |
|---|---|
| `HomeChatState.kt` | +`failedReason` field, `finalizeRunningTools()`, `persistCurrentHistoryIfAny()`, fixed `matchesTool()` |
| `ConversationFormatter.kt` | Default tool state `Failed` (was `Succeeded`), fixed `matchesTool()` |
| `HomeChatComponents.kt` | `label()` shows interrupt reason when present |
| `strings.xml` ×3 | New `ui_tool_status_failed_reason_interrupted` string |
| `HomeChatControllerTest.kt` | 2 new tests: finalize + persist on stop |

## Test plan
- [x] All existing unit tests pass (`:app:testDebugUnitTest` + `:agent-runtime:testDebugUnitTest`)
- [x] New `stopGenerating_finalizesRunningToolsToFailedWithInterruptedReason` test
- [x] New `stopGenerating_persistsCurrentHistory` test

🤖 Generated with [Claude Code](https://claude.com/claude-code)