### PR TITLE
feat: loading indicator + nested scroll fix

### DIFF
--- a/app/src/main/java/com/niki914/nexus/agentic/app/App.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/App.kt
@@ -36,8 +36,5 @@ class App : Application() {
         applicationScope.launch {
             XRepo.skills.seedDefaults()
         }
-        applicationScope.launch {
-            ConversationRepo.listConversations()
-        }
     }
 }

--- a/app/src/main/java/com/niki914/nexus/agentic/app/App.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/App.kt
@@ -36,5 +36,8 @@ class App : Application() {
         applicationScope.launch {
             XRepo.skills.seedDefaults()
         }
+        applicationScope.launch {
+            ConversationRepo.listConversations()
+        }
     }
 }

--- a/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/content/HomePageContent.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/content/HomePageContent.kt
@@ -295,15 +295,6 @@ private fun HomePageContentBody(
             .fillMaxSize()
             .liquidScreenHazeSource(),
     ) {
-        if (uiState.isLoadingConversation) {
-            LoadingIndicator(
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .size(48.dp),
-                color = MaterialTheme.colorScheme.primary,
-            )
-        }
-
         LazyColumn(
             state = listState,
             modifier = Modifier
@@ -370,6 +361,24 @@ private fun HomePageContentBody(
                         bottom = composerBottomPadding,
                     ),
             )
+        }
+
+        if (uiState.isLoadingConversation) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = {},
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                LoadingIndicator(
+                    modifier = Modifier.size(48.dp),
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/content/HomePageContent.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/content/HomePageContent.kt
@@ -18,12 +18,16 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.History
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -265,6 +269,7 @@ fun HomePageContent(
     }
 }
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun HomePageContentBody(
     uiState: HomeChatUiState,
@@ -290,6 +295,15 @@ private fun HomePageContentBody(
             .fillMaxSize()
             .liquidScreenHazeSource(),
     ) {
+        if (uiState.isLoadingConversation) {
+            LoadingIndicator(
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .size(48.dp),
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+
         LazyColumn(
             state = listState,
             modifier = Modifier

--- a/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/content/ToolChain.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/content/ToolChain.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.niki914.nexus.agentic.app.R
@@ -67,6 +68,9 @@ private val NoNestedScrollPropagation = object : NestedScrollConnection {
         available: Offset,
         source: NestedScrollSource,
     ): Offset = if (available.y != 0f) available.copy(x = 0f) else Offset.Zero
+
+    override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity =
+        Velocity(x = 0f, y = available.y)
 }
 
 // ── ToolChain — stateless, state driven by ViewModel ──────────────────────

--- a/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/content/ToolChain.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/content/ToolChain.kt
@@ -44,6 +44,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
@@ -56,6 +60,14 @@ import com.niki914.nexus.agentic.app.ui.nexus.model.HomeToolStatus
 
 private val SucceededColor = Color(0xFF4F8F6B)
 private val FailedColor = Color(0xFFB85C5C)
+
+private val NoNestedScrollPropagation = object : NestedScrollConnection {
+    override fun onPostScroll(
+        consumed: Offset,
+        available: Offset,
+        source: NestedScrollSource,
+    ): Offset = if (available.y != 0f) available.copy(x = 0f) else Offset.Zero
+}
 
 // ── ToolChain — stateless, state driven by ViewModel ──────────────────────
 
@@ -321,7 +333,7 @@ private fun ToolResultText(
         modifier = Modifier
             .let { if (overflow) it.fillMaxWidth() else it }
             .heightIn(max = 102.dp)
-            .let { if (overflow) it.verticalScroll(rememberScrollState()) else it },
+            .let { if (overflow) it.nestedScroll(NoNestedScrollPropagation).verticalScroll(rememberScrollState()) else it },
         contentAlignment = if (overflow) Alignment.TopStart else Alignment.Center,
     ) {
         SelectionContainer {

--- a/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/model/HomeChatState.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/model/HomeChatState.kt
@@ -93,6 +93,7 @@ data class HomeChatUiState(
     val input: String = "",
     val turns: List<HomeChatTurn> = emptyList(),
     val isGenerating: Boolean = false,
+    val isLoadingConversation: Boolean = false,
     val lastEventName: String? = null,
     val streamEventCount: Int = 0,
     val currentConversationId: String? = null,
@@ -347,6 +348,7 @@ class HomeChatViewModel internal constructor(
     private fun restoreLastConversationOnStartup() {
         if (startupRestoreAttempted) return
         startupRestoreAttempted = true
+        updateState { copy(isLoadingConversation = true) }
         viewModelScope.launch {
             try {
                 val conversationId = conversations.lastOpenedConversationId()
@@ -363,6 +365,7 @@ class HomeChatViewModel internal constructor(
                     copy(
                         input = record.draftText,
                         turns = restoredTurns,
+                        isLoadingConversation = false,
                         isGenerating = false,
                         lastEventName = null,
                         streamEventCount = 0,
@@ -376,6 +379,8 @@ class HomeChatViewModel internal constructor(
                 }
             } catch (throwable: Throwable) {
                 if (throwable is CancellationException) throw throwable
+            } finally {
+                updateState { copy(isLoadingConversation = false) }
             }
         }
     }
@@ -428,29 +433,35 @@ class HomeChatViewModel internal constructor(
         streamJob = null
         draftSaveJob?.cancel()
         draftSaveJob = null
-        val record = conversations.getConversation(id) ?: return
-        runtime.replaceHistory(record.history)
-        currentConversationId = id
-        conversations.setLastOpenedConversationId(id)
-        val restoredTurns = ConversationFormatter.toHomeTurns(record.history)
-        val restoredTitle = record.summary.title.takeIf {
-            restoredTurns.isNotEmpty() && it.isNotBlank()
-        }
-        nextTurnId = restoredTurns.nextTurnId()
-        updateState {
-            copy(
-                input = "",
-                turns = restoredTurns,
-                isGenerating = false,
-                lastEventName = null,
-                streamEventCount = 0,
-                currentConversationId = id,
-                currentConversationTitle = restoredTitle,
-                expandedToolRuns = emptySet(),
-                expandedToolResults = emptySet(),
-                expandedActionTurnId = null,
-                expandedActionSource = null,
-            )
+        updateState { copy(isLoadingConversation = true) }
+        try {
+            val record = conversations.getConversation(id) ?: return
+            runtime.replaceHistory(record.history)
+            currentConversationId = id
+            conversations.setLastOpenedConversationId(id)
+            val restoredTurns = ConversationFormatter.toHomeTurns(record.history)
+            val restoredTitle = record.summary.title.takeIf {
+                restoredTurns.isNotEmpty() && it.isNotBlank()
+            }
+            nextTurnId = restoredTurns.nextTurnId()
+            updateState {
+                copy(
+                    input = "",
+                    turns = restoredTurns,
+                    isLoadingConversation = false,
+                    isGenerating = false,
+                    lastEventName = null,
+                    streamEventCount = 0,
+                    currentConversationId = id,
+                    currentConversationTitle = restoredTitle,
+                    expandedToolRuns = emptySet(),
+                    expandedToolResults = emptySet(),
+                    expandedActionTurnId = null,
+                    expandedActionSource = null,
+                )
+            }
+        } finally {
+            updateState { copy(isLoadingConversation = false) }
         }
     }
 


### PR DESCRIPTION
## Summary
- Show page-level `LoadingIndicator` while conversation loads from DB (startup restore + switching conversations)
- Fix nested scroll propagation in tool result text — scrolling a tool result to its limit no longer transfers remaining scroll momentum to the conversation LazyColumn

## Test plan
- [ ] Cold launch with saved conversation: loading spinner appears, then conversation loads
- [ ] Switch conversations from history: loading spinner appears during DB read
- [ ] Open a tool result with overflow text, scroll to bottom: conversation list does not move
- [ ] Scroll tool result to top: conversation list does not move

🤖 Generated with [Claude Code](https://claude.com/claude-code)