### PR TITLE
feat: SOUL identity slot and Memory tool semantic redesign

### DIFF
--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/PromptComposer.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/PromptComposer.kt
@@ -25,7 +25,6 @@ class PromptComposer {
     fun compose(input: PromptComposerInput): PromptComposeResult {
         val finalSystemPrompt = listOfNotNull(
             buildStableTier(input),
-            buildContextTier(input),
             buildVolatileTier(input),
         ).joinToString(separator = "\n\n")
 
@@ -35,8 +34,9 @@ class PromptComposer {
     // --- Stable tier: identity, tools, skills, guidance (cacheable across turns) ---
 
     private fun buildStableTier(input: PromptComposerInput): String {
+        val identity = input.additionalInstructions.trim().ifBlank { DEFAULT_AGENT_IDENTITY }
         return listOfNotNull(
-            DEFAULT_AGENT_IDENTITY,
+            identity,
             renderToolContext(input.tools, input.mcpDiscoverySnapshot),
             renderSkillContext(input.enabledSkills)
                 .takeIf { hasBuiltinTool(input, "load_skill") },
@@ -45,14 +45,6 @@ class PromptComposer {
             MEMORY_GUIDANCE.takeIf { hasBuiltinTool(input, "memorize") },
             SKILLS_GUIDANCE.takeIf { hasBuiltinTool(input, "load_skill") },
         ).joinToString(separator = "\n\n")
-    }
-
-    // --- Context tier: user-supplied instructions ---
-
-    private fun buildContextTier(input: PromptComposerInput): String? {
-        val text = input.additionalInstructions.trim()
-        if (text.isEmpty()) return null
-        return "## Additional instructions\n\n$text"
     }
 
     // --- Volatile tier: memory snapshot (per-session) ---

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/PromptComposer.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/PromptComposer.kt
@@ -42,7 +42,7 @@ class PromptComposer {
                 .takeIf { hasBuiltinTool(input, "load_skill") },
             TASK_COMPLETION_GUIDANCE.takeIf { hasAnyTool(input) },
             TOOL_USE_ENFORCEMENT_GUIDANCE.takeIf { hasAnyTool(input) },
-            MEMORY_GUIDANCE.takeIf { hasBuiltinTool(input, "memorize") },
+            MEMORY_GUIDANCE.takeIf { hasBuiltinTool(input, "memory") },
             SKILLS_GUIDANCE.takeIf { hasBuiltinTool(input, "load_skill") },
         ).joinToString(separator = "\n\n")
     }
@@ -200,7 +200,7 @@ class PromptComposer {
                 "(b) deliver a final result to the user."
 
         internal const val MEMORY_GUIDANCE =
-            "You have persistent memory across sessions. Save durable facts using the memorize " +
+            "You have persistent memory across sessions. Save durable facts using the memory " +
                 "tool: user preferences, environment details, tool quirks, and stable conventions. " +
                 "Memory is injected into every turn, so keep it compact and focused on facts that " +
                 "will still matter later.\n" +

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/PromptComposer.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/PromptComposer.kt
@@ -52,13 +52,9 @@ class PromptComposer {
     private fun buildVolatileTier(input: PromptComposerInput): String? {
         val items = input.memoryItems.map(String::trim).filter(String::isNotBlank)
         if (items.isEmpty()) return null
-        return buildString {
-            appendLine("## Agent Memory")
-            appendLine()
-            appendLine("<memory>")
-            items.forEach { appendLine("- $it") }
-            append("</memory>")
-        }
+        val separator = "═".repeat(46)
+        val content = items.joinToString("\n§\n")
+        return "$separator\nMEMORY\n$separator\n$content"
     }
 
     // --- Tool context ---
@@ -204,17 +200,26 @@ class PromptComposer {
                 "(b) deliver a final result to the user."
 
         internal const val MEMORY_GUIDANCE =
-            "# Memory\n" +
-                "You have persistent memory across sessions. Use the memorize tool to save " +
-                "durable facts: user preferences, environment details, and stable conventions. " +
-                "Memory is injected into every turn, so keep it compact and focused on facts " +
-                "that will still matter later.\n" +
+            "You have persistent memory across sessions. Save durable facts using the memorize " +
+                "tool: user preferences, environment details, tool quirks, and stable conventions. " +
+                "Memory is injected into every turn, so keep it compact and focused on facts that " +
+                "will still matter later.\n" +
+                "Prioritize what reduces future user steering — the most valuable memory is one " +
+                "that prevents the user from having to correct or remind you again. " +
+                "User preferences and recurring corrections matter more than procedural task details.\n" +
+                "Do NOT save task progress, session outcomes, completed-work logs, or temporary TODO " +
+                "state to memory; use conversation history to recall those from past interactions. " +
+                "Specifically: do not record PR numbers, issue numbers, commit SHAs, 'fixed bug X', " +
+                "'submitted PR Y', 'Phase N done', file counts, or any artifact that will be stale " +
+                "in 7 days. If a fact will be stale in a week, it does not belong in memory. " +
+                "If you've discovered a new way to do something, solved a problem that could be " +
+                "necessary later, save it as a skill with the skill tool.\n" +
                 "Write memories as declarative facts, not instructions to yourself. " +
-                "\"User prefers concise responses\" ✓ — \"Always respond concisely\" ✗. " +
-                "\"Project uses Kotlin with coroutines\" ✓ — \"Use coroutines for async\" ✗.\n" +
-                "Do NOT save task progress, session outcomes, PR numbers, commit SHAs, " +
-                "or anything that will be stale within a week. Procedures and workflows " +
-                "belong in skills, not memory."
+                "'User prefers concise responses' ✓ — 'Always respond concisely' ✗. " +
+                "'Project uses pytest with xdist' ✓ — 'Run tests with pytest -n 4' ✗. " +
+                "Imperative phrasing gets re-read as a directive in later sessions and can " +
+                "cause repeated work or override the user's current request. Procedures and " +
+                "workflows belong in skills, not memory."
 
         internal const val SKILLS_GUIDANCE =
             "# Skills\n" +

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/BuiltinToolRegistry.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/BuiltinToolRegistry.kt
@@ -3,7 +3,7 @@ package com.niki914.nexus.agentic.chat.agentic.buildin
 import com.niki914.nexus.agentic.chat.agentic.buildin.impl.CreateCustomToolBuiltin
 import com.niki914.nexus.agentic.chat.agentic.buildin.impl.LaunchAppBuiltin
 import com.niki914.nexus.agentic.chat.agentic.buildin.impl.LoadSkillBuiltin
-import com.niki914.nexus.agentic.chat.agentic.buildin.impl.MemorizeBuiltin
+import com.niki914.nexus.agentic.chat.agentic.buildin.impl.MemoryBuiltin
 import com.niki914.nexus.agentic.chat.agentic.buildin.impl.NotifyBuiltin
 import com.niki914.nexus.agentic.chat.agentic.buildin.impl.OpenUriBuiltin
 import com.niki914.nexus.agentic.chat.agentic.buildin.impl.ReadCustomToolBuiltin
@@ -27,7 +27,7 @@ class BuiltinToolRegistry(
             listOf(
                 CreateCustomToolBuiltin(),
                 LaunchAppBuiltin(),
-                MemorizeBuiltin(),
+                MemoryBuiltin(),
                 NotifyBuiltin(),
                 OpenUriBuiltin(),
                 ReadCustomToolBuiltin(),

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/MemorizeBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/MemorizeBuiltin.kt
@@ -10,22 +10,26 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 class MemorizeBuiltin : BuiltinTool(), RawJsonBuiltinTool {
     override val name: String = "memorize"
 
-    override val description: String = "Add a concise item to persistent memory."
+    override val description: String =
+        "Manage persistent memory across sessions. Use to save durable facts " +
+            "(user preferences, environment details, conventions). " +
+            "Memory items are shown in every turn's system prompt — " +
+            "this is a write tool, NOT a query tool. " +
+            "Use list to see saved items, add to save a new one, remove to delete by index."
 
     override val defaultEnabled: Boolean = true
 
     override fun configure(config: LocalToolConfig) {
         config.description = description
-        config.string("content") {
-            description = "The non-blank memory item to persist for future turns."
-            required = true
-        }
         config.rawJsonSchema(MEMORIZE_SCHEMA)
     }
 
@@ -33,75 +37,153 @@ class MemorizeBuiltin : BuiltinTool(), RawJsonBuiltinTool {
         return BuiltinToolResult.failure(
             code = "RAW_JSON_ONLY",
             message = "memorize must be executed through invokeRawJson().",
-            hint = "Use BuiltinToolExecutor to execute this builtin.",
+            hint = """Example: {"action":"add","content":"User prefers concise answers."}""",
         )
     }
 
     override suspend fun invokeRawJson(request: BuiltinToolRequest): String {
-        val content = try {
-            parseContent(request.argumentsJson)
-        } catch (throwable: Throwable) {
-            if (throwable is CancellationException) {
-                throw throwable
-            }
+        val args = try {
+            parseArgs(request.argumentsJson)
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: IllegalArgumentException) {
             return BuiltinToolResult.failure(
-                code = "INVALID_ARGUMENTS_JSON",
-                message = "memorize arguments must be a JSON object with a content field.",
-                hint = """Example: {"content":"The user prefers concise answers."}""",
-                fieldErrors = mapOf(
-                    "argumentsJson" to (throwable.message ?: "Invalid JSON object.")
-                ),
-            ).toJsonString()
-        }
-        if (content.isBlank()) {
-            return BuiltinToolResult.failure(
-                code = "MISSING_REQUIRED_FIELD",
-                message = "memorize requires non-blank content.",
-                hint = "Provide a concise memory item in the content field.",
-                fieldErrors = mapOf("content" to "Field 'content' must not be blank."),
+                code = "INVALID_ARGUMENTS",
+                message = error.message ?: "Invalid arguments.",
+                hint = """Example: {"action":"add","content":"User prefers concise answers."}""",
             ).toJsonString()
         }
 
+        val validationError = validateArgs(args)
+        if (validationError != null) {
+            return validationError.toJsonString()
+        }
+
         return try {
-            RuntimeEnvironment.awaitSettingsGateway().addMemory(content)
-            SUCCESS_JSON
-        } catch (throwable: Throwable) {
-            if (throwable is CancellationException) {
-                throw throwable
+            val gateway = RuntimeEnvironment.awaitSettingsGateway()
+            when (args.action) {
+                Action.ADD -> {
+                    gateway.addMemory(args.content!!)
+                    """{"ok":true,"action":"add"}"""
+                }
+                Action.REMOVE -> {
+                    val index = args.index!!
+                    val before = gateway.listMemories()
+                    if (index !in before.indices) {
+                        BuiltinToolResult.failure(
+                            code = "INDEX_OUT_OF_RANGE",
+                            message = "Memory index $index is out of range (0..${before.size - 1}).",
+                            hint = "Use list to see current items and their indices.",
+                        ).toJsonString()
+                    } else {
+                        gateway.deleteMemory(index)
+                        """{"ok":true,"action":"remove","index":$index}"""
+                    }
+                }
+                Action.LIST -> {
+                    val items = gateway.listMemories()
+                    val jsonItems = items.mapIndexed { i, text ->
+                        JsonObject(mapOf("index" to JsonPrimitive(i), "content" to JsonPrimitive(text)))
+                    }
+                    JsonObject(mapOf("ok" to JsonPrimitive(true), "action" to JsonPrimitive("list"), "items" to JsonPrimitive(jsonItems.toString()))).toString()
+                }
             }
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
             BuiltinToolResult.failure(
                 code = "SETTINGS_WRITE_FAILED",
-                message = "Failed to write memory: ${throwable.message ?: throwable::class.java.simpleName}.",
+                message = "Failed to access memory: ${error.message ?: error::class.java.simpleName}.",
                 hint = "Retry after confirming the settings provider is available.",
             ).toJsonString()
         }
     }
 
-    private fun parseContent(argumentsJson: String): String {
+    private fun parseArgs(argumentsJson: String): Args {
         val element = try {
             Json.parseToJsonElement(argumentsJson)
-        } catch (throwable: SerializationException) {
-            throw IllegalArgumentException("argumentsJson is not valid JSON.", throwable)
-        } catch (throwable: IllegalArgumentException) {
-            throw IllegalArgumentException("argumentsJson is not valid JSON.", throwable)
+        } catch (error: SerializationException) {
+            throw IllegalArgumentException("argumentsJson is not valid JSON.")
+        } catch (error: IllegalArgumentException) {
+            throw IllegalArgumentException("argumentsJson is not valid JSON.")
         }
         val obj = element as? JsonObject
             ?: throw IllegalArgumentException("argumentsJson must be a JSON object.")
-        return obj["content"]?.jsonPrimitive?.contentOrNull.orEmpty().trim()
+
+        val action = Action.from(obj["action"]?.jsonPrimitive?.contentOrNull)
+        val content = obj["content"]?.jsonPrimitive?.contentOrNull?.trim()
+        val index = obj["index"]?.jsonPrimitive?.intOrNull
+
+        return Args(action, content, index)
     }
 
+    private fun validateArgs(args: Args): BuiltinToolResult? {
+        return when (args.action) {
+            Action.ADD -> {
+                if (args.content.isNullOrBlank()) {
+                    BuiltinToolResult.failure(
+                        code = "INVALID_ARGUMENTS",
+                        message = "Field 'content' is required for add action.",
+                        hint = """Example: {"action":"add","content":"User prefers concise answers."}""",
+                    )
+                } else {
+                    null
+                }
+            }
+            Action.REMOVE -> {
+                if (args.index == null) {
+                    BuiltinToolResult.failure(
+                        code = "INVALID_ARGUMENTS",
+                        message = "Field 'index' is required for remove action.",
+                        hint = """Example: {"action":"remove","index":0}""",
+                    )
+                } else {
+                    null
+                }
+            }
+            Action.LIST -> null
+        }
+    }
+
+    private enum class Action {
+        ADD, REMOVE, LIST;
+
+        companion object {
+            fun from(wire: String?): Action {
+                return when (wire?.trim()?.lowercase()) {
+                    "remove" -> REMOVE
+                    "list" -> LIST
+                    else -> ADD
+                }
+            }
+        }
+    }
+
+    private data class Args(
+        val action: Action,
+        val content: String?,
+        val index: Int?,
+    )
+
     companion object {
-        private const val SUCCESS_JSON = """{"ok":true}"""
         private const val MEMORIZE_SCHEMA = """
             {
               "type": "object",
               "properties": {
+                "action": {
+                  "type": "string",
+                  "enum": ["add", "remove", "list"],
+                  "description": "add (save a fact), remove (delete by index), list (show all items with indices). Default: add."
+                },
                 "content": {
                   "type": "string",
-                  "description": "The non-blank memory item to persist for future turns."
+                  "description": "The memory item text. Required for add."
+                },
+                "index": {
+                  "type": "integer",
+                  "description": "Zero-based index of the memory to remove. Required for remove. Use list to see indices."
                 }
-              },
-              "required": ["content"]
+              }
             }
         """
     }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/MemorizeBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/MemorizeBuiltin.kt
@@ -9,6 +9,7 @@ import com.niki914.s3ss10n.LocalToolConfig
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
@@ -85,7 +86,7 @@ class MemorizeBuiltin : BuiltinTool(), RawJsonBuiltinTool {
                     val jsonItems = items.mapIndexed { i, text ->
                         JsonObject(mapOf("index" to JsonPrimitive(i), "content" to JsonPrimitive(text)))
                     }
-                    JsonObject(mapOf("ok" to JsonPrimitive(true), "action" to JsonPrimitive("list"), "items" to JsonPrimitive(jsonItems.toString()))).toString()
+                    JsonObject(mapOf("ok" to JsonPrimitive(true), "action" to JsonPrimitive("list"), "items" to JsonArray(jsonItems))).toString()
                 }
             }
         } catch (error: CancellationException) {
@@ -151,9 +152,12 @@ class MemorizeBuiltin : BuiltinTool(), RawJsonBuiltinTool {
         companion object {
             fun from(wire: String?): Action {
                 return when (wire?.trim()?.lowercase()) {
+                    null, "", "add" -> ADD
                     "remove" -> REMOVE
                     "list" -> LIST
-                    else -> ADD
+                    else -> throw IllegalArgumentException(
+                        "Unknown action '${wire!!.trim()}'. Expected add, remove, or list."
+                    )
                 }
             }
         }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/MemorizeBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/MemorizeBuiltin.kt
@@ -4,6 +4,7 @@ import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinTool
 import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinToolRequest
 import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinToolResult
 import com.niki914.nexus.agentic.chat.agentic.buildin.RawJsonBuiltinTool
+import com.niki914.nexus.agentic.runtime.settings.MemoryMutationResult
 import com.niki914.nexus.agentic.runtime.settings.RuntimeEnvironment
 import com.niki914.s3ss10n.LocalToolConfig
 import kotlinx.coroutines.CancellationException
@@ -73,52 +74,31 @@ class MemorizeBuiltin : BuiltinTool(), RawJsonBuiltinTool {
                     """{"ok":true,"action":"add"}"""
                 }
                 Action.REMOVE -> {
-                    val oldText = args.oldText!!
-                    val before = gateway.listMemories()
-                    val matches = before.mapIndexedNotNull { i, entry ->
-                        if (oldText in entry) i to entry else null
-                    }
-                    when {
-                        matches.isEmpty() -> BuiltinToolResult.failure(
+                    when (gateway.removeMemory(args.oldText!!)) {
+                        MemoryMutationResult.Ok -> """{"ok":true,"action":"remove"}"""
+                        MemoryMutationResult.NotFound -> BuiltinToolResult.failure(
                             code = "NOT_FOUND",
-                            message = "No entry matched '$oldText'.",
+                            message = "No entry matched '${args.oldText}'.",
                             hint = "Check the exact text of the entry you want to remove.",
                         ).toJsonString()
-                        matches.size > 1 && matches.map { it.second }.distinct().size > 1 ->
-                            BuiltinToolResult.failure(
-                                code = "AMBIGUOUS_MATCH",
-                                message = "Multiple entries matched '$oldText'. Be more specific.",
-                            ).toJsonString()
-                        else -> {
-                            gateway.deleteMemory(matches.first().first)
-                            """{"ok":true,"action":"remove"}"""
-                        }
+                        MemoryMutationResult.Ambiguous -> BuiltinToolResult.failure(
+                            code = "AMBIGUOUS_MATCH",
+                            message = "Multiple entries matched '${args.oldText}'. Be more specific.",
+                        ).toJsonString()
                     }
                 }
                 Action.REPLACE -> {
-                    val oldText = args.oldText!!
-                    val newContent = args.content!!
-                    val before = gateway.listMemories()
-                    val matches = before.mapIndexedNotNull { i, entry ->
-                        if (oldText in entry) i to entry else null
-                    }
-                    when {
-                        matches.isEmpty() -> BuiltinToolResult.failure(
+                    when (gateway.replaceMemory(args.oldText!!, args.content!!)) {
+                        MemoryMutationResult.Ok -> """{"ok":true,"action":"replace"}"""
+                        MemoryMutationResult.NotFound -> BuiltinToolResult.failure(
                             code = "NOT_FOUND",
-                            message = "No entry matched '$oldText'.",
+                            message = "No entry matched '${args.oldText}'.",
                             hint = "Check the exact text of the entry you want to replace.",
                         ).toJsonString()
-                        matches.size > 1 && matches.map { it.second }.distinct().size > 1 ->
-                            BuiltinToolResult.failure(
-                                code = "AMBIGUOUS_MATCH",
-                                message = "Multiple entries matched '$oldText'. Be more specific.",
-                            ).toJsonString()
-                        else -> {
-                            val idx = matches.first().first
-                            gateway.deleteMemory(idx)
-                            gateway.addMemory(newContent)
-                            """{"ok":true,"action":"replace"}"""
-                        }
+                        MemoryMutationResult.Ambiguous -> BuiltinToolResult.failure(
+                            code = "AMBIGUOUS_MATCH",
+                            message = "Multiple entries matched '${args.oldText}'. Be more specific.",
+                        ).toJsonString()
                     }
                 }
             }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/MemorizeBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/MemorizeBuiltin.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 class MemorizeBuiltin : BuiltinTool(), RawJsonBuiltinTool {
-    override val name: String = "memorize"
+    override val name: String = "memory"
 
     override val description: String =
         "Save durable facts to persistent memory that survive across sessions. Memory is " +
@@ -43,7 +43,7 @@ class MemorizeBuiltin : BuiltinTool(), RawJsonBuiltinTool {
     override suspend fun invoke(request: BuiltinToolRequest): BuiltinToolResult {
         return BuiltinToolResult.failure(
             code = "RAW_JSON_ONLY",
-            message = "memorize must be executed through invokeRawJson().",
+            message = "$name must be executed through invokeRawJson().",
             hint = """Example: {"action":"add","content":"User prefers concise answers."}""",
         )
     }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/MemorizeBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/MemorizeBuiltin.kt
@@ -152,11 +152,11 @@ class MemorizeBuiltin : BuiltinTool(), RawJsonBuiltinTool {
         companion object {
             fun from(wire: String?): Action {
                 return when (wire?.trim()?.lowercase()) {
-                    null, "", "add" -> ADD
+                    "add" -> ADD
                     "remove" -> REMOVE
                     "list" -> LIST
                     else -> throw IllegalArgumentException(
-                        "Unknown action '${wire!!.trim()}'. Expected add, remove, or list."
+                        "Unknown action '${wire?.trim().orEmpty()}'. Expected add, remove, or list."
                     )
                 }
             }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/MemorizeBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/MemorizeBuiltin.kt
@@ -9,11 +9,9 @@ import com.niki914.s3ss10n.LocalToolConfig
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -21,11 +19,18 @@ class MemorizeBuiltin : BuiltinTool(), RawJsonBuiltinTool {
     override val name: String = "memorize"
 
     override val description: String =
-        "Manage persistent memory across sessions. Use to save durable facts " +
-            "(user preferences, environment details, conventions). " +
-            "Memory items are shown in every turn's system prompt — " +
-            "this is a write tool, NOT a query tool. " +
-            "Use list to see saved items, add to save a new one, remove to delete by index."
+        "Save durable facts to persistent memory that survive across sessions. Memory is " +
+            "injected into every future turn, so keep entries compact and high-signal.\n\n" +
+            "WHEN: save proactively when the user states a preference, correction, or personal " +
+            "detail, or you learn a stable fact about their environment, conventions, or workflow. " +
+            "Priority: user preferences & corrections > environment facts > procedures. The best " +
+            "memory stops the user repeating themselves.\n\n" +
+            "ACTIONS: add (save a new fact), replace (update an existing entry), remove (delete " +
+            "an entry). Use old_text — a short unique substring of the target entry — to identify " +
+            "it for replace and remove.\n\n" +
+            "SKIP: trivial/obvious info, easily re-discovered facts, raw data dumps, task progress, " +
+            "completed-work logs, temporary TODO state. Reusable procedures belong in a skill, " +
+            "not memory."
 
     override val defaultEnabled: Boolean = true
 
@@ -68,25 +73,53 @@ class MemorizeBuiltin : BuiltinTool(), RawJsonBuiltinTool {
                     """{"ok":true,"action":"add"}"""
                 }
                 Action.REMOVE -> {
-                    val index = args.index!!
+                    val oldText = args.oldText!!
                     val before = gateway.listMemories()
-                    if (index !in before.indices) {
-                        BuiltinToolResult.failure(
-                            code = "INDEX_OUT_OF_RANGE",
-                            message = "Memory index $index is out of range (0..${before.size - 1}).",
-                            hint = "Use list to see current items and their indices.",
+                    val matches = before.mapIndexedNotNull { i, entry ->
+                        if (oldText in entry) i to entry else null
+                    }
+                    when {
+                        matches.isEmpty() -> BuiltinToolResult.failure(
+                            code = "NOT_FOUND",
+                            message = "No entry matched '$oldText'.",
+                            hint = "Check the exact text of the entry you want to remove.",
                         ).toJsonString()
-                    } else {
-                        gateway.deleteMemory(index)
-                        """{"ok":true,"action":"remove","index":$index}"""
+                        matches.size > 1 && matches.map { it.second }.distinct().size > 1 ->
+                            BuiltinToolResult.failure(
+                                code = "AMBIGUOUS_MATCH",
+                                message = "Multiple entries matched '$oldText'. Be more specific.",
+                            ).toJsonString()
+                        else -> {
+                            gateway.deleteMemory(matches.first().first)
+                            """{"ok":true,"action":"remove"}"""
+                        }
                     }
                 }
-                Action.LIST -> {
-                    val items = gateway.listMemories()
-                    val jsonItems = items.mapIndexed { i, text ->
-                        JsonObject(mapOf("index" to JsonPrimitive(i), "content" to JsonPrimitive(text)))
+                Action.REPLACE -> {
+                    val oldText = args.oldText!!
+                    val newContent = args.content!!
+                    val before = gateway.listMemories()
+                    val matches = before.mapIndexedNotNull { i, entry ->
+                        if (oldText in entry) i to entry else null
                     }
-                    JsonObject(mapOf("ok" to JsonPrimitive(true), "action" to JsonPrimitive("list"), "items" to JsonArray(jsonItems))).toString()
+                    when {
+                        matches.isEmpty() -> BuiltinToolResult.failure(
+                            code = "NOT_FOUND",
+                            message = "No entry matched '$oldText'.",
+                            hint = "Check the exact text of the entry you want to replace.",
+                        ).toJsonString()
+                        matches.size > 1 && matches.map { it.second }.distinct().size > 1 ->
+                            BuiltinToolResult.failure(
+                                code = "AMBIGUOUS_MATCH",
+                                message = "Multiple entries matched '$oldText'. Be more specific.",
+                            ).toJsonString()
+                        else -> {
+                            val idx = matches.first().first
+                            gateway.deleteMemory(idx)
+                            gateway.addMemory(newContent)
+                            """{"ok":true,"action":"replace"}"""
+                        }
+                    }
                 }
             }
         } catch (error: CancellationException) {
@@ -113,9 +146,9 @@ class MemorizeBuiltin : BuiltinTool(), RawJsonBuiltinTool {
 
         val action = Action.from(obj["action"]?.jsonPrimitive?.contentOrNull)
         val content = obj["content"]?.jsonPrimitive?.contentOrNull?.trim()
-        val index = obj["index"]?.jsonPrimitive?.intOrNull
+        val oldText = obj["old_text"]?.jsonPrimitive?.contentOrNull?.trim()
 
-        return Args(action, content, index)
+        return Args(action, content, oldText)
     }
 
     private fun validateArgs(args: Args): BuiltinToolResult? {
@@ -127,36 +160,46 @@ class MemorizeBuiltin : BuiltinTool(), RawJsonBuiltinTool {
                         message = "Field 'content' is required for add action.",
                         hint = """Example: {"action":"add","content":"User prefers concise answers."}""",
                     )
-                } else {
-                    null
-                }
+                } else null
             }
             Action.REMOVE -> {
-                if (args.index == null) {
+                if (args.oldText.isNullOrBlank()) {
                     BuiltinToolResult.failure(
                         code = "INVALID_ARGUMENTS",
-                        message = "Field 'index' is required for remove action.",
-                        hint = """Example: {"action":"remove","index":0}""",
+                        message = "Field 'old_text' is required for remove action.",
+                        hint = """Example: {"action":"remove","old_text":"User prefers"}""",
                     )
-                } else {
-                    null
+                } else null
+            }
+            Action.REPLACE -> {
+                when {
+                    args.oldText.isNullOrBlank() -> BuiltinToolResult.failure(
+                        code = "INVALID_ARGUMENTS",
+                        message = "Field 'old_text' is required for replace action.",
+                        hint = """Example: {"action":"replace","old_text":"User prefers","content":"User prefers short answers."}""",
+                    )
+                    args.content.isNullOrBlank() -> BuiltinToolResult.failure(
+                        code = "INVALID_ARGUMENTS",
+                        message = "Field 'content' is required for replace action.",
+                        hint = """Example: {"action":"replace","old_text":"User prefers","content":"User prefers short answers."}""",
+                    )
+                    else -> null
                 }
             }
-            Action.LIST -> null
         }
     }
 
     private enum class Action {
-        ADD, REMOVE, LIST;
+        ADD, REMOVE, REPLACE;
 
         companion object {
             fun from(wire: String?): Action {
                 return when (wire?.trim()?.lowercase()) {
                     "add" -> ADD
                     "remove" -> REMOVE
-                    "list" -> LIST
+                    "replace" -> REPLACE
                     else -> throw IllegalArgumentException(
-                        "Unknown action '${wire?.trim().orEmpty()}'. Expected add, remove, or list."
+                        "Unknown action '${wire?.trim().orEmpty()}'. Expected add, replace, or remove."
                     )
                 }
             }
@@ -166,7 +209,7 @@ class MemorizeBuiltin : BuiltinTool(), RawJsonBuiltinTool {
     private data class Args(
         val action: Action,
         val content: String?,
-        val index: Int?,
+        val oldText: String?,
     )
 
     companion object {
@@ -176,18 +219,19 @@ class MemorizeBuiltin : BuiltinTool(), RawJsonBuiltinTool {
               "properties": {
                 "action": {
                   "type": "string",
-                  "enum": ["add", "remove", "list"],
-                  "description": "add (save a fact), remove (delete by index), list (show all items with indices). Default: add."
+                  "enum": ["add", "replace", "remove"],
+                  "description": "The action to perform."
                 },
                 "content": {
                   "type": "string",
-                  "description": "The memory item text. Required for add."
+                  "description": "The entry content. Required for 'add' and 'replace'."
                 },
-                "index": {
-                  "type": "integer",
-                  "description": "Zero-based index of the memory to remove. Required for remove. Use list to see indices."
+                "old_text": {
+                  "type": "string",
+                  "description": "REQUIRED for 'replace' and 'remove': a short unique substring identifying the existing entry to modify. Omit only for 'add'."
                 }
-              }
+              },
+              "required": ["action"]
             }
         """
     }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/MemoryBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/MemoryBuiltin.kt
@@ -11,12 +11,10 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
-class MemorizeBuiltin : BuiltinTool(), RawJsonBuiltinTool {
+class MemoryBuiltin : BuiltinTool(), RawJsonBuiltinTool {
     override val name: String = "memory"
 
     override val description: String =
@@ -37,7 +35,7 @@ class MemorizeBuiltin : BuiltinTool(), RawJsonBuiltinTool {
 
     override fun configure(config: LocalToolConfig) {
         config.description = description
-        config.rawJsonSchema(MEMORIZE_SCHEMA)
+        config.rawJsonSchema(MEMORY_SCHEMA)
     }
 
     override suspend fun invoke(request: BuiltinToolRequest): BuiltinToolResult {
@@ -193,7 +191,7 @@ class MemorizeBuiltin : BuiltinTool(), RawJsonBuiltinTool {
     )
 
     companion object {
-        private const val MEMORIZE_SCHEMA = """
+        private const val MEMORY_SCHEMA = """
             {
               "type": "object",
               "properties": {

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/runtime/settings/MemoryMutationResult.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/runtime/settings/MemoryMutationResult.kt
@@ -1,0 +1,7 @@
+package com.niki914.nexus.agentic.runtime.settings
+
+sealed class MemoryMutationResult {
+    data object Ok : MemoryMutationResult()
+    data object NotFound : MemoryMutationResult()
+    data object Ambiguous : MemoryMutationResult()
+}

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/runtime/settings/RuntimeSettingsGateway.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/runtime/settings/RuntimeSettingsGateway.kt
@@ -33,6 +33,10 @@ interface RuntimeSettingsGateway {
 
     suspend fun addMemory(value: String)
 
+    suspend fun listMemories(): List<String> = emptyList()
+
+    suspend fun deleteMemory(index: Int)
+
     suspend fun listCustomTools(): List<RuntimeCustomTool>
 
     suspend fun saveCustomTool(

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/runtime/settings/RuntimeSettingsGateway.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/runtime/settings/RuntimeSettingsGateway.kt
@@ -33,9 +33,9 @@ interface RuntimeSettingsGateway {
 
     suspend fun addMemory(value: String)
 
-    suspend fun listMemories(): List<String> = emptyList()
+    suspend fun removeMemory(oldText: String): MemoryMutationResult
 
-    suspend fun deleteMemory(index: Int)
+    suspend fun replaceMemory(oldText: String, content: String): MemoryMutationResult
 
     suspend fun listCustomTools(): List<RuntimeCustomTool>
 

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/BuiltinToolRegistryTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/BuiltinToolRegistryTest.kt
@@ -19,7 +19,7 @@ class BuiltinToolRegistryTest {
         assertTrue(names.contains("screen_operation_accessibility"))
         assertTrue(names.contains("screen_operation_shell"))
         assertTrue(names.contains("launch_app"))
-        assertTrue(names.contains("memorize"))
+        assertTrue(names.contains("memory"))
         assertTrue(names.contains("notify"))
         assertTrue(names.contains("open_uri"))
         assertTrue(names.contains("read_custom_tool"))

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/BuiltinToolSettingsManagerTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/BuiltinToolSettingsManagerTest.kt
@@ -27,7 +27,7 @@ class BuiltinToolSettingsManagerTest {
         val items = manager.load()
 
         assertEquals(
-            listOf("create_custom_tool", "load_skill", "memorize", "notify", "read_custom_tool", "terminal"),
+            listOf("create_custom_tool", "load_skill", "memory", "notify", "read_custom_tool", "terminal"),
             items.map { it.name }.sorted()
         )
         assertTrue(items.all { it.enabled })

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/BuiltinToolTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/BuiltinToolTest.kt
@@ -72,7 +72,7 @@ class BuiltinToolTest {
                 "create_custom_tool",
                 "launch_app",
                 "load_skill",
-                "memorize",
+                "memory",
                 "notify",
                 "open_uri",
                 "read_custom_tool",
@@ -87,7 +87,7 @@ class BuiltinToolTest {
         assertEquals("create_custom_tool", registry.find("create_custom_tool")?.name)
         assertEquals("launch_app", registry.find("launch_app")?.name)
         assertEquals("load_skill", registry.find("load_skill")?.name)
-        assertEquals("memorize", registry.find("memorize")?.name)
+        assertEquals("memory", registry.find("memory")?.name)
         assertEquals("notify", registry.find("notify")?.name)
         assertEquals("open_uri", registry.find("open_uri")?.name)
         assertEquals("read_custom_tool", registry.find("read_custom_tool")?.name)

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/BuiltinToolTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/BuiltinToolTest.kt
@@ -6,7 +6,7 @@ import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinToolRequest
 import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinToolResult
 import com.niki914.nexus.agentic.chat.agentic.buildin.impl.CreateCustomToolBuiltin
 import com.niki914.nexus.agentic.chat.agentic.buildin.impl.LaunchAppBuiltin
-import com.niki914.nexus.agentic.chat.agentic.buildin.impl.MemorizeBuiltin
+import com.niki914.nexus.agentic.chat.agentic.buildin.impl.MemoryBuiltin
 import com.niki914.nexus.agentic.chat.agentic.buildin.impl.OpenUriBuiltin
 import com.niki914.nexus.agentic.chat.agentic.buildin.impl.ReadCustomToolBuiltin
 import com.niki914.nexus.agentic.chat.agentic.buildin.impl.SearchAppsBuiltin
@@ -100,10 +100,10 @@ class BuiltinToolTest {
     }
 
     @Test
-    fun memorizeAndReadCustomToolDescription_matchesConfigureDescription() {
+    fun memoryAndReadCustomToolDescription_matchesConfigureDescription() {
         listOf(
             LaunchAppBuiltin(),
-            MemorizeBuiltin(),
+            MemoryBuiltin(),
             OpenUriBuiltin(),
             ReadCustomToolBuiltin(),
             SearchAppsBuiltin(),

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/MemoryAndCustomToolBuiltinTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/MemoryAndCustomToolBuiltinTest.kt
@@ -23,7 +23,7 @@ class MemoryAndCustomToolBuiltinTest {
     }
 
     @Test
-    fun memorize_writesTrimmedMemoryAndReturnsMinimalSuccessJson() = runTest {
+    fun memorize_writesTrimmedMemoryAndReturnsSuccessJson() = runTest {
         val store = installRuntimeSettingsGatewayForTest()
 
         val resultJson = MemorizeBuiltin().invokeRawJson(
@@ -33,7 +33,9 @@ class MemoryAndCustomToolBuiltinTest {
             )
         )
 
-        assertEquals("""{"ok":true}""", resultJson)
+        val json = Json.parseToJsonElement(resultJson).jsonObject
+        assertTrue(json["ok"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("add", json["action"]!!.jsonPrimitive.content)
         assertEquals(listOf("User prefers concise answers."), store.memories)
         assertEquals(1, store.writeCount)
     }
@@ -51,8 +53,7 @@ class MemoryAndCustomToolBuiltinTest {
 
         val json = Json.parseToJsonElement(resultJson).jsonObject
         assertFalse(json["ok"]!!.jsonPrimitive.content.toBoolean())
-        assertEquals("MISSING_REQUIRED_FIELD", json["code"]!!.jsonPrimitive.content)
-        assertTrue(json["field_errors"]!!.jsonObject.containsKey("content"))
+        assertEquals("INVALID_ARGUMENTS", json["code"]!!.jsonPrimitive.content)
     }
 
     @Test

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/MemoryAndCustomToolBuiltinTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/MemoryAndCustomToolBuiltinTest.kt
@@ -174,7 +174,7 @@ class MemoryAndCustomToolBuiltinTest {
         val json = Json.parseToJsonElement(resultJson).jsonObject
         assertTrue(json["ok"]!!.jsonPrimitive.content.toBoolean())
         assertEquals("replace", json["action"]!!.jsonPrimitive.content)
-        assertEquals(listOf("keep", "also-keep", "User prefers light mode"), store.memories)
+        assertEquals(listOf("keep", "User prefers light mode", "also-keep"), store.memories)
     }
 
     @Test
@@ -228,7 +228,7 @@ class MemoryAndCustomToolBuiltinTest {
         val json = Json.parseToJsonElement(resultJson).jsonObject
         assertTrue(json["ok"]!!.jsonPrimitive.content.toBoolean())
         assertEquals("replace", json["action"]!!.jsonPrimitive.content)
-        assertEquals(listOf("same entry", "updated entry"), store.memories)
+        assertEquals(listOf("updated entry", "same entry"), store.memories)
     }
 
     @Test

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/MemoryAndCustomToolBuiltinTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/MemoryAndCustomToolBuiltinTest.kt
@@ -1,7 +1,7 @@
 package com.niki914.nexus.agentic.chat
 
 import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinToolRequest
-import com.niki914.nexus.agentic.chat.agentic.buildin.impl.MemorizeBuiltin
+import com.niki914.nexus.agentic.chat.agentic.buildin.impl.MemoryBuiltin
 import com.niki914.nexus.agentic.chat.agentic.buildin.impl.ReadCustomToolBuiltin
 import com.niki914.nexus.agentic.runtime.settings.RuntimeEnvironment
 import kotlinx.coroutines.test.runTest
@@ -23,10 +23,10 @@ class MemoryAndCustomToolBuiltinTest {
     }
 
     @Test
-    fun memorize_addWritesTrimmedMemoryAndReturnsSuccessJson() = runTest {
+    fun memory_addWritesTrimmedMemoryAndReturnsSuccessJson() = runTest {
         val store = installRuntimeSettingsGatewayForTest()
 
-        val resultJson = MemorizeBuiltin().invokeRawJson(
+        val resultJson = MemoryBuiltin().invokeRawJson(
             BuiltinToolRequest(
                 name = "memory",
                 argumentsJson = """{"action":"add","content":"  User prefers concise answers.  "}""",
@@ -41,10 +41,10 @@ class MemoryAndCustomToolBuiltinTest {
     }
 
     @Test
-    fun memorize_addReturnsStructuredErrorForBlankContent() = runTest {
+    fun memory_addReturnsStructuredErrorForBlankContent() = runTest {
         installRuntimeSettingsGatewayForTest()
 
-        val resultJson = MemorizeBuiltin().invokeRawJson(
+        val resultJson = MemoryBuiltin().invokeRawJson(
             BuiltinToolRequest(
                 name = "memory",
                 argumentsJson = """{"action":"add","content":"   "}""",
@@ -57,10 +57,10 @@ class MemoryAndCustomToolBuiltinTest {
     }
 
     @Test
-    fun memorize_missingActionReturnsError() = runTest {
+    fun memory_missingActionReturnsError() = runTest {
         installRuntimeSettingsGatewayForTest()
 
-        val resultJson = MemorizeBuiltin().invokeRawJson(
+        val resultJson = MemoryBuiltin().invokeRawJson(
             BuiltinToolRequest(
                 name = "memory",
                 argumentsJson = """{"content":"some fact"}""",
@@ -73,10 +73,10 @@ class MemoryAndCustomToolBuiltinTest {
     }
 
     @Test
-    fun memorize_unknownActionReturnsError() = runTest {
+    fun memory_unknownActionReturnsError() = runTest {
         installRuntimeSettingsGatewayForTest()
 
-        val resultJson = MemorizeBuiltin().invokeRawJson(
+        val resultJson = MemoryBuiltin().invokeRawJson(
             BuiltinToolRequest(
                 name = "memory",
                 argumentsJson = """{"action":"remvoe","content":"typo"}""",
@@ -89,10 +89,10 @@ class MemoryAndCustomToolBuiltinTest {
     }
 
     @Test
-    fun memorize_explicitAddActionWorks() = runTest {
+    fun memory_explicitAddActionWorks() = runTest {
         val store = installRuntimeSettingsGatewayForTest()
 
-        val resultJson = MemorizeBuiltin().invokeRawJson(
+        val resultJson = MemoryBuiltin().invokeRawJson(
             BuiltinToolRequest(
                 name = "memory",
                 argumentsJson = """{"action":"add","content":"explicit add"}""",
@@ -106,11 +106,11 @@ class MemoryAndCustomToolBuiltinTest {
     }
 
     @Test
-    fun memorize_removeDeletesByOldText() = runTest {
+    fun memory_removeDeletesByOldText() = runTest {
         val store = installRuntimeSettingsGatewayForTest()
         store.memories.addAll(listOf("keep", "delete-me-please", "also-keep"))
 
-        val resultJson = MemorizeBuiltin().invokeRawJson(
+        val resultJson = MemoryBuiltin().invokeRawJson(
             BuiltinToolRequest(
                 name = "memory",
                 argumentsJson = """{"action":"remove","old_text":"delete-me"}""",
@@ -124,11 +124,11 @@ class MemoryAndCustomToolBuiltinTest {
     }
 
     @Test
-    fun memorize_removeReturnsErrorForNotFound() = runTest {
+    fun memory_removeReturnsErrorForNotFound() = runTest {
         val store = installRuntimeSettingsGatewayForTest()
         store.memories.add("only")
 
-        val resultJson = MemorizeBuiltin().invokeRawJson(
+        val resultJson = MemoryBuiltin().invokeRawJson(
             BuiltinToolRequest(
                 name = "memory",
                 argumentsJson = """{"action":"remove","old_text":"nonexistent"}""",
@@ -142,11 +142,11 @@ class MemoryAndCustomToolBuiltinTest {
     }
 
     @Test
-    fun memorize_removeReturnsErrorForAmbiguousMatch() = runTest {
+    fun memory_removeReturnsErrorForAmbiguousMatch() = runTest {
         val store = installRuntimeSettingsGatewayForTest()
         store.memories.addAll(listOf("User prefers dark mode", "User prefers concise answers"))
 
-        val resultJson = MemorizeBuiltin().invokeRawJson(
+        val resultJson = MemoryBuiltin().invokeRawJson(
             BuiltinToolRequest(
                 name = "memory",
                 argumentsJson = """{"action":"remove","old_text":"User prefers"}""",
@@ -160,11 +160,11 @@ class MemoryAndCustomToolBuiltinTest {
     }
 
     @Test
-    fun memorize_replaceUpdatesEntry() = runTest {
+    fun memory_replaceUpdatesEntry() = runTest {
         val store = installRuntimeSettingsGatewayForTest()
         store.memories.addAll(listOf("keep", "User prefers dark mode", "also-keep"))
 
-        val resultJson = MemorizeBuiltin().invokeRawJson(
+        val resultJson = MemoryBuiltin().invokeRawJson(
             BuiltinToolRequest(
                 name = "memory",
                 argumentsJson = """{"action":"replace","old_text":"dark mode","content":"User prefers light mode"}""",
@@ -178,11 +178,11 @@ class MemoryAndCustomToolBuiltinTest {
     }
 
     @Test
-    fun memorize_replaceReturnsErrorForNotFound() = runTest {
+    fun memory_replaceReturnsErrorForNotFound() = runTest {
         val store = installRuntimeSettingsGatewayForTest()
         store.memories.add("only")
 
-        val resultJson = MemorizeBuiltin().invokeRawJson(
+        val resultJson = MemoryBuiltin().invokeRawJson(
             BuiltinToolRequest(
                 name = "memory",
                 argumentsJson = """{"action":"replace","old_text":"nonexistent","content":"new"}""",
@@ -196,11 +196,11 @@ class MemoryAndCustomToolBuiltinTest {
     }
 
     @Test
-    fun memorize_replaceReturnsErrorForAmbiguousMatch() = runTest {
+    fun memory_replaceReturnsErrorForAmbiguousMatch() = runTest {
         val store = installRuntimeSettingsGatewayForTest()
         store.memories.addAll(listOf("User prefers dark mode", "User prefers concise answers"))
 
-        val resultJson = MemorizeBuiltin().invokeRawJson(
+        val resultJson = MemoryBuiltin().invokeRawJson(
             BuiltinToolRequest(
                 name = "memory",
                 argumentsJson = """{"action":"replace","old_text":"User prefers","content":"new pref"}""",
@@ -214,11 +214,11 @@ class MemoryAndCustomToolBuiltinTest {
     }
 
     @Test
-    fun memorize_replaceAllowsDuplicateMatchWhenIdenticalContent() = runTest {
+    fun memory_replaceAllowsDuplicateMatchWhenIdenticalContent() = runTest {
         val store = installRuntimeSettingsGatewayForTest()
         store.memories.addAll(listOf("same entry", "same entry"))
 
-        val resultJson = MemorizeBuiltin().invokeRawJson(
+        val resultJson = MemoryBuiltin().invokeRawJson(
             BuiltinToolRequest(
                 name = "memory",
                 argumentsJson = """{"action":"replace","old_text":"same entry","content":"updated entry"}""",

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/MemoryAndCustomToolBuiltinTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/MemoryAndCustomToolBuiltinTest.kt
@@ -28,7 +28,7 @@ class MemoryAndCustomToolBuiltinTest {
 
         val resultJson = MemorizeBuiltin().invokeRawJson(
             BuiltinToolRequest(
-                name = "memorize",
+                name = "memory",
                 argumentsJson = """{"action":"add","content":"  User prefers concise answers.  "}""",
             )
         )
@@ -46,7 +46,7 @@ class MemoryAndCustomToolBuiltinTest {
 
         val resultJson = MemorizeBuiltin().invokeRawJson(
             BuiltinToolRequest(
-                name = "memorize",
+                name = "memory",
                 argumentsJson = """{"action":"add","content":"   "}""",
             )
         )
@@ -62,7 +62,7 @@ class MemoryAndCustomToolBuiltinTest {
 
         val resultJson = MemorizeBuiltin().invokeRawJson(
             BuiltinToolRequest(
-                name = "memorize",
+                name = "memory",
                 argumentsJson = """{"content":"some fact"}""",
             )
         )
@@ -78,7 +78,7 @@ class MemoryAndCustomToolBuiltinTest {
 
         val resultJson = MemorizeBuiltin().invokeRawJson(
             BuiltinToolRequest(
-                name = "memorize",
+                name = "memory",
                 argumentsJson = """{"action":"remvoe","content":"typo"}""",
             )
         )
@@ -94,7 +94,7 @@ class MemoryAndCustomToolBuiltinTest {
 
         val resultJson = MemorizeBuiltin().invokeRawJson(
             BuiltinToolRequest(
-                name = "memorize",
+                name = "memory",
                 argumentsJson = """{"action":"add","content":"explicit add"}""",
             )
         )
@@ -112,7 +112,7 @@ class MemoryAndCustomToolBuiltinTest {
 
         val resultJson = MemorizeBuiltin().invokeRawJson(
             BuiltinToolRequest(
-                name = "memorize",
+                name = "memory",
                 argumentsJson = """{"action":"remove","old_text":"delete-me"}""",
             )
         )
@@ -130,7 +130,7 @@ class MemoryAndCustomToolBuiltinTest {
 
         val resultJson = MemorizeBuiltin().invokeRawJson(
             BuiltinToolRequest(
-                name = "memorize",
+                name = "memory",
                 argumentsJson = """{"action":"remove","old_text":"nonexistent"}""",
             )
         )
@@ -148,7 +148,7 @@ class MemoryAndCustomToolBuiltinTest {
 
         val resultJson = MemorizeBuiltin().invokeRawJson(
             BuiltinToolRequest(
-                name = "memorize",
+                name = "memory",
                 argumentsJson = """{"action":"remove","old_text":"User prefers"}""",
             )
         )
@@ -166,7 +166,7 @@ class MemoryAndCustomToolBuiltinTest {
 
         val resultJson = MemorizeBuiltin().invokeRawJson(
             BuiltinToolRequest(
-                name = "memorize",
+                name = "memory",
                 argumentsJson = """{"action":"replace","old_text":"dark mode","content":"User prefers light mode"}""",
             )
         )
@@ -184,7 +184,7 @@ class MemoryAndCustomToolBuiltinTest {
 
         val resultJson = MemorizeBuiltin().invokeRawJson(
             BuiltinToolRequest(
-                name = "memorize",
+                name = "memory",
                 argumentsJson = """{"action":"replace","old_text":"nonexistent","content":"new"}""",
             )
         )
@@ -202,7 +202,7 @@ class MemoryAndCustomToolBuiltinTest {
 
         val resultJson = MemorizeBuiltin().invokeRawJson(
             BuiltinToolRequest(
-                name = "memorize",
+                name = "memory",
                 argumentsJson = """{"action":"replace","old_text":"User prefers","content":"new pref"}""",
             )
         )
@@ -220,7 +220,7 @@ class MemoryAndCustomToolBuiltinTest {
 
         val resultJson = MemorizeBuiltin().invokeRawJson(
             BuiltinToolRequest(
-                name = "memorize",
+                name = "memory",
                 argumentsJson = """{"action":"replace","old_text":"same entry","content":"updated entry"}""",
             )
         )

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/MemoryAndCustomToolBuiltinTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/MemoryAndCustomToolBuiltinTest.kt
@@ -23,7 +23,7 @@ class MemoryAndCustomToolBuiltinTest {
     }
 
     @Test
-    fun memorize_writesTrimmedMemoryAndReturnsSuccessJson() = runTest {
+    fun memorize_addWritesTrimmedMemoryAndReturnsSuccessJson() = runTest {
         val store = installRuntimeSettingsGatewayForTest()
 
         val resultJson = MemorizeBuiltin().invokeRawJson(
@@ -41,7 +41,7 @@ class MemoryAndCustomToolBuiltinTest {
     }
 
     @Test
-    fun memorize_returnsStructuredErrorForBlankContent() = runTest {
+    fun memorize_addReturnsStructuredErrorForBlankContent() = runTest {
         installRuntimeSettingsGatewayForTest()
 
         val resultJson = MemorizeBuiltin().invokeRawJson(
@@ -70,66 +70,6 @@ class MemoryAndCustomToolBuiltinTest {
         val json = Json.parseToJsonElement(resultJson).jsonObject
         assertFalse(json["ok"]!!.jsonPrimitive.content.toBoolean())
         assertEquals("INVALID_ARGUMENTS", json["code"]!!.jsonPrimitive.content)
-    }
-
-    @Test
-    fun memorize_listReturnsItemsAsJsonArray() = runTest {
-        val store = installRuntimeSettingsGatewayForTest()
-        store.memories.addAll(listOf("first", "second"))
-
-        val resultJson = MemorizeBuiltin().invokeRawJson(
-            BuiltinToolRequest(
-                name = "memorize",
-                argumentsJson = """{"action":"list"}""",
-            )
-        )
-
-        val json = Json.parseToJsonElement(resultJson).jsonObject
-        assertTrue(json["ok"]!!.jsonPrimitive.content.toBoolean())
-        assertEquals("list", json["action"]!!.jsonPrimitive.content)
-        val items = json["items"]!!.jsonArray
-        assertEquals(2, items.size)
-        assertEquals(0, items[0].jsonObject["index"]!!.jsonPrimitive.content.toInt())
-        assertEquals("first", items[0].jsonObject["content"]!!.jsonPrimitive.content)
-        assertEquals(1, items[1].jsonObject["index"]!!.jsonPrimitive.content.toInt())
-        assertEquals("second", items[1].jsonObject["content"]!!.jsonPrimitive.content)
-    }
-
-    @Test
-    fun memorize_removeDeletesByIndex() = runTest {
-        val store = installRuntimeSettingsGatewayForTest()
-        store.memories.addAll(listOf("keep", "delete-me", "also-keep"))
-
-        val resultJson = MemorizeBuiltin().invokeRawJson(
-            BuiltinToolRequest(
-                name = "memorize",
-                argumentsJson = """{"action":"remove","index":1}""",
-            )
-        )
-
-        val json = Json.parseToJsonElement(resultJson).jsonObject
-        assertTrue(json["ok"]!!.jsonPrimitive.content.toBoolean())
-        assertEquals("remove", json["action"]!!.jsonPrimitive.content)
-        assertEquals(1, json["index"]!!.jsonPrimitive.content.toInt())
-        assertEquals(listOf("keep", "also-keep"), store.memories)
-    }
-
-    @Test
-    fun memorize_removeReturnsErrorForOutOfRangeIndex() = runTest {
-        val store = installRuntimeSettingsGatewayForTest()
-        store.memories.add("only")
-
-        val resultJson = MemorizeBuiltin().invokeRawJson(
-            BuiltinToolRequest(
-                name = "memorize",
-                argumentsJson = """{"action":"remove","index":5}""",
-            )
-        )
-
-        val json = Json.parseToJsonElement(resultJson).jsonObject
-        assertFalse(json["ok"]!!.jsonPrimitive.content.toBoolean())
-        assertEquals("INDEX_OUT_OF_RANGE", json["code"]!!.jsonPrimitive.content)
-        assertEquals(listOf("only"), store.memories)
     }
 
     @Test
@@ -163,6 +103,132 @@ class MemoryAndCustomToolBuiltinTest {
         assertTrue(json["ok"]!!.jsonPrimitive.content.toBoolean())
         assertEquals("add", json["action"]!!.jsonPrimitive.content)
         assertEquals(listOf("explicit add"), store.memories)
+    }
+
+    @Test
+    fun memorize_removeDeletesByOldText() = runTest {
+        val store = installRuntimeSettingsGatewayForTest()
+        store.memories.addAll(listOf("keep", "delete-me-please", "also-keep"))
+
+        val resultJson = MemorizeBuiltin().invokeRawJson(
+            BuiltinToolRequest(
+                name = "memorize",
+                argumentsJson = """{"action":"remove","old_text":"delete-me"}""",
+            )
+        )
+
+        val json = Json.parseToJsonElement(resultJson).jsonObject
+        assertTrue(json["ok"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("remove", json["action"]!!.jsonPrimitive.content)
+        assertEquals(listOf("keep", "also-keep"), store.memories)
+    }
+
+    @Test
+    fun memorize_removeReturnsErrorForNotFound() = runTest {
+        val store = installRuntimeSettingsGatewayForTest()
+        store.memories.add("only")
+
+        val resultJson = MemorizeBuiltin().invokeRawJson(
+            BuiltinToolRequest(
+                name = "memorize",
+                argumentsJson = """{"action":"remove","old_text":"nonexistent"}""",
+            )
+        )
+
+        val json = Json.parseToJsonElement(resultJson).jsonObject
+        assertFalse(json["ok"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("NOT_FOUND", json["code"]!!.jsonPrimitive.content)
+        assertEquals(listOf("only"), store.memories)
+    }
+
+    @Test
+    fun memorize_removeReturnsErrorForAmbiguousMatch() = runTest {
+        val store = installRuntimeSettingsGatewayForTest()
+        store.memories.addAll(listOf("User prefers dark mode", "User prefers concise answers"))
+
+        val resultJson = MemorizeBuiltin().invokeRawJson(
+            BuiltinToolRequest(
+                name = "memorize",
+                argumentsJson = """{"action":"remove","old_text":"User prefers"}""",
+            )
+        )
+
+        val json = Json.parseToJsonElement(resultJson).jsonObject
+        assertFalse(json["ok"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("AMBIGUOUS_MATCH", json["code"]!!.jsonPrimitive.content)
+        assertEquals(2, store.memories.size)
+    }
+
+    @Test
+    fun memorize_replaceUpdatesEntry() = runTest {
+        val store = installRuntimeSettingsGatewayForTest()
+        store.memories.addAll(listOf("keep", "User prefers dark mode", "also-keep"))
+
+        val resultJson = MemorizeBuiltin().invokeRawJson(
+            BuiltinToolRequest(
+                name = "memorize",
+                argumentsJson = """{"action":"replace","old_text":"dark mode","content":"User prefers light mode"}""",
+            )
+        )
+
+        val json = Json.parseToJsonElement(resultJson).jsonObject
+        assertTrue(json["ok"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("replace", json["action"]!!.jsonPrimitive.content)
+        assertEquals(listOf("keep", "also-keep", "User prefers light mode"), store.memories)
+    }
+
+    @Test
+    fun memorize_replaceReturnsErrorForNotFound() = runTest {
+        val store = installRuntimeSettingsGatewayForTest()
+        store.memories.add("only")
+
+        val resultJson = MemorizeBuiltin().invokeRawJson(
+            BuiltinToolRequest(
+                name = "memorize",
+                argumentsJson = """{"action":"replace","old_text":"nonexistent","content":"new"}""",
+            )
+        )
+
+        val json = Json.parseToJsonElement(resultJson).jsonObject
+        assertFalse(json["ok"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("NOT_FOUND", json["code"]!!.jsonPrimitive.content)
+        assertEquals(listOf("only"), store.memories)
+    }
+
+    @Test
+    fun memorize_replaceReturnsErrorForAmbiguousMatch() = runTest {
+        val store = installRuntimeSettingsGatewayForTest()
+        store.memories.addAll(listOf("User prefers dark mode", "User prefers concise answers"))
+
+        val resultJson = MemorizeBuiltin().invokeRawJson(
+            BuiltinToolRequest(
+                name = "memorize",
+                argumentsJson = """{"action":"replace","old_text":"User prefers","content":"new pref"}""",
+            )
+        )
+
+        val json = Json.parseToJsonElement(resultJson).jsonObject
+        assertFalse(json["ok"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("AMBIGUOUS_MATCH", json["code"]!!.jsonPrimitive.content)
+        assertEquals(2, store.memories.size)
+    }
+
+    @Test
+    fun memorize_replaceAllowsDuplicateMatchWhenIdenticalContent() = runTest {
+        val store = installRuntimeSettingsGatewayForTest()
+        store.memories.addAll(listOf("same entry", "same entry"))
+
+        val resultJson = MemorizeBuiltin().invokeRawJson(
+            BuiltinToolRequest(
+                name = "memorize",
+                argumentsJson = """{"action":"replace","old_text":"same entry","content":"updated entry"}""",
+            )
+        )
+
+        val json = Json.parseToJsonElement(resultJson).jsonObject
+        assertTrue(json["ok"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("replace", json["action"]!!.jsonPrimitive.content)
+        assertEquals(listOf("same entry", "updated entry"), store.memories)
     }
 
     @Test

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/MemoryAndCustomToolBuiltinTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/MemoryAndCustomToolBuiltinTest.kt
@@ -29,7 +29,7 @@ class MemoryAndCustomToolBuiltinTest {
         val resultJson = MemorizeBuiltin().invokeRawJson(
             BuiltinToolRequest(
                 name = "memorize",
-                argumentsJson = """{"content":"  User prefers concise answers.  "}""",
+                argumentsJson = """{"action":"add","content":"  User prefers concise answers.  "}""",
             )
         )
 
@@ -47,7 +47,23 @@ class MemoryAndCustomToolBuiltinTest {
         val resultJson = MemorizeBuiltin().invokeRawJson(
             BuiltinToolRequest(
                 name = "memorize",
-                argumentsJson = """{"content":"   "}""",
+                argumentsJson = """{"action":"add","content":"   "}""",
+            )
+        )
+
+        val json = Json.parseToJsonElement(resultJson).jsonObject
+        assertFalse(json["ok"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("INVALID_ARGUMENTS", json["code"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun memorize_missingActionReturnsError() = runTest {
+        installRuntimeSettingsGatewayForTest()
+
+        val resultJson = MemorizeBuiltin().invokeRawJson(
+            BuiltinToolRequest(
+                name = "memorize",
+                argumentsJson = """{"content":"some fact"}""",
             )
         )
 

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/MemoryAndCustomToolBuiltinTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/MemoryAndCustomToolBuiltinTest.kt
@@ -57,6 +57,99 @@ class MemoryAndCustomToolBuiltinTest {
     }
 
     @Test
+    fun memorize_listReturnsItemsAsJsonArray() = runTest {
+        val store = installRuntimeSettingsGatewayForTest()
+        store.memories.addAll(listOf("first", "second"))
+
+        val resultJson = MemorizeBuiltin().invokeRawJson(
+            BuiltinToolRequest(
+                name = "memorize",
+                argumentsJson = """{"action":"list"}""",
+            )
+        )
+
+        val json = Json.parseToJsonElement(resultJson).jsonObject
+        assertTrue(json["ok"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("list", json["action"]!!.jsonPrimitive.content)
+        val items = json["items"]!!.jsonArray
+        assertEquals(2, items.size)
+        assertEquals(0, items[0].jsonObject["index"]!!.jsonPrimitive.content.toInt())
+        assertEquals("first", items[0].jsonObject["content"]!!.jsonPrimitive.content)
+        assertEquals(1, items[1].jsonObject["index"]!!.jsonPrimitive.content.toInt())
+        assertEquals("second", items[1].jsonObject["content"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun memorize_removeDeletesByIndex() = runTest {
+        val store = installRuntimeSettingsGatewayForTest()
+        store.memories.addAll(listOf("keep", "delete-me", "also-keep"))
+
+        val resultJson = MemorizeBuiltin().invokeRawJson(
+            BuiltinToolRequest(
+                name = "memorize",
+                argumentsJson = """{"action":"remove","index":1}""",
+            )
+        )
+
+        val json = Json.parseToJsonElement(resultJson).jsonObject
+        assertTrue(json["ok"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("remove", json["action"]!!.jsonPrimitive.content)
+        assertEquals(1, json["index"]!!.jsonPrimitive.content.toInt())
+        assertEquals(listOf("keep", "also-keep"), store.memories)
+    }
+
+    @Test
+    fun memorize_removeReturnsErrorForOutOfRangeIndex() = runTest {
+        val store = installRuntimeSettingsGatewayForTest()
+        store.memories.add("only")
+
+        val resultJson = MemorizeBuiltin().invokeRawJson(
+            BuiltinToolRequest(
+                name = "memorize",
+                argumentsJson = """{"action":"remove","index":5}""",
+            )
+        )
+
+        val json = Json.parseToJsonElement(resultJson).jsonObject
+        assertFalse(json["ok"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("INDEX_OUT_OF_RANGE", json["code"]!!.jsonPrimitive.content)
+        assertEquals(listOf("only"), store.memories)
+    }
+
+    @Test
+    fun memorize_unknownActionReturnsError() = runTest {
+        installRuntimeSettingsGatewayForTest()
+
+        val resultJson = MemorizeBuiltin().invokeRawJson(
+            BuiltinToolRequest(
+                name = "memorize",
+                argumentsJson = """{"action":"remvoe","content":"typo"}""",
+            )
+        )
+
+        val json = Json.parseToJsonElement(resultJson).jsonObject
+        assertFalse(json["ok"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("INVALID_ARGUMENTS", json["code"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun memorize_explicitAddActionWorks() = runTest {
+        val store = installRuntimeSettingsGatewayForTest()
+
+        val resultJson = MemorizeBuiltin().invokeRawJson(
+            BuiltinToolRequest(
+                name = "memorize",
+                argumentsJson = """{"action":"add","content":"explicit add"}""",
+            )
+        )
+
+        val json = Json.parseToJsonElement(resultJson).jsonObject
+        assertTrue(json["ok"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("add", json["action"]!!.jsonPrimitive.content)
+        assertEquals(listOf("explicit add"), store.memories)
+    }
+
+    @Test
     fun readCustomTool_returnsAllCustomToolImplementationsWhenNameIsOmitted() = runTest {
         installRuntimeSettingsGatewayForTest(
             FakeRuntimeSettingsGateway(

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/PromptComposerTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/PromptComposerTest.kt
@@ -318,9 +318,9 @@ class PromptComposerTest {
                 tools = ResolvedTools(
                     builtinTools = listOf(
                         LocalTool.Builtin(
-                            name = "memorize",
+                            name = "memory",
                             description = "Add to persistent memory",
-                            tool = FakeBuiltinTool(name = "memorize"),
+                            tool = FakeBuiltinTool(name = "memory"),
                         )
                     )
                 ),

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/PromptComposerTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/PromptComposerTest.kt
@@ -20,7 +20,7 @@ import org.junit.Test
 
 class PromptComposerTest {
 
-    // --- Tier structure ---
+    // --- Identity slot (stable tier) ---
 
     @Test
     fun compose_stableTierAlwaysContainsIdentity() {
@@ -32,22 +32,24 @@ class PromptComposerTest {
     }
 
     @Test
-    fun compose_contextTierRendersWhenInstructionsPresent() {
-        val result = PromptComposer().compose(
-            PromptComposerInput(additionalInstructions = "Custom context instructions.")
-        )
-
-        assertTrue(result.finalSystemPrompt.contains("## Additional instructions"))
-        assertTrue(result.finalSystemPrompt.contains("Custom context instructions."))
-    }
-
-    @Test
-    fun compose_contextTierOmittedWhenInstructionsBlank() {
+    fun compose_emptyAdditionalInstructionsUsesDefaultIdentity() {
         val result = PromptComposer().compose(
             PromptComposerInput(additionalInstructions = " ")
         )
 
-        assertFalse(result.finalSystemPrompt.contains("## Additional instructions"))
+        assertTrue(result.finalSystemPrompt.contains(PromptComposer.DEFAULT_AGENT_IDENTITY))
+        assertTrue(result.finalSystemPrompt.startsWith(PromptComposer.DEFAULT_AGENT_IDENTITY))
+    }
+
+    @Test
+    fun compose_additionalInstructionsReplacesDefaultIdentity() {
+        val customIdentity = "You are a custom test assistant."
+        val result = PromptComposer().compose(
+            PromptComposerInput(additionalInstructions = customIdentity)
+        )
+
+        assertFalse(result.finalSystemPrompt.contains(PromptComposer.DEFAULT_AGENT_IDENTITY))
+        assertTrue(result.finalSystemPrompt.startsWith(customIdentity))
     }
 
     @Test
@@ -59,12 +61,10 @@ class PromptComposerTest {
             )
         )
 
-        val stableIdx = result.finalSystemPrompt.indexOf(PromptComposer.DEFAULT_AGENT_IDENTITY)
-        val contextIdx = result.finalSystemPrompt.indexOf("## Additional instructions")
+        val stableIdx = result.finalSystemPrompt.indexOf("ctx")
         val volatileIdx = result.finalSystemPrompt.indexOf("## Agent Memory")
 
-        assertTrue(stableIdx < contextIdx)
-        assertTrue(contextIdx < volatileIdx)
+        assertTrue(stableIdx < volatileIdx)
     }
 
     // --- Memory section (volatile tier) ---

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/PromptComposerTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/PromptComposerTest.kt
@@ -62,7 +62,7 @@ class PromptComposerTest {
         )
 
         val stableIdx = result.finalSystemPrompt.indexOf("ctx")
-        val volatileIdx = result.finalSystemPrompt.indexOf("## Agent Memory")
+        val volatileIdx = result.finalSystemPrompt.indexOf("═══")
 
         assertTrue(stableIdx < volatileIdx)
     }
@@ -78,12 +78,12 @@ class PromptComposerTest {
             )
         )
 
-        assertFalse(result.finalSystemPrompt.contains("## Agent Memory"))
-        assertFalse(result.finalSystemPrompt.contains("<memory>"))
+        assertFalse(result.finalSystemPrompt.contains("═══"))
     }
 
     @Test
-    fun compose_wrapsMemoryItemsInSingleXmlBlock() {
+    fun compose_rendersMemoryItemsInHermesBlockFormat() {
+        val sep = "═".repeat(46)
         val result = PromptComposer().compose(
             PromptComposerInput(
                 additionalInstructions = "base",
@@ -91,8 +91,8 @@ class PromptComposerTest {
             )
         )
 
-        assertTrue(result.finalSystemPrompt.contains("## Agent Memory"))
-        assertTrue(result.finalSystemPrompt.contains("<memory>\n- A\n- B\n</memory>"))
+        assertTrue(result.finalSystemPrompt.contains("$sep\nMEMORY\n$sep"))
+        assertTrue(result.finalSystemPrompt.contains("A\n§\nB"))
     }
 
     // --- Tool context (stable tier) ---

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/RuntimeSettingsTestFakes.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/RuntimeSettingsTestFakes.kt
@@ -221,7 +221,7 @@ private fun defaultBuiltinToolSettings(): List<RuntimeBuiltinToolSetting> {
     return listOf(
         RuntimeBuiltinToolSetting("create_custom_tool", "Create custom tools.", enabled = true),
         RuntimeBuiltinToolSetting("load_skill", "Load a skill by id.", enabled = true),
-        RuntimeBuiltinToolSetting("memorize", "Add a memory item.", enabled = true),
+        RuntimeBuiltinToolSetting("memory", "Add a memory item.", enabled = true),
         RuntimeBuiltinToolSetting("notify", "Post host notifications.", enabled = true),
         RuntimeBuiltinToolSetting(
             "read_custom_tool",

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/RuntimeSettingsTestFakes.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/RuntimeSettingsTestFakes.kt
@@ -1,5 +1,6 @@
 package com.niki914.nexus.agentic.chat
 
+import com.niki914.nexus.agentic.runtime.settings.MemoryMutationResult
 import com.niki914.nexus.agentic.runtime.settings.RuntimeBridge
 import com.niki914.nexus.agentic.runtime.settings.RuntimeEnvironment
 import com.niki914.nexus.agentic.runtime.settings.RuntimeHostGateway
@@ -101,12 +102,35 @@ internal class FakeRuntimeSettingsGateway(
         memories.add(normalized)
     }
 
-    override suspend fun listMemories(): List<String> = memories.toList()
+    override suspend fun removeMemory(oldText: String): MemoryMutationResult {
+        val matches = memories.mapIndexedNotNull { i, entry ->
+            if (oldText in entry) i to entry else null
+        }
+        return when {
+            matches.isEmpty() -> MemoryMutationResult.NotFound
+            matches.size > 1 && matches.map { it.second }.distinct().size > 1 ->
+                MemoryMutationResult.Ambiguous
+            else -> {
+                recordWrite()
+                memories.removeAt(matches.first().first)
+                MemoryMutationResult.Ok
+            }
+        }
+    }
 
-    override suspend fun deleteMemory(index: Int) {
-        if (index in memories.indices) {
-            recordWrite()
-            memories.removeAt(index)
+    override suspend fun replaceMemory(oldText: String, content: String): MemoryMutationResult {
+        val matches = memories.mapIndexedNotNull { i, entry ->
+            if (oldText in entry) i to entry else null
+        }
+        return when {
+            matches.isEmpty() -> MemoryMutationResult.NotFound
+            matches.size > 1 && matches.map { it.second }.distinct().size > 1 ->
+                MemoryMutationResult.Ambiguous
+            else -> {
+                recordWrite()
+                memories[matches.first().first] = content
+                MemoryMutationResult.Ok
+            }
         }
     }
 

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/RuntimeSettingsTestFakes.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/RuntimeSettingsTestFakes.kt
@@ -101,6 +101,15 @@ internal class FakeRuntimeSettingsGateway(
         memories.add(normalized)
     }
 
+    override suspend fun listMemories(): List<String> = memories.toList()
+
+    override suspend fun deleteMemory(index: Int) {
+        if (index in memories.indices) {
+            recordWrite()
+            memories.removeAt(index)
+        }
+    }
+
     override suspend fun listCustomTools(): List<RuntimeCustomTool> = customTools.toList()
 
     override suspend fun saveCustomTool(

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/runtime/settings/RuntimeEnvironmentTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/runtime/settings/RuntimeEnvironmentTest.kt
@@ -94,6 +94,8 @@ private class FakeRuntimeSettingsGateway : RuntimeSettingsGateway {
 
     override suspend fun addMemory(value: String) = Unit
 
+    override suspend fun deleteMemory(index: Int) = Unit
+
     override suspend fun listCustomTools(): List<RuntimeCustomTool> = emptyList()
 
     override suspend fun saveCustomTool(

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/runtime/settings/RuntimeEnvironmentTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/runtime/settings/RuntimeEnvironmentTest.kt
@@ -1,5 +1,6 @@
 package com.niki914.nexus.agentic.runtime.settings
 
+import com.niki914.nexus.agentic.runtime.settings.MemoryMutationResult
 import com.niki914.nexus.agentic.runtime.settings.model.RuntimeBuiltinToolSetting
 import com.niki914.nexus.agentic.runtime.settings.model.RuntimeCustomTool
 import com.niki914.nexus.agentic.runtime.settings.model.RuntimeCustomToolValidation
@@ -94,7 +95,11 @@ private class FakeRuntimeSettingsGateway : RuntimeSettingsGateway {
 
     override suspend fun addMemory(value: String) = Unit
 
-    override suspend fun deleteMemory(index: Int) = Unit
+    override suspend fun removeMemory(oldText: String): MemoryMutationResult =
+        MemoryMutationResult.Ok
+
+    override suspend fun replaceMemory(oldText: String, content: String): MemoryMutationResult =
+        MemoryMutationResult.Ok
 
     override suspend fun listCustomTools(): List<RuntimeCustomTool> = emptyList()
 

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/runtime/settings/RuntimeSettingsGatewaySkillContractTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/runtime/settings/RuntimeSettingsGatewaySkillContractTest.kt
@@ -43,6 +43,8 @@ private class MinimalRuntimeSettingsGateway : RuntimeSettingsGateway {
 
     override suspend fun addMemory(value: String) = Unit
 
+    override suspend fun deleteMemory(index: Int) = Unit
+
     override suspend fun listCustomTools(): List<RuntimeCustomTool> = emptyList()
 
     override suspend fun saveCustomTool(

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/runtime/settings/RuntimeSettingsGatewaySkillContractTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/runtime/settings/RuntimeSettingsGatewaySkillContractTest.kt
@@ -1,5 +1,6 @@
 package com.niki914.nexus.agentic.runtime.settings
 
+import com.niki914.nexus.agentic.runtime.settings.MemoryMutationResult
 import com.niki914.nexus.agentic.runtime.settings.model.RuntimeBuiltinToolSetting
 import com.niki914.nexus.agentic.runtime.settings.model.RuntimeCustomTool
 import com.niki914.nexus.agentic.runtime.settings.model.RuntimeCustomToolValidation
@@ -43,7 +44,11 @@ private class MinimalRuntimeSettingsGateway : RuntimeSettingsGateway {
 
     override suspend fun addMemory(value: String) = Unit
 
-    override suspend fun deleteMemory(index: Int) = Unit
+    override suspend fun removeMemory(oldText: String): MemoryMutationResult =
+        MemoryMutationResult.Ok
+
+    override suspend fun replaceMemory(oldText: String, content: String): MemoryMutationResult =
+        MemoryMutationResult.Ok
 
     override suspend fun listCustomTools(): List<RuntimeCustomTool> = emptyList()
 

--- a/app/src/main/java/com/niki914/nexus/agentic/repo/XRepo.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/repo/XRepo.kt
@@ -10,6 +10,7 @@ import com.niki914.nexus.store.StoreDescriptorRegistry
 import com.niki914.nexus.xposed.api.util.ContextProvider
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import com.niki914.nexus.agentic.runtime.settings.MemoryMutationResult
 import com.niki914.nexus.agentic.runtime.settings.model.RuntimeAgentMemoryMode as AgentMemoryMode
 import com.niki914.nexus.agentic.runtime.settings.model.RuntimeAgentProfile as AgentProfile
 import com.niki914.nexus.agentic.runtime.settings.model.RuntimeAgentValidation as AgentValidation
@@ -363,25 +364,23 @@ class MemoryApi internal constructor(
 
     suspend fun add(value: String) {
         val normalizedValue = value.trim()
-        if (normalizedValue.isBlank()) {
-            return
+        if (normalizedValue.isBlank()) return
+        repo.updateJsonOrFalse(StoreDescriptorRegistry.AGENT_MAIN_MEMORY_ID) { json ->
+            val current = MemorySettingsCodec.parseMemories(json)
+            if (normalizedValue in current) return@updateJsonOrFalse null
+            MemorySettingsCodec.encodeMemories(current + normalizedValue, System.currentTimeMillis())
         }
-        writeMemories(list() + normalizedValue)
     }
 
     suspend fun update(index: Int, value: String) {
         val normalizedValue = value.trim()
         repo.updateJsonOrFalse(StoreDescriptorRegistry.AGENT_MAIN_MEMORY_ID) { json ->
-            val currentMemories = MemorySettingsCodec.parseMemories(json)
-            if (index !in currentMemories.indices) {
-                return@updateJsonOrFalse null
-            }
+            val current = MemorySettingsCodec.parseMemories(json)
+            if (index !in current.indices) return@updateJsonOrFalse null
             val updated = if (normalizedValue.isBlank()) {
-                currentMemories.filterIndexed { itemIndex, _ -> itemIndex != index }
+                current.filterIndexed { i, _ -> i != index }
             } else {
-                currentMemories.mapIndexed { itemIndex, item ->
-                    if (itemIndex == index) normalizedValue else item
-                }
+                current.mapIndexed { i, item -> if (i == index) normalizedValue else item }
             }
             MemorySettingsCodec.encodeMemories(updated, System.currentTimeMillis())
         }
@@ -389,16 +388,86 @@ class MemoryApi internal constructor(
 
     suspend fun delete(index: Int) {
         repo.updateJsonOrFalse(StoreDescriptorRegistry.AGENT_MAIN_MEMORY_ID) { json ->
-            val currentMemories = MemorySettingsCodec.parseMemories(json)
-            if (index !in currentMemories.indices) {
-                return@updateJsonOrFalse null
-            }
+            val current = MemorySettingsCodec.parseMemories(json)
+            if (index !in current.indices) return@updateJsonOrFalse null
             MemorySettingsCodec.encodeMemories(
-                currentMemories.filterIndexed { itemIndex, _ -> itemIndex != index },
+                current.filterIndexed { i, _ -> i != index },
                 System.currentTimeMillis(),
             )
         }
     }
+
+    suspend fun removeByText(oldText: String): MemoryMutationResult {
+        var result: MemoryMutationResult = MemoryMutationResult.NotFound
+        repo.updateJsonOrFalse(StoreDescriptorRegistry.AGENT_MAIN_MEMORY_ID) { json ->
+            val current = MemorySettingsCodec.parseMemories(json)
+            val matches = findMatches(current, oldText)
+            when {
+                matches.isEmpty() -> {
+                    result = MemoryMutationResult.NotFound
+                    null
+                }
+                hasMultipleDistinct(matches) -> {
+                    result = MemoryMutationResult.Ambiguous
+                    null
+                }
+                else -> {
+                    result = MemoryMutationResult.Ok
+                    MemorySettingsCodec.encodeMemories(
+                        current.filterIndexed { index, _ -> index != matches.first().index },
+                        System.currentTimeMillis(),
+                    )
+                }
+            }
+        }
+        return result
+    }
+
+    suspend fun replaceByText(oldText: String, newContent: String): MemoryMutationResult {
+        val normalizedContent = newContent.trim()
+        if (normalizedContent.isBlank()) return MemoryMutationResult.NotFound
+        var result: MemoryMutationResult = MemoryMutationResult.NotFound
+        repo.updateJsonOrFalse(StoreDescriptorRegistry.AGENT_MAIN_MEMORY_ID) { json ->
+            val current = MemorySettingsCodec.parseMemories(json)
+            val matches = findMatches(current, oldText)
+            when {
+                matches.isEmpty() -> {
+                    result = MemoryMutationResult.NotFound
+                    null
+                }
+                hasMultipleDistinct(matches) -> {
+                    result = MemoryMutationResult.Ambiguous
+                    null
+                }
+                else -> {
+                    result = MemoryMutationResult.Ok
+                    val matchedIndex = matches.first().index
+                    MemorySettingsCodec.encodeMemories(
+                        current.mapIndexed { index, item ->
+                            if (index == matchedIndex) normalizedContent else item
+                        },
+                        System.currentTimeMillis(),
+                    )
+                }
+            }
+        }
+        return result
+    }
+
+    private fun findMatches(
+        entries: List<String>,
+        oldText: String,
+    ): List<IndexedEntry> {
+        return entries.mapIndexedNotNull { index, entry ->
+            if (oldText in entry) IndexedEntry(index, entry) else null
+        }
+    }
+
+    private fun hasMultipleDistinct(matches: List<IndexedEntry>): Boolean {
+        return matches.size > 1 && matches.map { it.content }.distinct().size > 1
+    }
+
+    private data class IndexedEntry(val index: Int, val content: String)
 
     private suspend fun writeMemories(memories: List<String>) {
         repo.writeJson(

--- a/app/src/main/java/com/niki914/nexus/agentic/repo/XRepo.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/repo/XRepo.kt
@@ -942,16 +942,10 @@ class BuiltinToolApi internal constructor(
         toolName: String,
         defaultEnabled: Boolean
     ): Boolean {
-        return if (toolName == TERMINAL_TOOL_NAME) {
-            // 只读兼容旧 run_command 开关；写入仍使用当前 terminal key。
-            this[TERMINAL_TOOL_NAME] ?: this[LEGACY_RUN_COMMAND_TOOL_NAME] ?: defaultEnabled
-        } else {
-            this[toolName] ?: defaultEnabled
-        }
+        return this[toolName] ?: defaultEnabled
     }
 
     private companion object {
         private const val TERMINAL_TOOL_NAME = "terminal"
-        private const val LEGACY_RUN_COMMAND_TOOL_NAME = "run_command"
     }
 }

--- a/app/src/main/java/com/niki914/nexus/agentic/repo/XRepoRuntimeGateway.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/repo/XRepoRuntimeGateway.kt
@@ -52,6 +52,14 @@ class XRepoRuntimeGateway(
         repo.memory.add(value)
     }
 
+    override suspend fun listMemories(): List<String> {
+        return repo.memory.list()
+    }
+
+    override suspend fun deleteMemory(index: Int) {
+        repo.memory.delete(index)
+    }
+
     override suspend fun listCustomTools(): List<RuntimeCustomTool> = repo.customTools.list()
 
     override suspend fun saveCustomTool(

--- a/app/src/main/java/com/niki914/nexus/agentic/repo/XRepoRuntimeGateway.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/repo/XRepoRuntimeGateway.kt
@@ -1,5 +1,6 @@
 package com.niki914.nexus.agentic.repo
 
+import com.niki914.nexus.agentic.runtime.settings.MemoryMutationResult
 import com.niki914.nexus.agentic.runtime.settings.RuntimeSettingsGateway
 import com.niki914.nexus.agentic.runtime.settings.model.RuntimeBuiltinToolSetting
 import com.niki914.nexus.agentic.runtime.settings.model.RuntimeCustomTool
@@ -52,12 +53,12 @@ class XRepoRuntimeGateway(
         repo.memory.add(value)
     }
 
-    override suspend fun listMemories(): List<String> {
-        return repo.memory.list()
+    override suspend fun removeMemory(oldText: String): MemoryMutationResult {
+        return repo.memory.removeByText(oldText)
     }
 
-    override suspend fun deleteMemory(index: Int) {
-        repo.memory.delete(index)
+    override suspend fun replaceMemory(oldText: String, content: String): MemoryMutationResult {
+        return repo.memory.replaceByText(oldText, content)
     }
 
     override suspend fun listCustomTools(): List<RuntimeCustomTool> = repo.customTools.list()

--- a/app/src/test/java/com/niki914/nexus/agentic/repo/XRepoDomainSettingsTest.kt
+++ b/app/src/test/java/com/niki914/nexus/agentic/repo/XRepoDomainSettingsTest.kt
@@ -198,7 +198,7 @@ class XRepoDomainSettingsTest {
 
         val terminal = XRepo.builtinTools.list().first { it.name == "terminal" }
 
-        assertFalse(terminal.enabled)
+        assertTrue(terminal.enabled)
         assertTrue(store.writeIds.isEmpty())
     }
 

--- a/app/src/test/java/com/niki914/nexus/agentic/repo/XRepoTest.kt
+++ b/app/src/test/java/com/niki914/nexus/agentic/repo/XRepoTest.kt
@@ -505,7 +505,7 @@ class XRepoTest {
     }
 
     @Test
-    fun builtinTerminalInheritsLegacyRunCommandDisabledFlag() = runTest {
+    fun builtinTerminalIgnoresLegacyRunCommandFlag() = runTest {
         val store = installStore(
             FakeDomainSettingsStore(
                 StoreDescriptorRegistry.TOOLS_BUILTIN_ID to ToolSettingsCodec.encodeBuiltinEnabledForAgents(
@@ -516,7 +516,7 @@ class XRepoTest {
 
         val terminal = XRepo.builtinTools.list().single { it.name == "terminal" }
 
-        assertFalse(terminal.enabled)
+        assertTrue(terminal.enabled)
         assertEquals(0, store.writeCount)
     }
 

--- a/app/src/test/java/com/niki914/nexus/agentic/repo/XRepoTest.kt
+++ b/app/src/test/java/com/niki914/nexus/agentic/repo/XRepoTest.kt
@@ -265,15 +265,38 @@ class XRepoTest {
 
     @Test
     fun memoryApi_writeFailureThrowsNotReturnsOk() = runTest {
-        val store = installStore(FakeDomainSettingsStore(ownerWriteSucceeds = false))
+        installStore(FakeDomainSettingsStore(ownerWriteSucceeds = false))
 
+        var threw = false
         try {
             XRepo.memory.add("value")
-            // If add() doesn't throw with a failing store (updateJsonOrFalse might handle it differently), skip
-        } catch (_: Exception) {
-            // Expected — write failure should throw
+        } catch (_: IllegalStateException) {
+            threw = true
         }
+
+        assertTrue(threw)
         assertEquals(emptyList<String>(), XRepo.memory.list())
+    }
+
+    @Test
+    fun memoryApi_replaceWriteFailureThrowsAndPreservesOldEntry() = runTest {
+        val store = installStore(
+            FakeDomainSettingsStore(
+                StoreDescriptorRegistry.AGENT_MAIN_MEMORY_ID to
+                    MemorySettingsCodec.encodeMemories(listOf("old"), 0L),
+                ownerWriteSucceeds = false,
+            )
+        )
+
+        var threw = false
+        try {
+            XRepo.memory.replaceByText("old", "new")
+        } catch (_: IllegalStateException) {
+            threw = true
+        }
+
+        assertTrue(threw)
+        assertEquals(listOf("old"), XRepo.memory.list())
     }
 
     @Test

--- a/app/src/test/java/com/niki914/nexus/agentic/repo/XRepoTest.kt
+++ b/app/src/test/java/com/niki914/nexus/agentic/repo/XRepoTest.kt
@@ -11,6 +11,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import com.niki914.nexus.agentic.runtime.settings.MemoryMutationResult
 import com.niki914.nexus.agentic.runtime.settings.model.RuntimeCustomTool as CustomTool
 import com.niki914.nexus.agentic.runtime.settings.model.RuntimeExecutionRule as ExecutionRule
 import com.niki914.nexus.agentic.runtime.settings.model.RuntimeExecutionRuleEnabledMode as ExecutionRuleEnabledMode
@@ -172,6 +173,107 @@ class XRepoTest {
             listOf("B2", "C"),
             MemorySettingsCodec.parseMemories(store.jsonFor(StoreDescriptorRegistry.AGENT_MAIN_MEMORY_ID)),
         )
+    }
+
+    @Test
+    fun memoryApi_addDedupesIdenticalContent() = runTest {
+        val store = installStore(FakeDomainSettingsStore())
+
+        XRepo.memory.add("unique")
+        val writeCountAfterFirst = store.writeCount
+        XRepo.memory.add("unique")
+
+        assertEquals(writeCountAfterFirst, store.writeCount)
+        assertEquals(listOf("unique"), XRepo.memory.list())
+    }
+
+    @Test
+    fun memoryApi_removeByTextReturnsNotFoundForZeroMatches() = runTest {
+        val store = installStore(FakeDomainSettingsStore())
+        XRepo.memory.add("only")
+
+        val writeCountBefore = store.writeCount
+        val result = XRepo.memory.removeByText("nonexistent")
+
+        assertEquals(MemoryMutationResult.NotFound, result)
+        assertEquals(writeCountBefore, store.writeCount)
+        assertEquals(listOf("only"), XRepo.memory.list())
+    }
+
+    @Test
+    fun memoryApi_removeByTextReturnsAmbiguousForMultipleDistinctMatches() = runTest {
+        val store = installStore(FakeDomainSettingsStore())
+        XRepo.memory.replaceAll(listOf("User prefers dark mode", "User prefers concise answers"))
+
+        val writeCountBefore = store.writeCount
+        val result = XRepo.memory.removeByText("User prefers")
+
+        assertEquals(MemoryMutationResult.Ambiguous, result)
+        assertEquals(writeCountBefore, store.writeCount)
+        assertEquals(2, XRepo.memory.list().size)
+    }
+
+    @Test
+    fun memoryApi_removeByTextAllowsIdenticalDuplicates() = runTest {
+        val store = installStore(FakeDomainSettingsStore())
+        XRepo.memory.replaceAll(listOf("dup", "dup", "unique"))
+
+        val result = XRepo.memory.removeByText("dup")
+
+        assertEquals(MemoryMutationResult.Ok, result)
+        assertEquals(2, XRepo.memory.list().size)
+        assertEquals(listOf("dup", "unique"), XRepo.memory.list())
+    }
+
+    @Test
+    fun memoryApi_replaceByTextUpdatesInPlace() = runTest {
+        val store = installStore(FakeDomainSettingsStore())
+        XRepo.memory.replaceAll(listOf("keep", "old", "also-keep"))
+
+        val writeCountBefore = store.writeCount
+        val result = XRepo.memory.replaceByText("old", "new")
+
+        assertEquals(MemoryMutationResult.Ok, result)
+        assertEquals(writeCountBefore + 1, store.writeCount)
+        assertEquals(listOf("keep", "new", "also-keep"), XRepo.memory.list())
+    }
+
+    @Test
+    fun memoryApi_replaceByTextReturnsNotFoundForZeroMatches() = runTest {
+        val store = installStore(FakeDomainSettingsStore())
+        XRepo.memory.add("only")
+
+        val writeCountBefore = store.writeCount
+        val result = XRepo.memory.replaceByText("nonexistent", "new")
+
+        assertEquals(MemoryMutationResult.NotFound, result)
+        assertEquals(writeCountBefore, store.writeCount)
+        assertEquals(listOf("only"), XRepo.memory.list())
+    }
+
+    @Test
+    fun memoryApi_replaceByTextReturnsAmbiguousForMultipleDistinctMatches() = runTest {
+        val store = installStore(FakeDomainSettingsStore())
+        XRepo.memory.replaceAll(listOf("User prefers dark mode", "User prefers concise answers"))
+
+        val writeCountBefore = store.writeCount
+        val result = XRepo.memory.replaceByText("User prefers", "new")
+
+        assertEquals(MemoryMutationResult.Ambiguous, result)
+        assertEquals(writeCountBefore, store.writeCount)
+    }
+
+    @Test
+    fun memoryApi_writeFailureThrowsNotReturnsOk() = runTest {
+        val store = installStore(FakeDomainSettingsStore(ownerWriteSucceeds = false))
+
+        try {
+            XRepo.memory.add("value")
+            // If add() doesn't throw with a failing store (updateJsonOrFalse might handle it differently), skip
+        } catch (_: Exception) {
+            // Expected — write failure should throw
+        }
+        assertEquals(emptyList<String>(), XRepo.memory.list())
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **SOUL identity slot**: 将 Model Configuration 页面的 Prompt 字段重新定位为身份槽位（概念对齐 Hermes SOUL.md）。填了就用它替代默认 agent 身份，不填就回退到硬编码 `DEFAULT_AGENT_IDENTITY`。移除了 `buildContextTier()`，因为 Prompt 字段不再承载"附加指令"的语义。
- **Memory 工具对齐 Hermes**: `memory` 工具从单参数 `content` add-only 改为 action-based CRUD（`add`/`replace`/`remove`），agent 通过 `old_text` 子串匹配定位目标条目（不再暴露 index），匹配逻辑下沉到 `MemoryApi` 的一次原子 `updateJsonOrFalse` 临界区内完成。注入格式从 markdown `<memory>` 改为 Hermes 的 `═══` + `§` 分隔块。`MEMORY_GUIDANCE` 和 tool description 逐字抄 Hermes。`add` 幂等去重，`replace` 原位替换。工具名 `memorize` → `memory`，类名 `MemorizeBuiltin` → `MemoryBuiltin`。

## Key review points

### 与 Hermes 的对齐
- **身份槽位**: Nexus 没有文件系统 SOUL.md，但语义一致——一个用户可选的槽位，可以覆盖默认身份。放在 stable tier 第一段。
- **Memory 工具契约**: `action` 集 `{add, replace, remove}` 与 Hermes 一致；`remove` 和 `replace` 使用 `old_text` 子串匹配；0 匹配返回 `NOT_FOUND`、2+ 不同匹配返回 `AMBIGUOUS_MATCH`、完全相同的多条匹配操作第一条——均为 Hermes 行为。工具名 `memory` 与 Hermes 一致。
- **注入格式**: `═══` (46字符) + `MEMORY` 头 + `§` 条目分隔，对齐 Hermes `_render_block()`。
- **原子性**: `add` 在 `updateJsonOrFalse` 内去重（幂等）；`removeByText`/`replaceByText` 在同一临界区内完成 read-match-modify-write，消除删加窗口和 index 漂移。
- **Gateway 清理**: 删除 `listMemories()` 和 `deleteMemory(index)`，新增 `removeMemory(oldText)` 和 `replaceMemory(oldText, content)`，返回 `MemoryMutationResult`。agent-runtime 完全不知道记忆是列表或 index。

### 未对齐（有意）
- **双 store (memory/user)**: Nexus 保持单层列表。
- **Batch operations / Char budget**: 不做。
- **`session_search`**: Nexus 没有，`MEMORY_GUIDANCE` 中改为"conversation history"。

### 清理
- **`run_command` legacy compat**: `XRepo.BuiltinToolApi` 中 `terminal` 对 `run_command` 的兼容回退已删除。旧用户如果曾禁用 `run_command`，升级后 `terminal` 会按默认值启用。

### 边界问题
- **旧用户遗留 Prompt**: 旧用户 Prompt 字段中可能包含旧版 XML 标签，这些文本现在会被当作身份槽位内容原样注入 stable tier。不做迁移。
- **`action` 必填**: 不带 action 的调用返回 `INVALID_ARGUMENTS`（不向后兼容）。
- **工具名改名**: `memorize` → `memory`。旧用户曾禁用 `memorize` 的配置会失效，`memory` 按 `defaultEnabled = true` 启用。不做兼容读取。

🤖 Generated with [Claude Code](https://claude.com/claude-code)