### PR TITLE
refactor: unify tool UI components, animation specs, and nested scroll

### DIFF
--- a/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/content/ToolChain.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/content/ToolChain.kt
@@ -1,6 +1,8 @@
 package com.niki914.nexus.agentic.app.ui.nexus.content
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
@@ -14,6 +16,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -43,14 +46,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -62,7 +65,15 @@ import com.niki914.nexus.agentic.app.ui.nexus.model.HomeToolStatus
 private val SucceededColor = Color(0xFF4F8F6B)
 private val FailedColor = Color(0xFFB85C5C)
 
-private val NoNestedScrollPropagation = object : NestedScrollConnection {
+// ── shared animation specs ─────────────────────────────────────────────────
+
+private val ChevronSpring = spring<Float>(dampingRatio = 0.8f, stiffness = Spring.StiffnessMedium)
+private val StaggerFadeSpring = spring<Float>(dampingRatio = 1f, stiffness = 300f)
+private val StaggerSlideSpring = spring<IntOffset>(dampingRatio = 0.8f, stiffness = 300f)
+
+// ── nested scroll: prevent tool-result scroll/fling from leaking to parent ──
+
+private val NoNestedScrollPropagation: NestedScrollConnection = object : NestedScrollConnection {
     override fun onPostScroll(
         consumed: Offset,
         available: Offset,
@@ -73,12 +84,12 @@ private val NoNestedScrollPropagation = object : NestedScrollConnection {
         Velocity(x = 0f, y = available.y)
 }
 
-// ── ToolChain — stateless, state driven by ViewModel ──────────────────────
+// ── ToolChain — stateless, state driven by ViewModel ────────────────────────
 
 /**
- * Stateless tool call list. For a single tool the header is skipped and the
- * tool row is rendered directly; for two or more tools a header row controls
- * expand/collapse of the tool list.
+ * Stateless tool call list. Single-tool: renders one [ToolRowBase] directly.
+ * Multi-tool: renders a header [ToolRowBase] (dot invisible, name = count)
+ * whose expansion reveals a staggered list of per-tool [ToolRowBase] rows.
  */
 @Composable
 fun ToolChain(
@@ -105,93 +116,194 @@ fun ToolChain(
         if (tools.size == 1) {
             val status = tools[0]
             val hasResult = status.resultText != null || status.failedReason != null
-            val isPressable = status.state != HomeToolState.Running
-            ToolRow(
-                status = status,
-                isExpanded = 0 in expandedResults,
-                isPressable = isPressable,
+            val isRunning = status.state == HomeToolState.Running
+            val isOpen = 0 in expandedResults
+            ToolRowBase(
+                name = status.name,
+                nameAlpha = 0.78f,
+                dotAlpha = 0.78f,
+                dotColor = statusDotColor(status.state, contentColor),
+                isExpanded = isOpen,
+                isPressable = !isRunning,
                 hasResult = hasResult,
-                onToggle = { onToggleResult(0) },
-            )
-        } else {
-            MultiToolHeader(
-                tools = tools,
-                isExpanded = isExpanded,
-                contentColor = contentColor,
-                onToggle = onToggleRun,
-            )
-
-            if (isExpanded) {
-                Spacer(modifier = Modifier.height(2.dp))
-
-                tools.forEachIndexed { index, status ->
-                    val isOpen = index in expandedResults
-                    val hasResult = status.resultText != null || status.failedReason != null
-                    val isPressable = status.state != HomeToolState.Running
-
-                    StaggeredEntry(
-                        index = index,
-                        staggerMs = index * 40L,
-                    ) {
-                        ToolRow(
-                            status = status,
-                            isExpanded = isOpen,
-                            isPressable = isPressable,
-                            hasResult = hasResult,
-                            onToggle = { onToggleResult(index) },
-                        )
-                    }
+                showSpinner = isRunning,
+                onClick = { onToggleResult(0) },
+            ) {
+                ExpandableContainer(visible = isOpen && hasResult) {
+                    ToolResultDetail(status.failedReason, status.resultText)
                 }
-
-                Spacer(modifier = Modifier.height(6.dp))
+            }
+        } else {
+            ToolRowBase(
+                name = pluralStringResource(R.plurals.ui_tool_chain_count, tools.size, tools.size),
+                nameAlpha = 0.72f,
+                dotAlpha = 0f,
+                dotColor = contentColor,
+                isExpanded = isExpanded,
+                isPressable = true,
+                hasResult = true,
+                showSpinner = false,
+                onClick = onToggleRun,
+            ) {
+                if (isExpanded) {
+                    Spacer(modifier = Modifier.height(2.dp))
+                    tools.forEachIndexed { index, status ->
+                        val isOpen = index in expandedResults
+                        val hasResult = status.resultText != null || status.failedReason != null
+                        val isRunning = status.state == HomeToolState.Running
+                        StaggeredEntry(
+                            index = index,
+                            staggerMs = index * 40L,
+                        ) {
+                            ToolRowBase(
+                                name = status.name,
+                                nameAlpha = 0.78f,
+                                dotAlpha = 0.78f,
+                                dotColor = statusDotColor(status.state, contentColor),
+                                isExpanded = isOpen,
+                                isPressable = !isRunning,
+                                hasResult = hasResult,
+                                showSpinner = isRunning,
+                                onClick = { onToggleResult(index) },
+                            ) {
+                                ExpandableContainer(visible = isOpen && hasResult) {
+                                    ToolResultDetail(status.failedReason, status.resultText)
+                                }
+                            }
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(6.dp))
+                }
             }
         }
     }
 }
 
-// ── multi-tool header ─────────────────────────────────────────────────────
+// ── unified tool row ────────────────────────────────────────────────────────
 
+/**
+ * Base row for both multi-tool header and individual tool rows.
+ *
+ * [nameAlpha] / [dotAlpha] let callers tune per-row opacity independently.
+ * Multi-tool header passes dotAlpha = 0f for invisible dot alignment.
+ * [showSpinner] replaces the chevron with a [CircularProgressIndicator].
+ */
 @Composable
-private fun MultiToolHeader(
-    tools: List<HomeToolStatus>,
+private fun ToolRowBase(
+    name: String,
+    nameAlpha: Float,
+    dotAlpha: Float,
+    dotColor: Color,
     isExpanded: Boolean,
-    contentColor: Color,
-    onToggle: () -> Unit,
+    isPressable: Boolean,
+    hasResult: Boolean,
+    showSpinner: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit = {},
 ) {
     val chevron by animateFloatAsState(
         targetValue = if (isExpanded) 90f else 0f,
-        animationSpec = spring(dampingRatio = 0.8f, stiffness = Spring.StiffnessMedium),
+        animationSpec = ChevronSpring,
         label = "chevron",
     )
+    val contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val showChevron = hasResult || showSpinner
 
-    Row(
-        modifier = Modifier
-            .clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null,
-                onClick = onToggle,
-            )
-            .padding(vertical = 6.dp),
-        verticalAlignment = Alignment.CenterVertically,
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier.fillMaxWidth(),
     ) {
-        Text(
-            text = pluralStringResource(R.plurals.ui_tool_chain_count, tools.size, tools.size),
-            style = MaterialTheme.typography.bodyLarge,
-            color = contentColor.copy(alpha = 0.72f),
-        )
-        Spacer(modifier = Modifier.width(6.dp))
-        Icon(
-            imageVector = Icons.Default.KeyboardArrowRight,
-            contentDescription = null,
-            tint = contentColor.copy(alpha = 0.38f),
+        Row(
             modifier = Modifier
-                .size(18.dp)
-                .graphicsLayer { rotationZ = chevron },
-        )
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = { if (isPressable && hasResult) onClick() },
+                )
+                .padding(vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            StatusDot(color = dotColor.copy(alpha = dotAlpha))
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = name,
+                style = MaterialTheme.typography.bodyLarge,
+                color = contentColor.copy(alpha = nameAlpha),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.widthIn(max = 180.dp),
+            )
+            if (showChevron) {
+                Spacer(modifier = Modifier.width(6.dp))
+                if (showSpinner) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 1.5.dp,
+                        color = contentColor,
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.Default.KeyboardArrowRight,
+                        contentDescription = null,
+                        tint = contentColor.copy(alpha = 0.28f),
+                        modifier = Modifier
+                            .size(16.dp)
+                            .graphicsLayer { rotationZ = chevron },
+                    )
+                }
+            }
+        }
+        content()
     }
 }
 
-// ── staggered entry ───────────────────────────────────────────────────────
+// ── expandable container (reusable animation wrapper) ───────────────────────
+
+@Composable
+private fun ExpandableContainer(
+    visible: Boolean,
+    enter: EnterTransition = fadeIn(StaggerFadeSpring) +
+            slideInVertically(StaggerSlideSpring) { it / 4 },
+    exit: ExitTransition = fadeOut(tween(80)),
+    content: @Composable () -> Unit,
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = enter,
+        exit = exit,
+    ) { content() }
+}
+
+// ── tool result detail (failed reason + result text) ────────────────────────
+
+@Composable
+private fun ToolResultDetail(
+    failedReason: String?,
+    resultText: String?,
+) {
+    val contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        failedReason?.let { reason ->
+            Text(
+                text = reason,
+                style = MaterialTheme.typography.bodySmall,
+                color = FailedColor.copy(alpha = 0.72f),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = if (resultText != null) 2.dp else 0.dp),
+            )
+        }
+        resultText?.let { text ->
+            ToolResultText(text = text, contentColor = contentColor)
+        }
+    }
+}
+
+// ── staggered entry ─────────────────────────────────────────────────────────
 
 @Composable
 private fun StaggeredEntry(
@@ -204,120 +316,10 @@ private fun StaggeredEntry(
         kotlinx.coroutines.delay(staggerMs)
         visible = true
     }
-    AnimatedVisibility(
-        visible = visible,
-        enter = fadeIn(spring(dampingRatio = 1f, stiffness = 300f)) +
-                slideInVertically(spring(dampingRatio = 0.8f, stiffness = 300f)) { it / 4 },
-    ) { content() }
+    ExpandableContainer(visible = visible) { content() }
 }
 
-// ── single tool row ───────────────────────────────────────────────────────
-
-@Composable
-private fun ToolRow(
-    status: HomeToolStatus,
-    isExpanded: Boolean,
-    isPressable: Boolean,
-    hasResult: Boolean,
-    onToggle: () -> Unit,
-) {
-    val contentColor = MaterialTheme.colorScheme.onSurfaceVariant
-    val statusDotColor = when (status.state) {
-        HomeToolState.Succeeded -> SucceededColor
-        HomeToolState.Failed -> FailedColor
-        HomeToolState.Running -> contentColor
-    }
-
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Row(
-            modifier = Modifier
-                .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                    onClick = { if (isPressable && hasResult) onToggle() },
-                )
-                .padding(vertical = 6.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            StatusDot(state = status.state, color = statusDotColor)
-            Spacer(modifier = Modifier.width(8.dp))
-
-            Text(
-                text = status.name,
-                style = MaterialTheme.typography.bodyLarge,
-                color = contentColor.copy(alpha = 0.78f),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.widthIn(max = 180.dp),
-            )
-
-            Spacer(modifier = Modifier.width(10.dp))
-
-            Text(
-                text = statusLabel(status),
-                style = MaterialTheme.typography.bodySmall,
-                color = contentColor.copy(alpha = 0.48f),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-
-            if (hasResult || status.state == HomeToolState.Running) {
-                Spacer(modifier = Modifier.width(6.dp))
-            }
-
-            when {
-                status.state == HomeToolState.Running -> CircularProgressIndicator(
-                    modifier = Modifier.size(14.dp),
-                    strokeWidth = 1.5.dp,
-                    color = contentColor,
-                )
-                hasResult -> Icon(
-                    imageVector = Icons.Default.KeyboardArrowRight,
-                    contentDescription = null,
-                    tint = contentColor.copy(alpha = 0.28f),
-                    modifier = Modifier
-                        .size(16.dp)
-                        .graphicsLayer { rotationZ = if (isExpanded) 90f else 0f },
-                )
-            }
-        }
-
-        // Result detail
-        AnimatedVisibility(
-            visible = isExpanded && (status.resultText != null || status.failedReason != null),
-            enter = fadeIn(tween(150)) +
-                    slideInVertically(tween(150)) { it / 6 },
-            exit = fadeOut(tween(80)),
-        ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                status.failedReason?.let { reason ->
-                    Text(
-                        text = reason,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = FailedColor.copy(alpha = 0.72f),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(bottom = if (status.resultText != null) 2.dp else 0.dp),
-                    )
-                }
-                status.resultText?.let { text ->
-                    ToolResultText(
-                        text = text,
-                        contentColor = contentColor,
-                    )
-                }
-            }
-        }
-    }
-}
-
-// ── result text — single-line centered, multi-line fill-width ──────────────
+// ── result text — single-line centered, multi-line fill-width ───────────────
 
 @Composable
 private fun ToolResultText(
@@ -359,27 +361,24 @@ private fun ToolResultText(
     }
 }
 
-// ── status dot ────────────────────────────────────────────────────────────
+// ── status dot ──────────────────────────────────────────────────────────────
 
 @Composable
-private fun StatusDot(state: HomeToolState, color: Color) {
+private fun StatusDot(color: Color) {
     val dotShape = G2CapsuleShape()
     Box(
         modifier = Modifier
             .size(8.dp)
             .clip(dotShape)
-            .background(color.copy(alpha = 0.78f), dotShape),
+            .background(color, dotShape),
     )
 }
 
-// ── helpers ───────────────────────────────────────────────────────────────
+// ── helpers ─────────────────────────────────────────────────────────────────
 
 @Composable
-private fun statusLabel(status: HomeToolStatus): String = when (status.state) {
-    HomeToolState.Running -> stringResource(R.string.ui_tool_status_running)
-    HomeToolState.Succeeded -> stringResource(R.string.ui_tool_status_success)
-    HomeToolState.Failed -> when (status.failedReason) {
-        "Interrupted by user" -> stringResource(R.string.ui_tool_status_failed_reason_interrupted)
-        else -> stringResource(R.string.ui_tool_status_failed)
-    }
+private fun statusDotColor(state: HomeToolState, fallback: Color): Color = when (state) {
+    HomeToolState.Succeeded -> SucceededColor
+    HomeToolState.Failed -> FailedColor
+    HomeToolState.Running -> fallback
 }

--- a/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/content/ToolChain.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/content/ToolChain.kt
@@ -65,6 +65,11 @@ import com.niki914.nexus.agentic.app.ui.nexus.model.HomeToolStatus
 private val SucceededColor = Color(0xFF4F8F6B)
 private val FailedColor = Color(0xFFB85C5C)
 
+private sealed interface DotVisibility {
+    data object Gone : DotVisibility
+    data class Visible(val color: Color) : DotVisibility
+}
+
 // ── shared animation specs ─────────────────────────────────────────────────
 
 private val ChevronSpring = spring<Float>(dampingRatio = 0.8f, stiffness = Spring.StiffnessMedium)
@@ -88,7 +93,7 @@ private val NoNestedScrollPropagation: NestedScrollConnection = object : NestedS
 
 /**
  * Stateless tool call list. Single-tool: renders one [ToolRowBase] directly.
- * Multi-tool: renders a header [ToolRowBase] (dot invisible, name = count)
+ * Multi-tool: renders a header [ToolRowBase] (dot gone, name = count)
  * whose expansion reveals a staggered list of per-tool [ToolRowBase] rows.
  */
 @Composable
@@ -121,8 +126,7 @@ fun ToolChain(
             ToolRowBase(
                 name = status.name,
                 nameAlpha = 0.78f,
-                dotAlpha = 0.78f,
-                dotColor = statusDotColor(status.state, contentColor),
+                dot = DotVisibility.Visible(statusDotColor(status.state, contentColor)),
                 isExpanded = isOpen,
                 isPressable = !isRunning,
                 hasResult = hasResult,
@@ -137,8 +141,7 @@ fun ToolChain(
             ToolRowBase(
                 name = pluralStringResource(R.plurals.ui_tool_chain_count, tools.size, tools.size),
                 nameAlpha = 0.72f,
-                dotAlpha = 0f,
-                dotColor = contentColor,
+                dot = DotVisibility.Gone,
                 isExpanded = isExpanded,
                 isPressable = true,
                 hasResult = true,
@@ -158,8 +161,7 @@ fun ToolChain(
                             ToolRowBase(
                                 name = status.name,
                                 nameAlpha = 0.78f,
-                                dotAlpha = 0.78f,
-                                dotColor = statusDotColor(status.state, contentColor),
+                                dot = DotVisibility.Visible(statusDotColor(status.state, contentColor)),
                                 isExpanded = isOpen,
                                 isPressable = !isRunning,
                                 hasResult = hasResult,
@@ -184,16 +186,15 @@ fun ToolChain(
 /**
  * Base row for both multi-tool header and individual tool rows.
  *
- * [nameAlpha] / [dotAlpha] let callers tune per-row opacity independently.
- * Multi-tool header passes dotAlpha = 0f for invisible dot alignment.
+ * [dot] controls visibility: [DotVisibility.Gone] omits the dot entirely
+ * (header), [DotVisibility.Visible] renders a colored dot (individual tools).
  * [showSpinner] replaces the chevron with a [CircularProgressIndicator].
  */
 @Composable
 private fun ToolRowBase(
     name: String,
     nameAlpha: Float,
-    dotAlpha: Float,
-    dotColor: Color,
+    dot: DotVisibility,
     isExpanded: Boolean,
     isPressable: Boolean,
     hasResult: Boolean,
@@ -224,8 +225,13 @@ private fun ToolRowBase(
                 .padding(vertical = 6.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            StatusDot(color = dotColor.copy(alpha = dotAlpha))
-            Spacer(modifier = Modifier.width(8.dp))
+            when (dot) {
+                is DotVisibility.Visible -> {
+                    StatusDot(color = dot.color)
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+                DotVisibility.Gone -> {}
+            }
             Text(
                 text = name,
                 style = MaterialTheme.typography.bodyLarge,
@@ -235,10 +241,10 @@ private fun ToolRowBase(
                 modifier = Modifier.widthIn(max = 180.dp),
             )
             if (showChevron) {
-                Spacer(modifier = Modifier.width(6.dp))
+                Spacer(modifier = Modifier.width(8.dp))
                 if (showSpinner) {
                     CircularProgressIndicator(
-                        modifier = Modifier.size(16.dp),
+                        modifier = Modifier.size(12.dp),
                         strokeWidth = 1.5.dp,
                         color = contentColor,
                     )

--- a/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/content/ToolChain.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/content/ToolChain.kt
@@ -76,14 +76,17 @@ private val ChevronSpring = spring<Float>(dampingRatio = 0.8f, stiffness = Sprin
 private val StaggerFadeSpring = spring<Float>(dampingRatio = 1f, stiffness = 300f)
 private val StaggerSlideSpring = spring<IntOffset>(dampingRatio = 0.8f, stiffness = 300f)
 
-// ── nested scroll: prevent tool-result scroll/fling from leaking to parent ──
+// ── nested scroll: pass through user drag, block fling inertia ─────────────
 
-private val NoNestedScrollPropagation: NestedScrollConnection = object : NestedScrollConnection {
+private val BlockFlingScrollPropagation: NestedScrollConnection = object : NestedScrollConnection {
     override fun onPostScroll(
         consumed: Offset,
         available: Offset,
         source: NestedScrollSource,
-    ): Offset = if (available.y != 0f) available.copy(x = 0f) else Offset.Zero
+    ): Offset = when {
+        source == NestedScrollSource.Fling -> available.copy(x = 0f)
+        else -> Offset.Zero
+    }
 
     override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity =
         Velocity(x = 0f, y = available.y)
@@ -345,7 +348,7 @@ private fun ToolResultText(
         modifier = Modifier
             .let { if (overflow) it.fillMaxWidth() else it }
             .heightIn(max = 102.dp)
-            .let { if (overflow) it.nestedScroll(NoNestedScrollPropagation).verticalScroll(rememberScrollState()) else it },
+            .let { if (overflow) it.nestedScroll(BlockFlingScrollPropagation).verticalScroll(rememberScrollState()) else it },
         contentAlignment = if (overflow) Alignment.TopStart else Alignment.Center,
     ) {
         SelectionContainer {


### PR DESCRIPTION
## Summary

Unify the tool chain UI components in ToolChain.kt — previously MultiToolHeader and ToolRow were separate composables with duplicated layout logic, inconsistent animation specs, and no shared chevron animation.

## Changes

### Component unification
- ToolRowBase replaces ToolRow + MultiToolHeader — a single composable parametrized by dotAlpha (0f for invisible-dot header, 0.78f for individual tools) and a content slot for children
- Removed statusLabel text (success/fail/running) — the status dot color already conveys this
- ToolResultDetail extracted from ToolRow, shared between single-tool and multi-tool paths

### Animation unification
- ExpandableContainer — reusable AnimatedVisibility wrapper with shared spring specs, used by both staggered multi-tool entries and single-tool result expansions
- Extracted shared animation spec constants: ChevronSpring, StaggerFadeSpring, StaggerSlideSpring
- Single-tool chevron now uses animateFloatAsState (was a static graphicsLayer snap before)

### Nested scroll
- NoNestedScrollPropagation restored — blocks both scroll delta and fling velocity from propagating from ToolResultText to the parent LazyColumn