### PR TITLE
perf: reduce prompt token bloat — load_skill protocol + screen_operation token dedup

### DIFF
--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/AccessibilityController.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/AccessibilityController.kt
@@ -559,7 +559,7 @@ object AccessibilityController {
         val pos = PruningRules.posOf(bounds, screenW, screenH)
 
         val sb = StringBuilder()
-        sb.append("{token: \"${version}_$index\", t: ${type.name.lowercase()}, b: [${bounds.left},${bounds.top},${bounds.right},${bounds.bottom}], pos: $pos")
+        sb.append("{i: $index, t: ${type.name.lowercase()}, b: [${bounds.left},${bounds.top},${bounds.right},${bounds.bottom}], pos: $pos")
 
         if (text.isNotEmpty()) {
             val quoted =
@@ -602,7 +602,11 @@ object AccessibilityController {
 
         val st = SemanticToken.parse(token).getOrElse {
             return BuiltinToolResult.failure(
-                "INVALID_ARGUMENTS", "Invalid token format: $token"
+                "INVALID_ARGUMENTS",
+                "Invalid token format: '$token'. " +
+                    "Token must be assembled as {version}_{i} — join the snapshot version " +
+                    "(from the YAML header) with the node's index (i field), separated by underscore. " +
+                    "Example: version \"a3f2c91e7b40\" + node {i: 42, ...} → token \"a3f2c91e7b40_42\"."
             )
         }
 
@@ -611,7 +615,8 @@ object AccessibilityController {
                 "VERSION_MISMATCH",
                 "Token version '${st.version}' does not match current version '$currentVersion'. " +
                         "The snapshot has been refreshed — use screen_operation_accessibility " +
-                        "with read or search to get fresh tokens, then retry."
+                        "with read or search to get a fresh version and indices, " +
+                        "then assemble new tokens as {version}_{i}."
             )
         }
 

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/TreeFormatter.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/TreeFormatter.kt
@@ -170,7 +170,7 @@ object TreeFormatter {
     ): String {
         val sb = StringBuilder()
         sb.append(
-            "{token: \"${version}_${node.index}\", t: ${node.semanticType.name.lowercase()}, b: [${node.bounds.left},${node.bounds.top},${node.bounds.right},${node.bounds.bottom}], pos: ${
+            "{i: ${node.index}, t: ${node.semanticType.name.lowercase()}, b: [${node.bounds.left},${node.bounds.top},${node.bounds.right},${node.bounds.bottom}], pos: ${
                 PruningRules.posOf(
                     node.bounds,
                     screenWidth,

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/LoadSkillBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/LoadSkillBuiltin.kt
@@ -1,8 +1,8 @@
 package com.niki914.nexus.agentic.chat.agentic.buildin.impl
 
-import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinTool
 import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinToolRequest
-import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinToolResult
+import com.niki914.nexus.agentic.chat.agentic.buildin.TextResultBuiltinTool
+import com.niki914.nexus.agentic.chat.agentic.buildin.TextToolResult
 import com.niki914.nexus.agentic.runtime.settings.RuntimeEnvironment
 import com.niki914.nexus.agentic.runtime.settings.model.RuntimeLoadedSkill
 import com.niki914.s3ss10n.LocalToolConfig
@@ -13,7 +13,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 
-class LoadSkillBuiltin : BuiltinTool() {
+class LoadSkillBuiltin : TextResultBuiltinTool() {
     override val name: String = "load_skill"
 
     override val description: String =
@@ -30,56 +30,49 @@ class LoadSkillBuiltin : BuiltinTool() {
         config.rawJsonSchema(LOAD_SKILL_SCHEMA)
     }
 
-    override suspend fun invoke(request: BuiltinToolRequest): BuiltinToolResult {
+    override suspend fun invokeText(request: BuiltinToolRequest): TextToolResult {
         val skillId = when (val result = parseSkillId(request.argumentsJson)) {
             is SkillIdParseResult.Success -> result.id
             is SkillIdParseResult.InvalidJson -> {
-                return BuiltinToolResult.failure(
+                return TextToolResult.failure(
                     code = "INVALID_ARGUMENTS_JSON",
-                    message = "load_skill arguments must be a JSON object with an id field.",
-                    hint = """Example: {"id":"skill-a"}""",
-                    fieldErrors = mapOf("argumentsJson" to result.message),
+                    message = "load_skill arguments must be a JSON object with an id field. " +
+                        "Example: {\"id\":\"skill-a\"} (${result.message})",
                 )
             }
 
             SkillIdParseResult.MissingId -> {
-                return BuiltinToolResult.failure(
+                return TextToolResult.failure(
                     code = "MISSING_SKILL_ID",
-                    message = "load_skill requires a non-blank skill id.",
-                    hint = "Use an id from the available_skills prompt block.",
-                    fieldErrors = mapOf("id" to "Skill id is required."),
+                    message = "load_skill requires a non-blank skill id. " +
+                        "Use an id from the available_skills prompt block.",
                 )
             }
         }
 
         return try {
             val skill = RuntimeEnvironment.awaitSettingsGateway().loadSkill(skillId)
-                ?: return BuiltinToolResult.failure(
+                ?: return TextToolResult.failure(
                     code = "SKILL_NOT_FOUND",
-                    message = "Skill '$skillId' was not found.",
-                    hint = "Use an id from the available_skills prompt block.",
-                    fieldErrors = mapOf("id" to "Unknown skill id."),
+                    message = "Skill '$skillId' was not found. " +
+                        "Use an id from the available_skills prompt block.",
                 )
             if (!skill.enabled) {
-                return BuiltinToolResult.failure(
+                return TextToolResult.failure(
                     code = "SKILL_DISABLED",
-                    message = "Skill '$skillId' is disabled.",
-                    hint = "Use an enabled id from the available_skills prompt block.",
-                    fieldErrors = mapOf("id" to "Disabled skill id."),
+                    message = "Skill '$skillId' is disabled. " +
+                        "Use an enabled id from the available_skills prompt block.",
                 )
             }
-            BuiltinToolResult.success(
-                message = "Skill loaded.",
-                data = skill.toJsonData(),
-            )
+            TextToolResult.success(skill.content)
         } catch (throwable: Throwable) {
             if (throwable is CancellationException) {
                 throw throwable
             }
-            BuiltinToolResult.failure(
+            TextToolResult.failure(
                 code = "SETTINGS_READ_FAILED",
-                message = "Failed to load skill: ${throwable.message ?: throwable::class.java.simpleName}.",
-                hint = "Retry after confirming the settings provider is available.",
+                message = "Failed to load skill: ${throwable.message ?: throwable::class.java.simpleName}. " +
+                    "Retry after confirming the settings provider is available.",
             )
         }
     }
@@ -101,16 +94,6 @@ class LoadSkillBuiltin : BuiltinTool() {
 
     private fun JsonObject.stringOrNull(key: String): String? {
         return (this[key] as? JsonPrimitive)?.contentOrNull
-    }
-
-    private fun RuntimeLoadedSkill.toJsonData(): JsonObject {
-        return JsonObject(
-            linkedMapOf(
-                "skill_name" to JsonPrimitive(name),
-                "skill_path" to JsonPrimitive(relativePath),
-                "skill_content" to JsonPrimitive(content),
-            )
-        )
     }
 
     private sealed interface SkillIdParseResult {

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationAccessibilityBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationAccessibilityBuiltin.kt
@@ -27,11 +27,14 @@ class ScreenOperationAccessibilityBuiltin : TextResultBuiltinTool() {
     override val description: String =
         "Screen interaction via accessibility service. " +
                 "Operations: read (capture YAML tree), tap, long_click, scroll_forward, " +
-                "scroll_backward, set_text, search. Target nodes by token (format: " +
-                "version_index, e.g. \"a3f2c91e7b40_42\") from the most recently returned " +
-                "snapshot. Every successful write " +
-                "op auto-captures the updated tree — no separate read needed.\n\n" +
-                "YAML fields: token=node_identifier, " +
+                "scroll_backward, set_text, search. Target nodes by constructing a token " +
+                "from the snapshot version (YAML header) and the node's index (i field), " +
+                "joined with underscore: \"{version}_{i}\" (e.g. version \"a3f2c91e7b40\" + " +
+                "node {i: 42, ...} → token \"a3f2c91e7b40_42\"). " +
+                "Every successful write op auto-captures the updated tree — " +
+                "no separate read needed.\n\n" +
+                "YAML fields: version=snapshot_version (header), " +
+                "i=node_index (assemble token as {version}_{i} when calling back), " +
                 "t=semantic_type(button/input/text/image/list/list_item/switch/checkbox/tab/chip/toolbar/dialog/container), " +
                 "b=bounds[left,top,right,bottom], pos=3x3_grid_position, txt=display_text, h=content_description, " +
                 "tap=clickable, hold=long_clickable, edit=editable, scroll=scrollable, " +
@@ -40,7 +43,7 @@ class ScreenOperationAccessibilityBuiltin : TextResultBuiltinTool() {
                 "keywords: [\"term1\", \"term2\"] (required, JSON string array). " +
                 "match_mode: \"any\" (default) | \"all\". " +
                 "limit: max results (default 10). " +
-                "Returns matched nodes with tokens + version header.\n\n" +
+                "Returns matched nodes with index + version header.\n\n" +
                 "If read returns root-only or empty tree: app likely uses non-native UI " +
                 "(Flutter/Unity/WebView) — stop, do not retry.\n\n" +
                 "wait_mode (default \"stable\"): \"stable\" detects when the UI actually settles " +
@@ -50,9 +53,8 @@ class ScreenOperationAccessibilityBuiltin : TextResultBuiltinTool() {
                 "Must be \"stable\" or \"delay\".\n" +
                 "wait_ms: for \"stable\" the max deadline (default 2000, max 60000); " +
                 "for \"delay\" required (no default), the fixed blind-wait duration.\n\n" +
-                "Tokens belong to exactly one snapshot — every read, search, and successful " +
-                "write operation produces a fresh version. Use only tokens from the most " +
-                "recently returned result.\n\n" +
+                "Every read, search, and successful write operation produces a fresh version. " +
+                "Assemble tokens from the most recently returned result only.\n\n" +
                 "Every result uses the #!tool-result protocol " +
                 "(#!status, #!code, #!message, then payload). " +
                 "See the Phone Use skill for failure recovery rules."
@@ -64,7 +66,7 @@ class ScreenOperationAccessibilityBuiltin : TextResultBuiltinTool() {
             required = true
         }
         config.string("token") {
-            description = "Node token from the latest snapshot result (format: version_index). Required for tap, long_click, scroll_forward, scroll_backward, set_text."
+            description = "Target node token, assembled as {version}_{i} — snapshot version from YAML header + underscore + node index from the i field. Required for tap, long_click, scroll_forward, scroll_backward, set_text."
             required = false
         }
         config.string("text") {

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/stream/LocalToolResultClassifier.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/stream/LocalToolResultClassifier.kt
@@ -31,6 +31,7 @@ data class ParsedToolResult(
 
     companion object {
         private val TEXT_RESULT_TOOL_NAMES = setOf(
+            "load_skill",
             "screen_operation_accessibility",
             "screen_operation_shell",
         )

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/BuiltinToolExecutorTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/BuiltinToolExecutorTest.kt
@@ -8,6 +8,8 @@ import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinToolRegistry
 import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinToolRequest
 import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinToolResult
 import com.niki914.nexus.agentic.chat.agentic.buildin.RawJsonBuiltinTool
+import com.niki914.nexus.agentic.chat.agentic.buildin.TextToolResult
+import com.niki914.nexus.agentic.chat.agentic.buildin.TextToolResultCodec
 import com.niki914.nexus.agentic.chat.agentic.buildin.impl.LoadSkillBuiltin
 import com.niki914.nexus.agentic.runtime.settings.model.RuntimeLoadedSkill
 import com.niki914.s3ss10n.LocalToolConfig
@@ -17,6 +19,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 class BuiltinToolExecutorTest {
@@ -105,14 +108,12 @@ class BuiltinToolExecutorTest {
         )
         val executor = BuiltinToolExecutor(BuiltinToolRegistry(listOf(LoadSkillBuiltin())))
 
-        val resultJson = executor.execute("load_skill", """{"id":"skill-a"}""")
+        val resultRaw = executor.execute("load_skill", """{"id":"skill-a"}""")
 
-        val json = Json.parseToJsonElement(resultJson).jsonObject
-        assertEquals("OK", json["code"]!!.jsonPrimitive.content)
-        val data = json["data"]!!.jsonObject
-        assertEquals("Skill A", data["skill_name"]!!.jsonPrimitive.content)
-        assertEquals("skills/skill-a/SKILL.md", data["skill_path"]!!.jsonPrimitive.content)
-        assertEquals("# Skill A", data["skill_content"]!!.jsonPrimitive.content)
+        val result = TextToolResultCodec.decode(resultRaw)
+        assertNotNull("Expected #!tool-result protocol output", result)
+        assertEquals(TextToolResult.Status.Success, result!!.status)
+        assertEquals("# Skill A", result.payload)
     }
 
     @Test(expected = CancellationException::class)

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/LoadSkillBuiltinTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/LoadSkillBuiltinTest.kt
@@ -1,6 +1,8 @@
 package com.niki914.nexus.agentic.chat
 
 import com.niki914.nexus.agentic.chat.agentic.buildin.BuiltinToolRequest
+import com.niki914.nexus.agentic.chat.agentic.buildin.TextToolResult
+import com.niki914.nexus.agentic.chat.agentic.buildin.TextToolResultCodec
 import com.niki914.nexus.agentic.chat.agentic.buildin.impl.LoadSkillBuiltin
 import com.niki914.nexus.agentic.runtime.settings.RuntimeBridge
 import com.niki914.nexus.agentic.runtime.settings.RuntimeEnvironment
@@ -8,12 +10,9 @@ import com.niki914.nexus.agentic.runtime.settings.RuntimeHostGateway
 import com.niki914.nexus.agentic.runtime.settings.RuntimeSettingsGateway
 import com.niki914.nexus.agentic.runtime.settings.model.RuntimeLoadedSkill
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -31,14 +30,10 @@ class LoadSkillBuiltinTest {
             )
         )
 
-        val json = invoke("""{"id":"skill-a"}""")
+        val result = invokeAndDecode("""{"id":"skill-a"}""")
 
-        assertTrue(json["ok"]!!.jsonPrimitive.content.toBoolean())
-        assertEquals("OK", json["code"]!!.jsonPrimitive.content)
-        val data = json["data"]!!.jsonObject
-        assertEquals("Skill A", data["skill_name"]!!.jsonPrimitive.content)
-        assertEquals("skill-a/SKILL.md", data["skill_path"]!!.jsonPrimitive.content)
-        assertEquals("Skill content A", data["skill_content"]!!.jsonPrimitive.content)
+        assertEquals(TextToolResult.Status.Success, result.status)
+        assertEquals("Skill content A", result.payload)
     }
 
     @Test
@@ -49,46 +44,46 @@ class LoadSkillBuiltinTest {
             )
         )
 
-        val json = invoke("""{"skill_id":"skill-a"}""")
+        val result = invokeAndDecode("""{"skill_id":"skill-a"}""")
 
-        assertEquals("OK", json["code"]!!.jsonPrimitive.content)
-        assertEquals(
-            "Skill content A",
-            json["data"]!!.jsonObject["skill_content"]!!.jsonPrimitive.content
-        )
+        assertEquals(TextToolResult.Status.Success, result.status)
+        assertEquals("Skill content A", result.payload)
     }
 
     @Test
     fun invoke_missingId_returnsFailure() = runTest {
         installRuntimeSettingsGatewayForTest()
 
-        val json = invoke("{}")
+        val result = invokeAndDecode("{}")
 
-        assertFalse(json["ok"]!!.jsonPrimitive.content.toBoolean())
-        assertEquals("MISSING_SKILL_ID", json["code"]!!.jsonPrimitive.content)
-        assertTrue(json["field_errors"]!!.jsonObject.containsKey("id"))
+        assertEquals(TextToolResult.Status.Failure, result.status)
+        assertEquals("MISSING_SKILL_ID", result.code)
+        assertNotNull(result.message)
+        assertTrue(result.message!!.contains("available_skills"))
     }
 
     @Test
     fun invoke_invalidJson_returnsFailure() = runTest {
         installRuntimeSettingsGatewayForTest()
 
-        val json = invoke("not-json")
+        val result = invokeAndDecode("not-json")
 
-        assertFalse(json["ok"]!!.jsonPrimitive.content.toBoolean())
-        assertEquals("INVALID_ARGUMENTS_JSON", json["code"]!!.jsonPrimitive.content)
-        assertTrue(json["field_errors"]!!.jsonObject.containsKey("argumentsJson"))
+        assertEquals(TextToolResult.Status.Failure, result.status)
+        assertEquals("INVALID_ARGUMENTS_JSON", result.code)
+        assertNotNull(result.message)
+        assertTrue(result.message!!.contains("JSON"))
     }
 
     @Test
     fun invoke_missingSkill_returnsFailure() = runTest {
         installRuntimeSettingsGatewayForTest()
 
-        val json = invoke("""{"id":"missing"}""")
+        val result = invokeAndDecode("""{"id":"missing"}""")
 
-        assertFalse(json["ok"]!!.jsonPrimitive.content.toBoolean())
-        assertEquals("SKILL_NOT_FOUND", json["code"]!!.jsonPrimitive.content)
-        assertTrue(json["field_errors"]!!.jsonObject.containsKey("id"))
+        assertEquals(TextToolResult.Status.Failure, result.status)
+        assertEquals("SKILL_NOT_FOUND", result.code)
+        assertNotNull(result.message)
+        assertTrue(result.message!!.contains("missing"))
     }
 
     @Test
@@ -99,11 +94,12 @@ class LoadSkillBuiltinTest {
             )
         )
 
-        val json = invoke("""{"id":"skill-a"}""")
+        val result = invokeAndDecode("""{"id":"skill-a"}""")
 
-        assertFalse(json["ok"]!!.jsonPrimitive.content.toBoolean())
-        assertEquals("SKILL_DISABLED", json["code"]!!.jsonPrimitive.content)
-        assertTrue(json["field_errors"]!!.jsonObject.containsKey("id"))
+        assertEquals(TextToolResult.Status.Failure, result.status)
+        assertEquals("SKILL_DISABLED", result.code)
+        assertNotNull(result.message)
+        assertTrue(result.message!!.contains("disabled"))
     }
 
     @Test
@@ -115,20 +111,25 @@ class LoadSkillBuiltinTest {
             )
         )
 
-        val json = invoke("""{"id":"skill-a"}""")
+        val result = invokeAndDecode("""{"id":"skill-a"}""")
 
-        assertFalse(json["ok"]!!.jsonPrimitive.content.toBoolean())
-        assertEquals("SETTINGS_READ_FAILED", json["code"]!!.jsonPrimitive.content)
+        assertEquals(TextToolResult.Status.Failure, result.status)
+        assertEquals("SETTINGS_READ_FAILED", result.code)
+        assertNotNull(result.message)
+        assertTrue(result.message!!.contains("settings"))
     }
 
-    private suspend fun invoke(argumentsJson: String) = Json.parseToJsonElement(
-        LoadSkillBuiltin().invoke(
+    private suspend fun invokeAndDecode(argumentsJson: String): TextToolResult {
+        val raw = LoadSkillBuiltin().invokeRawJson(
             BuiltinToolRequest(
                 name = "load_skill",
                 argumentsJson = argumentsJson,
             )
-        ).toJsonString()
-    ).jsonObject
+        )
+        val decoded = TextToolResultCodec.decode(raw)
+        assertNotNull("Expected #!tool-result protocol output, got: $raw", decoded)
+        return decoded!!
+    }
 
     private fun loadedSkill(
         id: String,

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/accessibility/TreeFormatterTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/accessibility/TreeFormatterTest.kt
@@ -71,7 +71,7 @@ class TreeFormatterTest {
     ): String {
         val sb = StringBuilder()
         sb.append(
-            "{token: \"${version}_${node.index}\", t: ${node.semanticType.name.lowercase()}, b: [${node.bounds.left},${node.bounds.top},${node.bounds.right},${node.bounds.bottom}], pos: ${
+            "{i: ${node.index}, t: ${node.semanticType.name.lowercase()}, b: [${node.bounds.left},${node.bounds.top},${node.bounds.right},${node.bounds.bottom}], pos: ${
                 PruningRules.posOf(
                     node.bounds,
                     screenWidth,
@@ -180,8 +180,8 @@ class TreeFormatterTest {
         assertTrue("must contain app package", yaml.contains("app: test.package"))
         assertTrue("must contain version header", yaml.contains("""version: "0000""""))
         assertTrue("must contain tree root", yaml.contains("tree:"))
-        assertTrue("must contain container node", yaml.contains("""{token: "0000_0", t: container"""))
-        assertTrue("must contain button node", yaml.contains("""{token: "0000_1", t: button"""))
+        assertTrue("must contain container node", yaml.contains("""{i: 0, t: container"""))
+        assertTrue("must contain button node", yaml.contains("""{i: 1, t: button"""))
         assertTrue("must mark clickable", yaml.contains("tap: true"))
         assertTrue("must include text", yaml.contains("txt: OK"))
     }
@@ -231,10 +231,10 @@ class TreeFormatterTest {
         )
 
         // Button should be a direct child of root (no empty shell in between).
-        assertTrue("button must appear in tree", yaml.contains("""{token: "0000_1", t: button"""))
-        assertTrue("button token must reference index 1", yaml.contains("""token: "0000_1""""))
+        assertTrue("button must appear in tree", yaml.contains("""{i: 1, t: button"""))
+        assertTrue("button token must reference index 1", yaml.contains("""i: 1"""))
         // The container at index 0 is the parent
-        assertTrue("parent must be container at index 0", yaml.contains("""{token: "0000_0", t: container"""))
+        assertTrue("parent must be container at index 0", yaml.contains("""{i: 0, t: container"""))
         // Verify button text is present
         assertTrue("button text must appear", yaml.contains("txt: \"click me\""))
     }
@@ -383,7 +383,7 @@ class TreeFormatterTest {
             ),
         )
 
-        assertTrue("root node must appear in output", yaml.contains("""{token: "0000_0", t: container"""))
+        assertTrue("root node must appear in output", yaml.contains("""{i: 0, t: container"""))
         assertTrue("tree section must be present", yaml.contains("tree:"))
     }
 
@@ -554,7 +554,7 @@ class TreeFormatterTest {
 
         assertTrue(
             "leaf must appear in output directly under root",
-            yaml.contains("""{token: "0000_1", t: button""")
+            yaml.contains("""{i: 1, t: button""")
         )
         assertTrue(
             "leaf text must be present",
@@ -562,7 +562,7 @@ class TreeFormatterTest {
         )
         assertFalse(
             "must not contain intermediate container at index 0",
-            yaml.contains("""{token: "0000_0", t: container""")
+            yaml.contains("""{i: 0, t: container""")
         )
     }
 }

--- a/app/src/main/assets/skills/phone-use/SKILL.md
+++ b/app/src/main/assets/skills/phone-use/SKILL.md
@@ -34,7 +34,7 @@ See each tool's own description for full parameter docs, operation lists, YAML f
 
 ### screen_operation_accessibility
 
-Primary tool for reading the screen and interacting with labeled UI nodes. All node-based operations target a node by its `token` (format: `"$version_$index"`, e.g. `"a3f2c91e7b40_42"`) from the most recently returned snapshot. Every successful write operation (tap, long_click, scroll_forward, scroll_backward, set_text) auto-returns the updated YAML tree — no separate read needed.
+Primary tool for reading the screen and interacting with labeled UI nodes. The YAML header contains the snapshot `version`. Each node has an `i` (index) field. To target a node, construct the token by joining the snapshot `version` with the node's `i`, separated by `_`: e.g. header `version: "a3f2c91e7b40"` + node `{i: 42, ...}` → token `"a3f2c91e7b40_42"`. Every successful write operation (tap, long_click, scroll_forward, scroll_backward, set_text) auto-returns the updated YAML tree — no separate read needed.
 
 **Non-native app detection:** If `read` returns an empty or root-only tree, the current app likely uses a non-native UI framework (Flutter, Unity, WebView, game engine). **Stop immediately and report to the user.** Do not retry.
 
@@ -69,7 +69,7 @@ After the app is open, call `screen_operation_accessibility(operation: "read")`.
 screen_operation_accessibility(operation: "read")
 ```
 
-Each node has a `token` you use with `screen_operation_accessibility`.
+Each node has an `i` (index). Assemble the token as `{version}_{i}` when calling `screen_operation_accessibility`.
 
 ### 2b. Search for specific elements (optional)
 
@@ -79,9 +79,9 @@ When the screen has many nodes and you know what text or label you're looking fo
 screen_operation_accessibility(operation: "search", keywords: ["目标文本"])
 ```
 
-Use the returned `token` directly with `screen_operation_accessibility`.
+Use the returned `i` with the snapshot `version` to construct a token for `screen_operation_accessibility`.
 
-Search creates a new snapshot — tokens from a previous read or search become invalid. Use only tokens from this search result.
+Search creates a new snapshot — indices from a previous read or search must be paired with the new version. Use only the freshest result.
 
 ### 3. Act on the tree
 
@@ -101,7 +101,7 @@ All write operations (tap, scroll, swipe, key) now return the updated screen tre
 However, **re-read explicitly** after `launch_app` or whenever you need a fresh view after external state changes. Tokens are versioned — every read, search, and successful write operation produces a fresh version. Never reuse tokens from an older snapshot.
 
 Every result uses the `#!tool-result` protocol. Check `#!status` first:
-- **Success:** the payload is the updated tree — use its tokens/coordinates directly.
+- **Success:** the payload is the updated tree — assemble tokens from its version + indices and use coordinates directly.
 - **Failure with payload:** the action was not executed or its outcome is uncertain. Inspect the tree, derive fresh tokens/coordinates. Retry only when the error indicates the action was definitely not executed. `SHELL_TIMEOUT` and `SHELL_SESSION_LOST` mean the action may have partially executed — verify via the tree, do NOT blindly retry.
 - **Failure without payload:** for validation errors (`INVALID_ARGUMENTS_JSON`, `INVALID_OPERATION`, `INVALID_ARGUMENTS`), correct the arguments directly. For `SEARCH_FAILED`, the accessibility tree could not be searched — check the message; retry after `read` if the service is available. For `CAPTURE_FAILED_AFTER_ACTION`, the action may have succeeded — `read` before deciding.
 


### PR DESCRIPTION
## Summary

Two prompt-optimization changes targeting context-window bloat.

### 1. refactor(load_skill): switch to #!tool-result text protocol
load_skill now returns raw SKILL.md content as payload directly instead of wrapping it in a JSON envelope.

### 2. perf(screen_operation): deduplicate version from node tokens
Nodes now emit {i: 42} (just the index) instead of {token: "a3f2c91e7b40_42"}. The LLM assembles the token as {version}_{i} when calling back. Saves ~13 chars per node.

🤖 Generated with Claude Code