### PR TITLE
fix: isolate Python runtime in a separate process and hard-stop tools on terminate

### DIFF
--- a/agent-runtime/src/main/AndroidManifest.xml
+++ b/agent-runtime/src/main/AndroidManifest.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <!--
+            Python 解释器运行在独立进程：execute_python 的硬超时/终止键杀工具
+            通过杀进程实现，Python 侧 segfault/内存膨胀不会带崩主进程。
+        -->
+        <service
+            android:name="com.niki914.nexus.agentic.chat.agentic.python.PythonWorkerService"
+            android:process=":python"
+            android:exported="false" />
+    </application>
 
 </manifest>

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/LLMController.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/LLMController.kt
@@ -9,6 +9,7 @@ import com.niki914.nexus.agentic.chat.agentic.ToolManager
 import com.niki914.nexus.agentic.chat.agentic.accessibility.AccessibilityController
 import com.niki914.nexus.agentic.chat.agentic.mcp.McpDiscoveryCacheStore
 import com.niki914.nexus.agentic.chat.agentic.shell.TerminalSessionPool
+import com.niki914.nexus.agentic.chat.agentic.python.PyRuntime
 import com.niki914.nexus.agentic.chat.agentic.stream.LlmStreamEventMapper
 import com.niki914.nexus.agentic.runtime.R
 import com.niki914.nexus.agentic.runtime.settings.RuntimeEnvironment
@@ -255,11 +256,19 @@ object LLMController {
     }.flowOn(Dispatchers.IO)
 
     suspend fun resetConversation() {
+        // 先杀 python worker：Binder 调用立即断开 → 工具协程快速死亡，
+        // 新会话也不继承上一个回合的 Python 状态（超时泄漏/卡死解释器）
+        PyRuntime.kill()
         session?.resetConversation()
         TerminalSessionPool.closeAll()
     }
 
     suspend fun stopCurrentRound(keepCurrentTurn: Boolean = false) {
+        // 先杀 python worker：终止键语义 = 杀掉仍在运行的 Python 工具（进程级硬杀）。
+        // 必须放在 session.stop() 之前——s3ss10n 的 stop 会 join 等待工具协程，
+        // 而工具协程卡在 Binder 调用上（worker 里 Python 还在跑），
+        // 不先杀进程，stop 会一直挂到 Python 自然结束。
+        PyRuntime.kill()
         session?.stop(keepCurrentTurn = keepCurrentTurn)
     }
 

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/LLMController.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/LLMController.kt
@@ -256,19 +256,24 @@ object LLMController {
     }.flowOn(Dispatchers.IO)
 
     suspend fun resetConversation() {
-        // 先杀 python worker：Binder 调用立即断开 → 工具协程快速死亡，
-        // 新会话也不继承上一个回合的 Python 状态（超时泄漏/卡死解释器）
+        // 先杀 python worker / 关 terminal 会话：Binder 调用与 exec 立即结束，
+        // 工具协程快速死亡，新会话不继承上一个回合的工具状态
         PyRuntime.kill()
-        session?.resetConversation()
         TerminalSessionPool.closeAll()
+        session?.resetConversation()
     }
 
     suspend fun stopCurrentRound(keepCurrentTurn: Boolean = false) {
-        // 先杀 python worker：终止键语义 = 杀掉仍在运行的 Python 工具（进程级硬杀）。
-        // 必须放在 session.stop() 之前——s3ss10n 的 stop 会 join 等待工具协程，
-        // 而工具协程卡在 Binder 调用上（worker 里 Python 还在跑），
-        // 不先杀进程，stop 会一直挂到 Python 自然结束。
+        // 终止键语义 = 杀掉仍在运行的工具，必须先杀后 stop：
+        // - PyRuntime.kill()：python 工具在独立进程，杀进程使 Binder 调用断开
+        // - TerminalSessionPool.closeAll()：terminal 工具没有独立进程，
+        //   协程取消传播不可靠（命令进程不随取消终止，exec 的 coroutineScope
+        //   会等子协程，且 executeForegroundLocal 取消时会话泄漏）。
+        //   关会话 → session.state 变 Closed → 正在执行的 exec 走
+        //   SessionTerminated 正常路径返回 → 工具协程立即结束。
+        // 不先杀，s3ss10n 的 stop 会 join 等待工具协程直到命令自然结束。
         PyRuntime.kill()
+        TerminalSessionPool.closeAll()
         session?.stop(keepCurrentTurn = keepCurrentTurn)
     }
 

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/python/IPythonWorkerService.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/python/IPythonWorkerService.kt
@@ -1,0 +1,127 @@
+package com.niki914.nexus.agentic.chat.agentic.python
+
+import android.os.Binder
+import android.os.IBinder
+import android.os.IInterface
+import android.os.Parcel
+
+/**
+ * Binder interface to the Python worker running in the dedicated `:python` process.
+ *
+ * All three methods are synchronous (blocking) calls:
+ * - [exec] blocks until the Python code finishes or its own join timeout fires
+ *   (returns the `TimeoutError` text). If the interpreter is hard-stuck (native
+ *   code holding the GIL), the call may never return — the client must wrap it
+ *   in a timeout and then call [kill].
+ * - [ping] performs a fast interpreter probe; it also never returns when the
+ *   interpreter is stuck. The client uses it to detect a dead interpreter
+ *   before paying a full exec timeout.
+ * - [kill] destroys the worker process without touching the interpreter
+ *   (always executable while a Binder thread is free).
+ */
+interface IPythonWorkerService : IInterface {
+    fun exec(code: String?, timeoutMs: Long): String?
+    fun ping(): String?
+    fun kill()
+
+    abstract class Stub : Binder(), IPythonWorkerService {
+        init {
+            attachInterface(this, DESCRIPTOR)
+        }
+
+        override fun asBinder(): IBinder = this
+
+        override fun onTransact(code: Int, data: Parcel, reply: Parcel?, flags: Int): Boolean {
+            when (code) {
+                TRANSACTION_exec -> {
+                    data.enforceInterface(DESCRIPTOR)
+                    val codeText = data.readString()
+                    val timeoutMs = data.readLong()
+                    val result = exec(codeText, timeoutMs)
+                    reply?.writeNoException()
+                    reply?.writeString(result)
+                    return true
+                }
+
+                TRANSACTION_ping -> {
+                    data.enforceInterface(DESCRIPTOR)
+                    val result = ping()
+                    reply?.writeNoException()
+                    reply?.writeString(result)
+                    return true
+                }
+
+                TRANSACTION_kill -> {
+                    data.enforceInterface(DESCRIPTOR)
+                    kill()
+                    reply?.writeNoException()
+                    return true
+                }
+
+                else -> return super.onTransact(code, data, reply, flags)
+            }
+        }
+
+        companion object {
+            private const val DESCRIPTOR =
+                "com.niki914.nexus.agentic.chat.agentic.python.IPythonWorkerService"
+            private const val TRANSACTION_exec = 1
+            private const val TRANSACTION_ping = 2
+            private const val TRANSACTION_kill = 3
+
+            fun asInterface(obj: IBinder?): IPythonWorkerService? {
+                if (obj == null) return null
+                val iin = obj.queryLocalInterface(DESCRIPTOR)
+                if (iin != null && iin is IPythonWorkerService) return iin
+                return Proxy(obj)
+            }
+        }
+
+        private class Proxy(private val remote: IBinder) : IPythonWorkerService {
+            override fun asBinder(): IBinder = remote
+
+            override fun exec(code: String?, timeoutMs: Long): String? {
+                val data = Parcel.obtain()
+                val reply = Parcel.obtain()
+                try {
+                    data.writeInterfaceToken(DESCRIPTOR)
+                    data.writeString(code)
+                    data.writeLong(timeoutMs)
+                    remote.transact(TRANSACTION_exec, data, reply, 0)
+                    reply.readException()
+                    return reply.readString()
+                } finally {
+                    reply.recycle()
+                    data.recycle()
+                }
+            }
+
+            override fun ping(): String? {
+                val data = Parcel.obtain()
+                val reply = Parcel.obtain()
+                try {
+                    data.writeInterfaceToken(DESCRIPTOR)
+                    remote.transact(TRANSACTION_ping, data, reply, 0)
+                    reply.readException()
+                    return reply.readString()
+                } finally {
+                    reply.recycle()
+                    data.recycle()
+                }
+            }
+
+            override fun kill() {
+                val data = Parcel.obtain()
+                val reply = Parcel.obtain()
+                try {
+                    data.writeInterfaceToken(DESCRIPTOR)
+                    remote.transact(TRANSACTION_kill, data, reply, 0)
+                    reply.readException()
+                } finally {
+                    reply.recycle()
+                    data.recycle()
+                }
+            }
+        }
+    }
+}

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/python/PyRuntime.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/python/PyRuntime.kt
@@ -8,6 +8,8 @@ import android.os.DeadObjectException
 import android.os.IBinder
 import android.os.RemoteException
 import com.niki914.nexus.xposed.api.util.ContextProvider
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
@@ -46,9 +48,10 @@ class PythonWorkerUnavailableException :
  */
 object PyRuntime {
 
-    // 锁死检测的 ping 窗口：也覆盖 Chaquopy 冷启动（Python.start 首次可达数秒）。
-    // ping 只是预检优化——真正的锁死由 exec 的 timeout+2s 兜底，放宽窗口不损失正确性。
-    private const val PING_TIMEOUT_MS = 10_000L
+    // 锁死检测的 ping 窗口：与 worker 的 30s 初始化上限对齐，覆盖慢设备冷启动
+    // （Python.start 首次可达数十秒）。ping 只是预检优化——真正的锁死由 exec
+    // 的 timeout+2s 兜底，放宽窗口不损失正确性。
+    private const val PING_TIMEOUT_MS = 30_000L
     private const val EXEC_GRACE_MS = 2_000L
     private const val CONNECT_TIMEOUT_MS = 10_000L
     private const val PROCESS_DIE_SETTLE_MS = 200L
@@ -80,6 +83,8 @@ object PyRuntime {
         testService = null
         pingTimeoutMsOverride = null
         pythonUsed = false
+        terminatePending = false
+        activeExecCount.set(0)
         service = null
         bound = false
         appContext = null
@@ -88,6 +93,18 @@ object PyRuntime {
     /** True when the current worker process has executed python since warm-up. */
     @Volatile
     private var pythonUsed = false
+
+    /**
+     * P1 竞态收口：kill() 在 service 为 null（killAndReconnect 的重连窗口内）
+     * 时无法立即杀进程，把终止意图记在这里；killAndReconnect 完成 bind 后
+     * 检查并消费，杀掉刚重连的 worker，让在途 exec 终止。
+     * 仅在 exec 在途时记录（activeExecCount > 0），避免 idle 状态的终止键
+     * 污染下一次调用。
+     */
+    @Volatile
+    private var terminatePending = false
+
+    private val activeExecCount = AtomicInteger(0)
 
     private val connection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
@@ -122,6 +139,15 @@ object PyRuntime {
      */
     suspend fun exec(code: String, timeoutMs: Long): String {
         pythonUsed = true
+        activeExecCount.incrementAndGet()
+        try {
+            return execInternal(code, timeoutMs)
+        } finally {
+            activeExecCount.decrementAndGet()
+        }
+    }
+
+    private suspend fun execInternal(code: String, timeoutMs: Long): String {
         ensureConnected()
         var svc = testService ?: service ?: throw PythonWorkerUnavailableException()
         if (!isHealthy(svc)) {
@@ -140,8 +166,17 @@ object PyRuntime {
     suspend fun kill() {
         if (!pythonUsed) return
         pythonUsed = false
-        val target = testService ?: service ?: return
+        val target = testService ?: service
         service = null
+        if (target == null) {
+            // 重连窗口内（service 尚未就绪）且有 exec 在途：记下终止意图，
+            // 由 killAndReconnect 在 bind 完成后收口——否则在途 exec 会继续
+            // 使用重连后的新 worker。idle 状态下不记录，避免污染下一次调用。
+            if (activeExecCount.get() > 0) {
+                terminatePending = true
+            }
+            return
+        }
         try {
             withContext(Dispatchers.IO) { target.kill() }
         } catch (_: Throwable) {
@@ -244,6 +279,20 @@ object PyRuntime {
                 bound = false
             }
             bindLocked(ctx)
+            if (terminatePending) {
+                // 重连期间终止键已按：杀掉刚重连的 worker，终止在途 exec。
+                // 消费掉 pending，避免误伤后续调用。
+                terminatePending = false
+                val fresh = service
+                service = null
+                fresh?.let {
+                    try {
+                        withContext(Dispatchers.IO) { it.kill() }
+                    } catch (_: Throwable) {
+                    }
+                }
+                throw CancellationException("Python worker terminated during reconnect")
+            }
         }
     }
 }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/python/PyRuntime.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/python/PyRuntime.kt
@@ -1,62 +1,225 @@
 package com.niki914.nexus.agentic.chat.agentic.python
 
-import com.chaquo.python.Python
-import com.chaquo.python.android.AndroidPlatform
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.DeadObjectException
+import android.os.IBinder
+import android.os.RemoteException
 import com.niki914.nexus.xposed.api.util.ContextProvider
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+
+class PythonWorkerUnavailableException :
+    IllegalStateException("Python worker is not connected")
 
 /**
- * Singleton that wraps Chaquopy's embedded Python runtime.
+ * Client for the Python worker in the dedicated `:python` process.
  *
- * Call [warmUp] during [Application.onCreate] (inside a coroutine) to
- * start the Python interpreter on a background thread before the first
- * tool invocation.  [warmUp] is idempotent — subsequent calls are no-ops
- * once the interpreter is running.
+ * Executes code through [IPythonWorkerService] with a two-layer timeout:
+ * 1. [exec] first pings the interpreter (2s) to detect a hard-stuck
+ *    interpreter before paying the full exec timeout. On failure the worker
+ *    process is killed and reconnected once, then the call is retried.
+ * 2. The exec call itself is wrapped in `timeoutMs + 2s`. A normal timeout
+ *    returns promptly from `runtime.exec_code` (it joins its own worker
+ *    thread), so exceeding the wrapper means the interpreter is stuck in
+ *    native code — the worker process is killed and the
+ *    [TimeoutCancellationException] rethrown so callers report TIMEOUT.
  *
- * Call [exec] from a coroutine context to run Python code and collect
- * its stdout as a plain string.
+ * [warmUp] should be called during [android.app.Application.onCreate] to
+ * bring up the worker process and start the interpreter early. [kill] is
+ * wired to the round-terminate path so stopping a turn hard-stops any
+ * in-flight Python tool.
+ *
+ * The Binder call is blocking, so every interaction is dispatched through
+ * [Dispatchers.IO] — this is what makes [withTimeout] able to fire: it
+ * cancels at the `withContext` boundary while the underlying Binder thread
+ * stays blocked until the worker process dies.
  */
 object PyRuntime {
 
-    @Volatile
-    private var started = false
+    private const val PING_TIMEOUT_MS = 2_000L
+    private const val EXEC_GRACE_MS = 2_000L
+    private const val CONNECT_TIMEOUT_MS = 10_000L
+    private const val PROCESS_DIE_SETTLE_MS = 200L
 
-    /**
-     * Start the Chaquopy Python interpreter.
-     *
-     * Waits for [ContextProvider] to be available (synchronous in practice —
-     * [ContextProvider.provide] is called during [Application.onCreate]).
-     * Safe to call multiple times; only the first call has any effect.
-     */
+    private val connectionMutex = Mutex()
+
+    @Volatile
+    private var service: IPythonWorkerService? = null
+
+    @Volatile
+    private var bound = false
+
+    @Volatile
+    private var appContext: Context? = null
+
+    /** 每次 bind 重建：完成后 [connection] 回调读最新实例。 */
+    @Volatile
+    private var pendingBinder = CompletableDeferred<IBinder?>()
+
+    /** Test hook: when set, all calls bypass the Binder layer. */
+    @Volatile
+    internal var testService: IPythonWorkerService? = null
+
+    internal fun resetForTest() {
+        testService = null
+        pythonUsed = false
+        service = null
+        bound = false
+        appContext = null
+    }
+
+    /** True when the current worker process has executed python since warm-up. */
+    @Volatile
+    private var pythonUsed = false
+
+    private val connection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+            binder?.linkToDeath(deathRecipient, 0)
+            pendingBinder.complete(binder)
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            service = null
+        }
+    }
+
+    private val deathRecipient = IBinder.DeathRecipient {
+        service = null
+    }
+
     suspend fun warmUp() {
-        if (started) return
-        val ctx = ContextProvider.await().applicationContext
-        Python.start(AndroidPlatform(ctx))
-        started = true
+        ensureConnected()
     }
 
     /**
-     * Execute Python code and return the captured stdout.
-     *
-     * If the interpreter has not been started yet (e.g. the warm-up
-     * coroutine has not run), [warmUp] is called inline.
-     *
-     * @param code      Python 3.11 source code. Print the final result
-     *                  to stdout; stderr is appended after stdout.
-     * @param timeoutMs Kotlin-side hard timeout in milliseconds (default 30000).
-     *                  Python receives timeoutMs / 1000.0 as a float so
-     *                  sub-second precision is preserved.
-     * @return Captured stdout/stderr string.
+     * Execute Python code in the worker process and return captured stdout.
+     * Never returns a stuck result: a hard-stuck interpreter is killed and
+     * the connection re-established before the retry.
      */
-    suspend fun exec(code: String, timeoutMs: Long = 30_000): String =
-        withTimeout(timeoutMs + 2_000L) {
-            withContext(Dispatchers.Default) {
-                if (!started) warmUp()
-                val py = Python.getInstance()
-                val runtime = py.getModule("runtime")
-                runtime.callAttr("exec_code", code, timeoutMs / 1000.0).toString()
+    suspend fun exec(code: String, timeoutMs: Long): String {
+        pythonUsed = true
+        ensureConnected()
+        var svc = testService ?: service ?: throw PythonWorkerUnavailableException()
+        val healthy = withTimeoutOrNull(PING_TIMEOUT_MS) {
+            try {
+                withContext(Dispatchers.IO) { svc.ping() } != null
+            } catch (_: RemoteException) {
+                false
+            } catch (_: DeadObjectException) {
+                false
+            }
+        } ?: false
+        if (!healthy) {
+            killAndReconnect()
+            svc = testService ?: service ?: throw PythonWorkerUnavailableException()
+        }
+        return execOn(svc, code, timeoutMs)
+    }
+
+    /** Kill the worker process — used by the round-terminate path. */
+    suspend fun kill() {
+        if (!pythonUsed) return
+        pythonUsed = false
+        val target = testService ?: service ?: return
+        service = null
+        try {
+            withContext(Dispatchers.IO) { target.kill() }
+        } catch (_: Throwable) {
+            // process dies mid-transact — expected
+        }
+    }
+
+    private suspend fun execOn(svc: IPythonWorkerService, code: String, timeoutMs: Long): String {
+        try {
+            return withTimeout(timeoutMs + EXEC_GRACE_MS) {
+                withContext(Dispatchers.IO) { svc.exec(code, timeoutMs) }
+            } ?: ""
+        } catch (e: TimeoutCancellationException) {
+            killAndReconnect()
+            throw e
+        } catch (e: RemoteException) {
+            service = null
+            throw PythonWorkerUnavailableException()
+        }
+    }
+
+    private suspend fun ensureConnected() {
+        if (testService != null || service != null) return
+        connectionMutex.withLock {
+            if (testService != null || service != null) return
+            val ctx = ContextProvider.await().applicationContext
+            appContext = ctx
+            bindLocked(ctx)
+        }
+    }
+
+    private suspend fun bindLocked(ctx: Context) {
+        if (bound) {
+            try {
+                ctx.unbindService(connection)
+            } catch (_: Exception) {
+            }
+            bound = false
+        }
+        bound = try {
+            ctx.bindService(
+                Intent(ctx, PythonWorkerService::class.java),
+                connection,
+                Context.BIND_AUTO_CREATE
+            )
+        } catch (_: Throwable) {
+            false
+        }
+        if (!bound) {
+            service = null
+            return
+        }
+        pendingBinder = CompletableDeferred()
+        val binder = withTimeoutOrNull(CONNECT_TIMEOUT_MS) { pendingBinder.await() }
+        if (binder == null) {
+            bound = false
+            service = null
+            try {
+                ctx.unbindService(connection)
+            } catch (_: Exception) {
+            }
+            return
+        }
+        service = IPythonWorkerService.Stub.asInterface(binder)
+    }
+
+    private suspend fun killAndReconnect() {
+        pythonUsed = false
+        val target = testService ?: service
+        service = null
+        if (target != null) {
+            try {
+                withContext(Dispatchers.IO) { target.kill() }
+            } catch (_: Throwable) {
             }
         }
+        if (testService != null) return
+        connectionMutex.withLock {
+            delay(PROCESS_DIE_SETTLE_MS)
+            val ctx = appContext ?: return@withLock
+            if (bound) {
+                try {
+                    ctx.unbindService(connection)
+                } catch (_: Exception) {
+                }
+                bound = false
+            }
+            bindLocked(ctx)
+        }
+    }
 }

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/python/PyRuntime.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/python/PyRuntime.kt
@@ -46,7 +46,9 @@ class PythonWorkerUnavailableException :
  */
 object PyRuntime {
 
-    private const val PING_TIMEOUT_MS = 2_000L
+    // 锁死检测的 ping 窗口：也覆盖 Chaquopy 冷启动（Python.start 首次可达数秒）。
+    // ping 只是预检优化——真正的锁死由 exec 的 timeout+2s 兜底，放宽窗口不损失正确性。
+    private const val PING_TIMEOUT_MS = 10_000L
     private const val EXEC_GRACE_MS = 2_000L
     private const val CONNECT_TIMEOUT_MS = 10_000L
     private const val PROCESS_DIE_SETTLE_MS = 200L
@@ -70,8 +72,13 @@ object PyRuntime {
     @Volatile
     internal var testService: IPythonWorkerService? = null
 
+    /** Test hook: shorten the ping window so stuck-interpreter tests run fast. */
+    @Volatile
+    internal var pingTimeoutMsOverride: Long? = null
+
     internal fun resetForTest() {
         testService = null
+        pingTimeoutMsOverride = null
         pythonUsed = false
         service = null
         bound = false
@@ -99,6 +106,13 @@ object PyRuntime {
 
     suspend fun warmUp() {
         ensureConnected()
+        // 等待解释器真正就绪（幂等）：Python.start 在 worker 的 HandlerThread
+        // 异步执行，首次调用若未就绪会让 ping 误判为卡死并触发杀进程重连。
+        val svc = testService ?: service ?: return
+        if (!isHealthy(svc)) {
+            // 启动窗口未完成——留给首次 exec 的重连逻辑处理，预热不杀进程
+            return
+        }
     }
 
     /**
@@ -110,18 +124,14 @@ object PyRuntime {
         pythonUsed = true
         ensureConnected()
         var svc = testService ?: service ?: throw PythonWorkerUnavailableException()
-        val healthy = withTimeoutOrNull(PING_TIMEOUT_MS) {
-            try {
-                withContext(Dispatchers.IO) { svc.ping() } != null
-            } catch (_: RemoteException) {
-                false
-            } catch (_: DeadObjectException) {
-                false
-            }
-        } ?: false
-        if (!healthy) {
+        if (!isHealthy(svc)) {
             killAndReconnect()
             svc = testService ?: service ?: throw PythonWorkerUnavailableException()
+            // 新进程冷启动中：等待就绪再执行，避免未就绪的 exec 被兜底超时
+            // 误判为卡死而再次杀进程（循环重连）
+            if (!isHealthy(svc)) {
+                throw PythonWorkerUnavailableException()
+            }
         }
         return execOn(svc, code, timeoutMs)
     }
@@ -138,6 +148,19 @@ object PyRuntime {
             // process dies mid-transact — expected
         }
     }
+
+    private fun pingTimeoutMs(): Long = pingTimeoutMsOverride ?: PING_TIMEOUT_MS
+
+    private suspend fun isHealthy(svc: IPythonWorkerService): Boolean =
+        withTimeoutOrNull(pingTimeoutMs()) {
+            try {
+                withContext(Dispatchers.IO) { svc.ping() } != null
+            } catch (_: RemoteException) {
+                false
+            } catch (_: DeadObjectException) {
+                false
+            }
+        } ?: false
 
     private suspend fun execOn(svc: IPythonWorkerService, code: String, timeoutMs: Long): String {
         try {
@@ -199,7 +222,8 @@ object PyRuntime {
     }
 
     private suspend fun killAndReconnect() {
-        pythonUsed = false
+        // 注意：不重置 pythonUsed。重连后的在途 exec 仍是本次周期内的 Python 工具，
+        // 终止键必须能杀掉它（P1：健康检查失败后的重连不能关闭终止保护）。
         val target = testService ?: service
         service = null
         if (target != null) {

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/python/PythonWorkerService.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/python/PythonWorkerService.kt
@@ -1,0 +1,92 @@
+package com.niki914.nexus.agentic.chat.agentic.python
+
+import android.app.Service
+import android.content.Intent
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.IBinder
+import android.os.Process
+import com.chaquo.python.Python
+import com.chaquo.python.android.AndroidPlatform
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Runs Chaquopy in the dedicated `:python` process (declared in
+ * `agent-runtime/src/main/AndroidManifest.xml`).
+ *
+ * Timeout model (see [IPythonWorkerService]):
+ * - Normal timeout: `runtime.exec_code` joins its worker thread for
+ *   `timeoutMs` and returns a `TimeoutError` text — no process kill, the
+ *   interpreter stays healthy and reusable.
+ * - Hard-stuck interpreter (native code holding the GIL): the Binder call
+ *   never returns; the client's `withTimeout` fires and it invokes [kill],
+ *   which destroys this process — the only reliable way to reclaim a stuck
+ *   Python interpreter.
+ *
+ * Python is initialized on a dedicated [HandlerThread] so the interpreter's
+ * "main thread" is stable for the process lifetime. Binder threads may call
+ * `callAttr` from anywhere (GIL serializes entry), same as the previous
+ * in-process implementation.
+ */
+class PythonWorkerService : Service() {
+
+    private val pythonThread = HandlerThread("python-main").apply { start() }
+    private val pythonHandler = Handler(pythonThread.looper)
+    private val ready = CountDownLatch(1)
+
+    @Volatile
+    private var initFailure: Throwable? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        pythonHandler.post {
+            try {
+                Python.start(AndroidPlatform(applicationContext))
+            } catch (t: Throwable) {
+                initFailure = t
+            } finally {
+                ready.countDown()
+            }
+        }
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = Stub()
+
+    override fun onDestroy() {
+        pythonThread.quitSafely()
+        super.onDestroy()
+    }
+
+    private fun awaitReady() {
+        if (!ready.await(30, TimeUnit.SECONDS)) {
+            throw IllegalStateException("Python interpreter failed to start within 30s")
+        }
+        initFailure?.let { throw it }
+    }
+
+    private inner class Stub : IPythonWorkerService.Stub() {
+        override fun exec(code: String?, timeoutMs: Long): String? {
+            awaitReady()
+            val py = Python.getInstance()
+            val runtime = py.getModule("runtime")
+            return runtime.callAttr(
+                "exec_code",
+                code ?: "",
+                timeoutMs / 1000.0
+            ).toString()
+        }
+
+        override fun ping(): String? {
+            awaitReady()
+            val py = Python.getInstance()
+            return py.getModule("time").callAttr("time").toString()
+        }
+
+        override fun kill() {
+            // Never touches the interpreter — always executable while any
+            // Binder thread is free. The process dies, reclaiming everything.
+            Process.killProcess(Process.myPid())
+        }
+    }
+}

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/python/PyRuntimeTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/python/PyRuntimeTest.kt
@@ -21,7 +21,9 @@ class PyRuntimeTest {
         var execResult: String? = "ok"
         var execBlockMs: Long = 0L
         var pingBlockMs: Long = 0L
+        var pingCalls = 0
         var killed = false
+        var killCount = 0
         var execCalls = 0
 
         override fun exec(code: String?, timeoutMs: Long): String? {
@@ -31,12 +33,15 @@ class PyRuntimeTest {
         }
 
         override fun ping(): String? {
-            if (pingBlockMs > 0) Thread.sleep(pingBlockMs)
+            // 只在第一次 ping 阻塞：重连后的第二次 ping 应恢复正常（模拟新进程）
+            val block = if (pingCalls++ == 0) pingBlockMs else 0L
+            if (block > 0) Thread.sleep(block)
             return "0"
         }
 
         override fun kill() {
             killed = true
+            killCount++
         }
     }
 
@@ -69,7 +74,10 @@ class PyRuntimeTest {
 
     @Test
     fun `exec hard-stuck interpreter kills worker and rethrows timeout`() = runBlocking {
-        val fake = FakeWorker().also { PyRuntime.testService = it }
+        val fake = FakeWorker().also {
+            PyRuntime.testService = it
+            PyRuntime.pingTimeoutMsOverride = 200
+        }
         fake.execBlockMs = 10_000L // blocks past the withTimeout wrapper (30ms + 2s grace)
 
         var caught: Throwable? = null
@@ -85,7 +93,10 @@ class PyRuntimeTest {
 
     @Test
     fun `stuck ping kills worker then retries exec`() = runBlocking {
-        val fake = FakeWorker().also { PyRuntime.testService = it }
+        val fake = FakeWorker().also {
+            PyRuntime.testService = it
+            PyRuntime.pingTimeoutMsOverride = 200
+        }
         fake.pingBlockMs = 10_000L // interpreter unresponsive
 
         val result = PyRuntime.exec("print('hi')", 30L)
@@ -94,6 +105,23 @@ class PyRuntimeTest {
         assertTrue(fake.killed)
         assertEquals(1, fake.execCalls)
         assertEquals("ok", result)
+    }
+
+    @Test
+    fun `kill after reconnect still hard-stops the in-flight exec`() = runBlocking {
+        // P1 回归：健康检查失败触发 killAndReconnect 后，重连的在途 exec
+        // 必须仍处于终止保护内——终止键不能因 pythonUsed 被重置而放行。
+        val fake = FakeWorker().also {
+            PyRuntime.testService = it
+            PyRuntime.pingTimeoutMsOverride = 200
+        }
+        fake.pingBlockMs = 10_000L // 首次 ping 卡死 → killAndReconnect（kill #1）
+
+        PyRuntime.exec("print('hi')", 30L) // 重连后 retry 成功
+
+        PyRuntime.kill() // 终止键
+
+        assertEquals(2, fake.killCount) // #1 来自 ping 卡死，#2 来自终止键
     }
 
     @Test

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/python/PyRuntimeTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/python/PyRuntimeTest.kt
@@ -1,0 +1,118 @@
+package com.niki914.nexus.agentic.chat.agentic.python
+
+import android.os.IBinder
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * 用 runBlocking（真实时间）而不是 runTest（虚拟时钟）：
+ * 超时路径依赖 withTimeout 对真实阻塞线程的取消，虚拟时钟下时序不可控。
+ */
+class PyRuntimeTest {
+
+    private class FakeWorker : IPythonWorkerService {
+        override fun asBinder(): IBinder = error("not used in tests")
+
+        var execResult: String? = "ok"
+        var execBlockMs: Long = 0L
+        var pingBlockMs: Long = 0L
+        var killed = false
+        var execCalls = 0
+
+        override fun exec(code: String?, timeoutMs: Long): String? {
+            execCalls++
+            if (execBlockMs > 0) Thread.sleep(execBlockMs)
+            return execResult
+        }
+
+        override fun ping(): String? {
+            if (pingBlockMs > 0) Thread.sleep(pingBlockMs)
+            return "0"
+        }
+
+        override fun kill() {
+            killed = true
+        }
+    }
+
+    @After
+    fun tearDown() {
+        PyRuntime.resetForTest()
+    }
+
+    @Test
+    fun `exec normal path returns worker result`() = runBlocking {
+        val fake = FakeWorker().also { PyRuntime.testService = it }
+
+        val result = PyRuntime.exec("print('hi')", 30_000L)
+
+        assertEquals("ok", result)
+        assertEquals(1, fake.execCalls)
+        assertFalse(fake.killed)
+    }
+
+    @Test
+    fun `exec normal timeout returns TimeoutError text without killing`() = runBlocking {
+        val fake = FakeWorker().also { PyRuntime.testService = it }
+        fake.execResult = "Execution timed out after 30s\n\nPartial output:\n"
+
+        val result = PyRuntime.exec("import time; time.sleep(999)", 30_000L)
+
+        assertTrue(result.contains("timed out after"))
+        assertFalse(fake.killed)
+    }
+
+    @Test
+    fun `exec hard-stuck interpreter kills worker and rethrows timeout`() = runBlocking {
+        val fake = FakeWorker().also { PyRuntime.testService = it }
+        fake.execBlockMs = 10_000L // blocks past the withTimeout wrapper (30ms + 2s grace)
+
+        var caught: Throwable? = null
+        try {
+            PyRuntime.exec("while True: pass", 30L)
+        } catch (t: Throwable) {
+            caught = t
+        }
+
+        assertTrue(fake.killed)
+        assertTrue(caught is TimeoutCancellationException)
+    }
+
+    @Test
+    fun `stuck ping kills worker then retries exec`() = runBlocking {
+        val fake = FakeWorker().also { PyRuntime.testService = it }
+        fake.pingBlockMs = 10_000L // interpreter unresponsive
+
+        val result = PyRuntime.exec("print('hi')", 30L)
+
+        // 测试模式无法真正重连：kill 后复用同一 fake 重试（生产路径是重新 bind 新进程）
+        assertTrue(fake.killed)
+        assertEquals(1, fake.execCalls)
+        assertEquals("ok", result)
+    }
+
+    @Test
+    fun `kill is no-op when python was never used this warm cycle`() = runBlocking {
+        val fake = FakeWorker().also { PyRuntime.testService = it }
+
+        PyRuntime.kill()
+
+        assertFalse(fake.killed)
+    }
+
+    @Test
+    fun `kill after exec hard-stops the worker`() = runBlocking {
+        val fake = FakeWorker().also { PyRuntime.testService = it }
+        PyRuntime.exec("print('hi')", 30_000L)
+        assertFalse(fake.killed)
+
+        PyRuntime.kill()
+
+        assertTrue(fake.killed)
+    }
+}

--- a/app/src/main/java/com/niki914/nexus/agentic/app/App.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/App.kt
@@ -2,8 +2,6 @@ package com.niki914.nexus.agentic.app
 
 import android.app.ActivityManager
 import android.app.Application
-import android.content.Context
-import android.os.Process
 import androidx.appcompat.app.AppCompatDelegate
 import com.google.android.material.color.DynamicColors
 import com.niki914.nexus.agentic.chat.agentic.python.PyRuntime
@@ -51,10 +49,10 @@ class App : Application() {
     }
 
     private fun isPythonWorkerProcess(): Boolean {
-        val manager = getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
-            ?: return false
-        return manager.runningAppProcesses?.any {
-            it.pid == Process.myPid() && it.processName == "$packageName:python"
-        } ?: false
+        // getMyMemoryState 是官方静态 API（API 23+，无权限），比 runningAppProcesses
+        // （官方标注仅用于调试/进程管理 UI）更适合作为核心分支判断。
+        val info = ActivityManager.RunningAppProcessInfo()
+        ActivityManager.getMyMemoryState(info)
+        return info.processName == "$packageName:python"
     }
 }

--- a/app/src/main/java/com/niki914/nexus/agentic/app/App.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/App.kt
@@ -1,6 +1,9 @@
 package com.niki914.nexus.agentic.app
 
+import android.app.ActivityManager
 import android.app.Application
+import android.content.Context
+import android.os.Process
 import androidx.appcompat.app.AppCompatDelegate
 import com.google.android.material.color.DynamicColors
 import com.niki914.nexus.agentic.chat.agentic.python.PyRuntime
@@ -21,6 +24,9 @@ class App : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        // `:python` worker 进程只需 PythonWorkerService，跳过主进程全部初始化
+        //（否则 ContextProvider 从未 provide，PyRuntime.warmUp 会永远挂起）
+        if (isPythonWorkerProcess()) return
         ContextProvider.provide(applicationContext)
         XRepo.init(this.applicationContext)
         ConversationRepo.init(this.applicationContext)
@@ -42,5 +48,13 @@ class App : Application() {
         applicationScope.launch {
             PyRuntime.warmUp()
         }
+    }
+
+    private fun isPythonWorkerProcess(): Boolean {
+        val manager = getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+            ?: return false
+        return manager.runningAppProcesses?.any {
+            it.pid == Process.myPid() && it.processName == "$packageName:python"
+        } ?: false
     }
 }


### PR DESCRIPTION
## 背景

两个 agent-loop 痛点：

1. **`execute_python` 超时不可靠**：`runtime.py` 用 `threading.Thread.join(timeout)` 做超时，Python 没有线程杀 API——超时后代码继续跑（`while True` 永久占 CPU 核、阻塞调用继续、副作用残留）；更严重的是 Chaquopy 单解释器串行，一次锁死（持有 GIL 的原生代码）会让**本会话内所有后续 python 调用固定超时**，回合被反复拖死。终止回合只取消协程，Python 照跑。
2. **终止键杀不掉运行中的工具**：python 工具卡在 Binder 调用上取消不生效；terminal 工具命令进程不随协程取消终止，`session.stop()` 的 join 被拖到命令自然结束，UI 工具行一直转圈。

## 改动

**Python 独立进程（跨进程隔离）**
- 新增 `PythonWorkerService`（`android:process=":python"`）+ 手写 Binder 接口 `IPythonWorkerService`（exec/ping/kill，跟随仓库无 .aidl 的模式）
- `PyRuntime` 重写为 IPC 客户端：bind/死亡重连；exec 前 ping 预检（2s）检测锁死解释器 → kill + 重连 + 重试；exec 超时兜底（timeout+2s，超出即真锁死 → kill）
- 超时语义分层：**正常超时不杀进程**（`exec_code` 的 join 正常返回 TimeoutError 文本，解释器保持健康可复用）；**锁死才杀**；**终止键杀**
- `pythonUsed` 门控：终止只在本次预热周期用过 python 时才杀进程，避免误杀闲置预热进程

**终止键硬杀工具**
- `LLMController.stopCurrentRound` / `resetConversation`：`PyRuntime.kill()` + `TerminalSessionPool.closeAll()` **先于** `session.stop()`
  - python：杀进程 → Binder 断开 → 工具协程瞬间死亡
  - terminal：关 libterm 会话（杀 shell 进程）→ 在途 exec 走 `SessionTerminated` 正常路径返回，不依赖协程取消传播
  - 不先杀的话 s3ss10n 的 stop 会 join 等待工具协程直到命令自然结束

**其他**
- `App` 在 `:python` 进程跳过主进程全部初始化（避免 ContextProvider 挂起）
- `PyRuntimeTest` 6 个用例：正常路径 / 正常超时不杀 / 卡死杀+抛超时 / ping 卡死杀+重试 / kill 门控

## 真机验证（已通过）

- `while True: pass` 超时 → 返回 TIMEOUT，`:python` 进程存活，后续调用正常（GIL 不锁死）
- sleep 60 运行中按终止键 → `:python` 进程被杀，下次调用冷启动恢复
- terminal `sleep 30` 运行中按终止键 → 工具行立即停止，命令进程被杀

## 后续（不在本 PR）

- s3ss10n 2.2.0 联调（[s3ss10n#2](https://github.com/niki914/s3ss10n/issues/2)）：idle 超时只计 LLM 阶段、reasoning 事件发射 → Nexus thinking 展示
- terminal 取消链剩余问题：`writeInteractive` 无超时、SSH 阻塞读写、`executeForegroundLocal` 泄漏的代码结构修复

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)
