### PR TITLE
WIP: waitForStable 语义稳定双通道（viewtree 耗时优化）— blocked on logging infra

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,0 +1,72 @@
+# Handover：feat/viewtree-latency-optimization 横评任务
+
+> 写给接手本分支的 agent。你存在的唯一使命在「使命」一节；其余是完成使命所需的最小背景。
+
+## 使命
+
+日志基建（**新设计，非 xevent，设计未定**）落地后，横评 **有本 PR vs 无本 PR**（基线 `1d13338`）两种实现的 `waitForStable()` 表现——**耗时 + 正确率**。横评结论必须能支撑两个决策：
+
+1. 噪声容忍阈值 `noiseToleranceMatches`：当前 6，候选 3（合并前定）
+2. 本分支：合并 or 放弃
+
+## 状态（2026-08-04）
+
+- 分支 `feat/viewtree-latency-optimization`，提交 `48b44dd`，WIP PR [#106](https://github.com/niki914/agentic-nexus/pull/106)，**已推送未合入**
+- 阻塞原因：无法量化收益，等待日志基建
+- 完整背景见 `PRD.md`（本文件同目录，工作区未提交）；改动见 `git show 48b44dd`
+
+## 机制速览（30 秒版）
+
+`waitForStable()` 从"事件静默 300ms + 原始树 hash 相邻一致"改为**双通道退出**：
+
+- **通道 A（事件静默）**：相邻两采样 fingerprint 一致 + 事件流静默 ≥300ms → 保留低事件 app（Settings 等）旧行为
+- **通道 B（语义稳定）**：`UiStabilityTracker` 3 个相同 fingerprint 跨 ≥150ms → 容忍弱事件噪声
+- **噪声容忍（方案 B，用户拍板）**：fingerprint 连续 6 个样本不变时，即使强事件持续（generation 递增）也放行 → 修复 Spotify 播放页"树不变但强事件刷"导致每步 timeout 2–5s 的问题
+- **fingerprint**：`TreeFormatter` 一次裁剪同时产出 YAML + 64 位 FNV-1a 指纹（覆盖 type/text/desc/bounds/clickable/checked/moreSummary/截断，忽略 index/version/className）
+- 稳定或超时都**直接返回已判样本**，不再二次抓树
+
+关键文件：`AccessibilityController.kt`（waitForStable + StableSample + 双通道）、`TreeFormatter.kt`（computeSemanticFingerprint）、`UiStabilityTracker.kt`（状态机 + 事件强弱分类）。
+
+## 已有实测数据（QA 2026-08-02/03，RMX3850/Spotify，勿重复测量）
+
+| 场景 | 旧实现 | 本分支 |
+|---|---|---|
+| 普通点击（无持续事件） | 2000ms（打满 timeout） | ~950ms |
+| 播放页（强事件刷、树不变） | 2–5s（每步 TIMEOUT） | ~1.1s（噪声容忍放行） |
+| progressbar 更新**进入 YAML**（时间文本/bounds 变） | 2000ms | 2000ms（**未解决**，PRD §10.4 按设计如此） |
+
+额外发现：**timeout note 反馈环**——模型在结果里看到 `# Note: settle timed out` 后会把 `wait_ms` 灌到 3–5s（QA 实测 elapsedMs=5021）。本分支让播放页退出时不带 note，这个通胀会自然回落。这是比表面延迟更重要的收益，横评要覆盖。
+
+## 横评设计（按新基建 schema 落地时调整，事件契约先行）
+
+**埋点契约（现在就可定义，与基建无关）**：每个 `waitForStable()` 退出时记录一条事件，字段：
+`{elapsedMs, exitReason: EVENT_IDLE|SEMANTIC_STABLE|TIMEOUT, appPackage, settleTimeoutMs, sampleCount, operationType}`
+
+PRD F-09 已要求此日志；本分支已留单行 `Log.d("NexusStable", ...)`（`logSettleResult`，合并前保留）。基建落地后把同一事件埋进**两个版本**。
+
+**耗时指标**：按 app × 操作类型分组的 `elapsedMs` 分位数（p50/p90/max）+ TIMEOUT 占比。样本量：每场景 ≥30 次操作。
+
+**正确率（无 ground truth，用代理指标）**：
+- **TIMEOUT 率**：结果含 timeout note 的比例（越低越好）
+- **旧树误返回**：操作后返回树不含预期效果（如点击后节点状态未变）。脚本抽查：连续 N 次同一操作，检查返回树关键节点
+- **wait_ms 通胀**：模型传入的 `wait_ms` 分布是否回落（验证反馈环修复）
+
+**无 PR 版本获取**：旧算法已删除，从基线 `git worktree add` 基于 `1d13338` 的干净工作区编译旧版 APK，与分支版分别真机跑同一操作序列（点击/播放暂停/滚动/文本输入），logcat 采集对比。注意基线无埋点，需手工在旧版加同一埋点事件。
+
+**输出契约**：一张对比表（app × 指标 × 版本），结论给"阈值选 6 还是 3"+"合并 or 放弃"。
+
+## 待定决策与已知坑
+
+- **阈值 6 vs 3**：方案 B 文档（progress.md）写 8，代码落 6，均未确认。3 的理由：容忍窗口与 fingerprint 路径 3×150ms 是同一种保证，6×150ms 只是保守过头；播放页可从 ~1.1s 降到 ~500ms
+- **progressbar 进 YAML 场景无解**：任何"YAML 变就不稳定"的算法只能等 deadline。唯一出路是重构 fingerprint 语义（忽略不可操作节点的 bounds/text 变化——语义规则，非 class 特判），那是新 PRD
+- **PRD 未修订**：方案 B 偏离 PRD F-04/AC-04（强事件必须重置），progress.md 记录为"未定项"；合并前要么改 PRD 要么 PR 描述声明偏离
+- **QA 诊断代码**（`computeDebugChannels`/`sampleClassSignatures`/`lastStrongEventType` 等，已标"Temporary diagnostic (QA)"）：合并前删除，保留 `logSettleResult` 单行
+- **ProviderSpec.kt 混入** `deepseek-v4-flash` 改动：与本分支无关，合并前移出
+
+## 负向约束
+
+- 日志基建落地前**不要动 waitForStable 算法**（含阈值调整）——那是横评之后的事
+- 不要造第二套临时观测系统；现状就是 `logSettleResult` 单行 + QA 诊断块
+- 不要用 xevent（用户已决定弃用，新设计未定）
+- 不要引入 app/class 特判（用户明确否决硬编码路径）
+- `docs/.asc_task/` 是任务文档，不是实现证据

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/AccessibilityController.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/AccessibilityController.kt
@@ -28,6 +28,7 @@ import android.os.SystemClock
 import kotlinx.coroutines.delay
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Accessibility service interaction controller.
@@ -66,6 +67,15 @@ object AccessibilityController {
     @Volatile
     var lastUiEventTime: Long = 0L
         private set
+
+    /**
+     * Monotonic generation counter, advanced only by strong UI events
+     * (window/text/scroll/checked changes). Sampled together with each stable
+     * sample; any change invalidates an in-progress semantic-stability run.
+     */
+    private val strongUiEventGeneration = AtomicLong(0L)
+
+    val currentStrongUiEventGeneration: Long get() = strongUiEventGeneration.get()
 
     /** Set by the app module before any screen-interaction calls. */
     @Volatile
@@ -135,10 +145,33 @@ object AccessibilityController {
         nodeCache.clear()
     }
 
-    /** Called from [NexusAccessibilityService.onAccessibilityEvent] on UI-significant events. */
-    fun recordUiEvent() {
+    /**
+     * Called from [NexusAccessibilityService.onAccessibilityEvent] for every
+     * filtered accessibility event: refreshes [lastUiEventTime] for all events,
+     * but advances the strong-event generation only for strong ones.
+     */
+    fun recordUiEvent(
+        significance: UiEventSignificance,
+        eventType: Int = 0,
+        contentChangeTypes: Int = 0,
+    ) {
         lastUiEventTime = SystemClock.elapsedRealtime()
+        if (significance == UiEventSignificance.STRONG) {
+            strongUiEventGeneration.incrementAndGet()
+            lastStrongEventType = eventType
+            lastStrongContentChangeTypes = contentChangeTypes
+        }
     }
+
+    // Temporary diagnostic (QA): last strong event details for timeout
+    // root-cause logging. Delete together with the QA block.
+    @Volatile
+    var lastStrongEventType: Int = 0
+        private set
+
+    @Volatile
+    var lastStrongContentChangeTypes: Int = 0
+        private set
 
     fun clearPointerOverlay() {
         pointerOverlay?.dispose()
@@ -314,7 +347,7 @@ object AccessibilityController {
 
         ensurePointerShown()
 
-        val yaml = TreeFormatter.format(ctx.root, ctx.widthPixels, ctx.heightPixels, ctx.appPackage, currentVersion)
+        val yaml = TreeFormatter.format(ctx.root, ctx.widthPixels, ctx.heightPixels, ctx.appPackage, currentVersion).yaml
 
         if (nodeCache.size <= 1) {
             return Result.failure(
@@ -341,85 +374,308 @@ object AccessibilityController {
         return captureScreen()
     }
 
+    private data class StableSample(
+        val snapshot: ScreenSnapshot,
+        val semanticFingerprint: Long,
+        val sampleTimeMs: Long,
+        val strongEventGeneration: Long,
+        // Temporary diagnostic (QA): per-class aggregated signature for
+        // timeout root-cause logging. Delete together with the QA block.
+        val classSignatures: Map<String, ClassSig> = emptyMap(),
+        // Temporary diagnostic (QA): per-channel fingerprint components.
+        val channels: DebugChannels? = null,
+    )
+
+    private const val MIN_DWELL_MS = 200L
+    private const val POLL_INTERVAL_MS = 50L
+    private const val EVENT_IDLE_MS = 300L
+
     /**
-     * Waits for the UI to settle after a write operation using a unified
-     * event-idle + tree-hash detection loop:
+     * Waits for the UI to settle after a write operation via dual exit channels:
      *
-     * 1. Dwell at least 200ms to let post-action events arrive.
-     * 2. Sample the tree every 50ms and compare consecutive structural hashes.
-     * 3. Return when two consecutive hashes match, no accessibility event arrived
-     *    between the two samples, and the event stream has been idle for >= 300ms.
+     * - Channel A (event idle): the previous and current samples share a
+     *   semantic fingerprint, no accessibility event arrived between the two
+     *   samples, and the event stream has been idle for >= 300ms.
+     * - Channel B (semantic stable): [UiStabilityTracker] reports
+     *   SEMANTIC_STABLE (3 consecutive identical fingerprints across >= 150ms),
+     *   tolerating weak accessibility event noise.
      *
-     * Falls back to a forced capture (with a warning header) if [settleTimeoutMs]
-     * is exceeded.
+     * Both channels re-check the strong-event generation before returning, and
+     * both return the sample that was judged stable (no second capture).
+     * If [settleTimeoutMs] is exceeded, returns the last successful sample with
+     * a timeout note header.
      */
     suspend fun waitForStable(settleTimeoutMs: Long): Result<ScreenSnapshot> {
         val startTime = SystemClock.elapsedRealtime()
+        val deadline = startTime + settleTimeoutMs
 
-        // Minimum 200ms dwell to let post-action events arrive, capped at remaining deadline.
-        val remaining = settleTimeoutMs - (SystemClock.elapsedRealtime() - startTime)
-        if (remaining > 0) {
-            delay(minOf(200L, remaining))
-        }
+        val dwellRemaining = deadline - SystemClock.elapsedRealtime()
+        if (dwellRemaining > 0) delay(minOf(MIN_DWELL_MS, dwellRemaining))
 
-        refreshNodeCache()
-        var previousHash = computeStructuralHash()
-        var previousSampleTime = SystemClock.elapsedRealtime()
+        val tracker = UiStabilityTracker()
+        var previous: StableSample? = null
+        var sampleCount = 0
+        // Temporary diagnostic (QA): per-class change counters for timeout
+        // root-cause logging. Delete together with the QA block.
+        val classChangeCounts = HashMap<String, Int>()
+        val classChangeFields = HashMap<String, MutableSet<String>>()
+        val channelChangeCounts = HashMap<String, Int>()
+        var genChangeCount = 0
 
         while (true) {
-            val now = SystemClock.elapsedRealtime()
-            if (now - startTime >= settleTimeoutMs) {
-                return captureScreen().map { snapshot ->
-                    snapshot.copy(yaml = buildString {
-                        appendLine("# Note: settle timed out after ${settleTimeoutMs}ms")
-                        append(snapshot.yaml)
-                    })
+            val sample = captureStableSample()
+            sampleCount += 1
+            val now = sample.sampleTimeMs
+
+            // Temporary diagnostic (QA): count strong-generation changes
+            // between adjacent samples.
+            if (previous != null && sample.strongEventGeneration != previous.strongEventGeneration) {
+                genChangeCount += 1
+            }
+
+            // Temporary diagnostic (QA): accumulate per-channel changes.
+            val prevCh = previous?.channels
+            val curCh = sample.channels
+            if (prevCh != null && curCh != null) {
+                if (prevCh.structure != curCh.structure) channelChangeCounts["struct"] = (channelChangeCounts["struct"] ?: 0) + 1
+                if (prevCh.text != curCh.text) channelChangeCounts["text"] = (channelChangeCounts["text"] ?: 0) + 1
+                if (prevCh.offscreen != curCh.offscreen) channelChangeCounts["offscreen"] = (channelChangeCounts["offscreen"] ?: 0) + 1
+                if (prevCh.bounds != curCh.bounds) channelChangeCounts["bounds"] = (channelChangeCounts["bounds"] ?: 0) + 1
+                if (prevCh.flags != curCh.flags) channelChangeCounts["flags"] = (channelChangeCounts["flags"] ?: 0) + 1
+                if (prevCh.truncation != curCh.truncation) channelChangeCounts["trunc"] = (channelChangeCounts["trunc"] ?: 0) + 1
+            }
+
+            // Temporary diagnostic (QA): accumulate per-class signature changes.
+            val prevSigs = previous?.classSignatures
+            if (prevSigs != null) {
+                val allClasses = sample.classSignatures.keys + prevSigs.keys
+                for (cn in allClasses) {
+                    val cur = sample.classSignatures[cn]
+                    val prev = prevSigs[cn]
+                    if (cur != prev) {
+                        classChangeCounts[cn] = (classChangeCounts[cn] ?: 0) + 1
+                        val fields = classChangeFields[cn] ?: mutableSetOf<String>()
+                        if (prev == null || cur == null) {
+                            fields.add("node-count")
+                        } else {
+                            if (prev.textHash != cur.textHash) fields.add("text")
+                            if (prev.boundsHash != cur.boundsHash) fields.add("bounds")
+                            if (prev.flagsHash != cur.flagsHash) fields.add("flags")
+                        }
+                        classChangeFields[cn] = fields
+                    }
                 }
             }
-            delay(50)
-            refreshNodeCache()
-            val currentHash = computeStructuralHash()
-            val sampleTime = SystemClock.elapsedRealtime()
 
-            if (currentHash == previousHash
-                && lastUiEventTime <= previousSampleTime
-                && sampleTime - lastUiEventTime >= 300L
-            ) {
-                return captureScreen()
+            if (now >= deadline) {
+                logSettleResult(StableExitReason.TIMEOUT, now - startTime, sampleCount)
+                val channelsStr = channelChangeCounts.entries
+                    .sortedByDescending { it.value }
+                    .joinToString(" ") { (name, count) -> "$name=$count" }
+                android.util.Log.d(
+                    "NexusStable",
+                    "timeout channels: $channelsStr",
+                )
+                val lastStrongTypeName = when (lastStrongEventType) {
+                    32 -> "WINDOW_STATE_CHANGED"
+                    2048 -> "WINDOW_CONTENT_CHANGED"
+                    4194304 -> "WINDOWS_CHANGED"
+                    4096 -> "VIEW_SCROLLED"
+                    16 -> "VIEW_TEXT_CHANGED"
+                    else -> lastStrongEventType.toString()
+                }
+                android.util.Log.d(
+                    "NexusStable",
+                    "timeout genChanges=$genChangeCount lastStrongEvent=$lastStrongTypeName(0x${lastStrongContentChangeTypes.toString(16)})",
+                )
+                val topChangers = classChangeCounts.entries
+                    .sortedByDescending { it.value }
+                    .take(3)
+                    .joinToString(", ") { (cn, count) ->
+                        val fields = classChangeFields[cn]?.sorted()?.joinToString("/") ?: ""
+                        "$cn($count)[$fields]"
+                    }
+                android.util.Log.d(
+                    "NexusStable",
+                    "timeout topClassChanges: $topChangers",
+                )
+                return Result.success(sample.snapshot.copy(yaml = buildString {
+                    appendLine("# Note: settle timed out after ${settleTimeoutMs}ms")
+                    append(sample.snapshot.yaml)
+                }))
             }
 
-            previousHash = currentHash
-            previousSampleTime = sampleTime
+            val prev = previous
+            if (prev != null
+                && sample.semanticFingerprint == prev.semanticFingerprint
+                && lastUiEventTime <= prev.sampleTimeMs
+                && now - lastUiEventTime >= EVENT_IDLE_MS
+                && currentStrongUiEventGeneration == sample.strongEventGeneration
+            ) {
+                logSettleResult(StableExitReason.EVENT_IDLE, now - startTime, sampleCount)
+                return Result.success(sample.snapshot)
+            }
+
+            val decision = tracker.addSample(
+                sample.semanticFingerprint, now, sample.strongEventGeneration,
+            )
+            if (decision == StabilityDecision.SEMANTIC_STABLE
+                && (currentStrongUiEventGeneration == sample.strongEventGeneration
+                    || tracker.noiseToleranceActive())
+            ) {
+                logSettleResult(StableExitReason.SEMANTIC_STABLE, now - startTime, sampleCount)
+                return Result.success(sample.snapshot)
+            }
+
+            previous = sample
+            delay(POLL_INTERVAL_MS)
         }
     }
 
     /**
-     * Computes a version-independent structural hash of the current [nodeCache].
+     * Builds one stable-wait sample: refreshes the node cache, formats the
+     * pruned tree into YAML + semantic fingerprint in one pass, and records
+     * the sample time and strong-event generation.
      *
-     * The hash covers node count, per-node class name, bounds, text, content
-     * description, and key boolean flags — enough to detect meaningful tree
-     * changes without paying YAML serialization cost.
+     * Sampling failures propagate to the caller unchanged (the existing
+     * [refreshNodeCache] exception protocol is preserved).
      */
-    private fun computeStructuralHash(): Int {
-        var hash = nodeCache.size
-        nodeCache.entries.sortedBy { it.key }.forEach { (index, node) ->
-            hash = 31 * hash + index
-            hash = 31 * hash + (node.className?.toString().orEmpty().hashCode())
-            hash = 31 * hash + (node.text?.toString().orEmpty().hashCode())
-            hash = 31 * hash + (node.contentDescription?.toString().orEmpty().hashCode())
-            hash = 31 * hash + node.isClickable.hashCode()
-            hash = 31 * hash + node.isLongClickable.hashCode()
-            hash = 31 * hash + node.isEditable.hashCode()
-            hash = 31 * hash + node.isScrollable.hashCode()
-            hash = 31 * hash + node.isVisibleToUser.hashCode()
+    private suspend fun captureStableSample(): StableSample {
+        val ctx = refreshNodeCache()
+        ensurePointerShown()
+        val formatted = TreeFormatter.format(
+            ctx.root, ctx.widthPixels, ctx.heightPixels, ctx.appPackage, currentVersion,
+        )
+        val snapshot = ScreenSnapshot(formatted.yaml, currentVersion, nodeCache.size)
+        return StableSample(
+            snapshot = snapshot,
+            semanticFingerprint = formatted.semanticFingerprint,
+            sampleTimeMs = SystemClock.elapsedRealtime(),
+            strongEventGeneration = strongUiEventGeneration.get(),
+            classSignatures = sampleClassSignatures(ctx),
+            channels = computeDebugChannels(ctx),
+        )
+    }
+
+    // Temporary diagnostic (QA): per-channel fingerprint components over the
+    // raw tree, mirroring the fingerprint's mix-in fields so timeout logging
+    // can show which semantic channel keeps changing (structure/order/type,
+    // text, offscreen summaries, bounds, flags, truncation). Delete together
+    // with the QA block.
+    private data class DebugChannels(
+        val structure: Long,
+        val text: Long,
+        val offscreen: Long,
+        val bounds: Long,
+        val flags: Long,
+        val truncation: Long,
+    )
+
+    private fun computeDebugChannels(ctx: ScreenContext): DebugChannels {
+        var structure = 0L
+        var text = 0L
+        var offscreen = 0L
+        var bounds = 0L
+        var flags = 0L
+        var nodeCount = 0
+        var maxDepth = 0
+
+        fun walk(node: AccessibilityNodeInfo, parentType: SemanticType?, depth: Int) {
+            nodeCount += 1
+            if (depth > maxDepth) maxDepth = depth
+            val cn = node.className?.toString() ?: ""
+            val type = PruningRules.mapSemanticType(cn, parentType)
+            structure = structure * 31 + type.name.hashCode()
+            structure = structure * 31 + nodeCount
+            val nodeText = node.text?.toString().orEmpty()
+            val nodeDesc = node.contentDescription?.toString().orEmpty()
+            text = text * 31 + nodeText.hashCode()
+            text = text * 31 + nodeDesc.hashCode()
             val rect = android.graphics.Rect()
             node.getBoundsInScreen(rect)
-            hash = 31 * hash + rect.left
-            hash = 31 * hash + rect.top
-            hash = 31 * hash + rect.right
-            hash = 31 * hash + rect.bottom
+            bounds = bounds * 31 + rect.left
+            bounds = bounds * 31 + rect.top
+            bounds = bounds * 31 + rect.right
+            bounds = bounds * 31 + rect.bottom
+            flags = flags * 31 + node.isClickable.hashCode()
+            flags = flags * 31 + node.isLongClickable.hashCode()
+            flags = flags * 31 + node.isEditable.hashCode()
+            flags = flags * 31 + node.isScrollable.hashCode()
+            flags = flags * 31 + node.isChecked.hashCode()
+            if (node.isScrollable) {
+                for (i in 0 until node.childCount) {
+                    val child = node.getChild(i) ?: continue
+                    val childRect = android.graphics.Rect()
+                    child.getBoundsInScreen(childRect)
+                    if (childRect.bottom <= 0 || childRect.top >= ctx.heightPixels) {
+                        offscreen = offscreen * 31 + (child.text?.toString().orEmpty().hashCode())
+                        offscreen = offscreen * 31 + (child.contentDescription?.toString().orEmpty().hashCode())
+                    }
+                }
+            }
+            for (i in 0 until node.childCount) {
+                node.getChild(i)?.let { walk(it, type, depth + 1) }
+            }
         }
-        return hash
+
+        walk(ctx.root, null, 0)
+        val truncation = (if (nodeCount >= 200) 1L else 0L) * 31 + (if (maxDepth > 20) 1L else 0L)
+        return DebugChannels(structure, text, offscreen, bounds, flags, truncation)
+    }
+
+    // Temporary diagnostic (QA): aggregate per-class signature over the raw
+    // tree so timeout logging can show which class keeps changing and in
+    // which field channel. Delete together with the QA block.
+    private data class ClassSig(
+        val textHash: Long,
+        val boundsHash: Long,
+        val flagsHash: Long,
+    )
+
+    private fun sampleClassSignatures(ctx: ScreenContext): Map<String, ClassSig> {
+        val byClass = HashMap<String, ClassSig>()
+        val stack = ArrayDeque<AccessibilityNodeInfo>()
+        stack.add(ctx.root)
+        while (stack.isNotEmpty()) {
+            val node = stack.removeLast()
+            val className = node.className?.toString().orEmpty()
+            if (className.isNotEmpty()) {
+                val prev = byClass[className]
+                var text = prev?.textHash ?: 0L
+                var bounds = prev?.boundsHash ?: 0L
+                var flags = prev?.flagsHash ?: 0L
+                text = text * 31 + node.text?.toString().orEmpty().hashCode()
+                text = text * 31 + node.contentDescription?.toString().orEmpty().hashCode()
+                text = text * 31 + node.childCount
+                val rect = android.graphics.Rect()
+                node.getBoundsInScreen(rect)
+                bounds = bounds * 31 + rect.left
+                bounds = bounds * 31 + rect.top
+                bounds = bounds * 31 + rect.right
+                bounds = bounds * 31 + rect.bottom
+                flags = flags * 31 + node.isClickable.hashCode()
+                flags = flags * 31 + node.isLongClickable.hashCode()
+                flags = flags * 31 + node.isEditable.hashCode()
+                flags = flags * 31 + node.isScrollable.hashCode()
+                flags = flags * 31 + node.isChecked.hashCode()
+                byClass[className] = ClassSig(text, bounds, flags)
+            }
+            for (i in 0 until node.childCount) {
+                node.getChild(i)?.let { stack.add(it) }
+            }
+        }
+        return byClass
+    }
+
+    // Temporary diagnostic log (F-09): delete this entire block after QA
+    // verification — remove this function definition and the 3 standalone call
+    // lines in waitForStable (EVENT_IDLE / SEMANTIC_STABLE / TIMEOUT branches).
+    // No other logic is affected.
+    private fun logSettleResult(exitReason: StableExitReason, elapsedMs: Long, sampleCount: Int) {
+        android.util.Log.d(
+            "NexusStable",
+            "waitForStable elapsedMs=$elapsedMs exitReason=$exitReason sampleCount=$sampleCount",
+        )
     }
 
     /**

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/TreeFormatter.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/TreeFormatter.kt
@@ -13,7 +13,7 @@ object TreeFormatter {
         screenHeight: Int,
         appPackage: String,
         version: String,
-    ): String {
+    ): FormattedTree {
         val indexCounter = AtomicInteger(0)
         val nodeCounter = AtomicInteger(0)
         val depthExceeded = AtomicBoolean(false)
@@ -41,7 +41,17 @@ object TreeFormatter {
             children = nodes,
             moreSummary = emptyList(),
         )
-        return toYaml(rootNode, screenWidth, screenHeight, appPackage, version, nodeCounter, depthExceeded)
+        return FormattedTree(
+            yaml = toYaml(rootNode, screenWidth, screenHeight, appPackage, version, nodeCounter, depthExceeded),
+            semanticFingerprint = computeSemanticFingerprint(
+                rootNode,
+                screenWidth,
+                screenHeight,
+                appPackage,
+                truncatedMaxNodes = nodeCounter.get() >= 200,
+                truncatedMaxDepth = depthExceeded.get(),
+            ),
+        )
     }
 
     private fun buildTree(
@@ -222,4 +232,78 @@ object TreeFormatter {
             text
         }
     }
+
+    /**
+     * Deterministic 64-bit FNV-1a fingerprint over the pruned tree's semantic
+     * fields plus screen size, app package and truncation flags.
+     *
+     * Must stay in sync with [toYaml]: every field that can reach the YAML
+     * output is mixed in here, and fields the YAML ignores (index, version,
+     * raw class names) must not be. Traversal follows [toYaml]'s DFS order.
+     */
+    internal fun computeSemanticFingerprint(
+        root: NodeInfo,
+        screenWidth: Int,
+        screenHeight: Int,
+        appPackage: String,
+        truncatedMaxNodes: Boolean,
+        truncatedMaxDepth: Boolean,
+    ): Long {
+        var seed = FNV_OFFSET_BASIS
+        seed = mixLong(seed, screenWidth.toLong())
+        seed = mixLong(seed, screenHeight.toLong())
+        seed = mixString(seed, appPackage)
+        seed = mixNode(seed, root)
+        seed = mixLong(seed, if (truncatedMaxNodes) 1L else 0L)
+        seed = mixLong(seed, if (truncatedMaxDepth) 1L else 0L)
+        return seed
+    }
+
+    private fun mixNode(seed: Long, node: NodeInfo): Long {
+        var s = mixString(seed, node.semanticType.name)
+        s = mixString(s, node.text)
+        s = mixString(s, node.contentDesc)
+        s = mixLong(s, node.bounds.left.toLong())
+        s = mixLong(s, node.bounds.top.toLong())
+        s = mixLong(s, node.bounds.right.toLong())
+        s = mixLong(s, node.bounds.bottom.toLong())
+        s = mixLong(s, if (node.isClickable) 1L else 0L)
+        s = mixLong(s, if (node.isLongClickable) 1L else 0L)
+        s = mixLong(s, if (node.isEditable) 1L else 0L)
+        s = mixLong(s, if (node.isScrollable) 1L else 0L)
+        s = mixLong(s, if (node.isChecked) 1L else 0L)
+        s = mixString(s, node.moreSummary.joinToString(", "))
+        for (child in node.children) {
+            s = mixNode(s, child)
+        }
+        return s
+    }
+
+    private fun mixLong(seed: Long, value: Long): Long = (seed xor value) * FNV_PRIME
+
+    private fun mixString(seed: Long, value: String): Long {
+        var s = seed
+        for (c in value) {
+            s = (s xor c.code.toLong()) * FNV_PRIME
+        }
+        return s
+    }
+
+    // 0xcbf29ce484222325 (14695981039346656037) exceeds Long.MAX_VALUE, so it
+    // is written as its two's-complement form: the bit pattern is identical
+    // and FNV-1a arithmetic is unaffected.
+    private const val FNV_OFFSET_BASIS = -0x340d631b7bdddcdbL
+    private const val FNV_PRIME = 0x100000001b3L
 }
+
+/**
+ * Result of a single formatting pass: the model-visible YAML and a
+ * deterministic 64-bit semantic fingerprint over the same pruned tree.
+ *
+ * Public because it is the return type of the public [TreeFormatter.format]
+ * (same pattern as [ScreenSnapshot]).
+ */
+data class FormattedTree(
+    val yaml: String,
+    val semanticFingerprint: Long,
+)

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/UiStabilityTracker.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/accessibility/UiStabilityTracker.kt
@@ -1,0 +1,169 @@
+package com.niki914.nexus.agentic.chat.agentic.accessibility
+
+import android.view.accessibility.AccessibilityEvent
+
+/**
+ * Semantic strength of a single accessibility event: strong events may change
+ * the model-visible UI tree, weak events are tolerated as noise.
+ *
+ * Public because it appears in [AccessibilityController.recordUiEvent]'s
+ * public signature, which the app module calls (cross-module visibility).
+ */
+enum class UiEventSignificance { WEAK, STRONG }
+
+/** Outcome of feeding one sample into the semantic stability state machine. */
+internal enum class StabilityDecision { CONTINUE, SEMANTIC_STABLE }
+
+/** Why `waitForStable` exited — used only for the temporary diagnostic log. */
+internal enum class StableExitReason { EVENT_IDLE, SEMANTIC_STABLE, TIMEOUT }
+
+/**
+ * Pure classifier that grades an accessibility event's semantic strength from
+ * its event type and content-change bit flags. No Android framework state is
+ * read (no `event.source`, className or packageName).
+ *
+ * Public because the app module's NexusAccessibilityService calls it
+ * (cross-module visibility).
+ */
+object UiEventClassifier {
+
+    /**
+     * Content-change bits that indicate a model-visible semantic change.
+     * Referenced against the project's compileSdk constants; lower SDKs never
+     * report the higher bits, so plain bit arithmetic is crash-safe there.
+     */
+    private val STRONG_BITS: Int =
+        AccessibilityEvent.CONTENT_CHANGE_TYPE_TEXT or
+            AccessibilityEvent.CONTENT_CHANGE_TYPE_CONTENT_DESCRIPTION or
+            AccessibilityEvent.CONTENT_CHANGE_TYPE_CHECKED or
+            AccessibilityEvent.CONTENT_CHANGE_TYPE_STATE_DESCRIPTION or
+            AccessibilityEvent.CONTENT_CHANGE_TYPE_PANE_TITLE or
+            AccessibilityEvent.CONTENT_CHANGE_TYPE_PANE_APPEARED or
+            AccessibilityEvent.CONTENT_CHANGE_TYPE_PANE_DISAPPEARED
+
+    fun classify(eventType: Int, contentChangeTypes: Int): UiEventSignificance {
+        return when (eventType) {
+            AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
+            AccessibilityEvent.TYPE_WINDOWS_CHANGED,
+            AccessibilityEvent.TYPE_VIEW_SCROLLED,
+            AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED,
+            -> UiEventSignificance.STRONG
+
+            AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED -> {
+                if ((contentChangeTypes and STRONG_BITS) != 0) {
+                    UiEventSignificance.STRONG
+                } else {
+                    UiEventSignificance.WEAK
+                }
+            }
+
+            // Defensive default: the production caller already filters to the
+            // five types above, anything else is treated as noise.
+            else -> UiEventSignificance.WEAK
+        }
+    }
+}
+
+/**
+ * Pure state machine that declares the UI semantically stable when
+ * [requiredSemanticMatches] consecutive samples carry the same semantic
+ * fingerprint across at least [requiredSemanticSpanMs], without any strong
+ * event arriving in between.
+ *
+ * Noise tolerance: when a fingerprint stays identical across
+ * [noiseToleranceMatches] samples while strong events keep arriving (events
+ * that never materialise as model-visible tree changes), the tree is
+ * provably long-stable and the strong-event reset is bypassed. A value of 0
+ * disables tolerance and keeps the strict PRD behaviour.
+ */
+internal class UiStabilityTracker(
+    private val requiredSemanticMatches: Int = 3,
+    private val requiredSemanticSpanMs: Long = 150L,
+    private val noiseToleranceMatches: Int = 6,
+) {
+    private var previousFingerprint: Long? = null
+    private var matchingSampleCount: Int = 0
+    private var sequenceStartTimeMs: Long = 0L
+    private var lastStrongGeneration: Long = 0L
+    private var lastSampleTimeMs: Long = Long.MIN_VALUE
+
+    /**
+     * Cumulative count of samples whose fingerprint equalled the previous
+     * sample's — independent of sequence resets, so sustained strong events
+     * cannot starve it. Reset to 1 whenever the fingerprint changes.
+     */
+    private var sameFingerprintSampleCount: Int = 0
+
+    /** True when the noise-tolerance window is active for the current sample. */
+    internal fun noiseToleranceActive(): Boolean =
+        noiseToleranceMatches > 0 && sameFingerprintSampleCount >= noiseToleranceMatches
+
+    /**
+     * Feeds one sample into the state machine. The five rules are evaluated
+     * in order; any condition that starts a new sequence returns [StabilityDecision.CONTINUE].
+     */
+    fun addSample(
+        fingerprint: Long,
+        sampleTimeMs: Long,
+        strongEventGeneration: Long,
+    ): StabilityDecision {
+        // Rule 1: first sample — start a new sequence.
+        if (previousFingerprint == null) {
+            previousFingerprint = fingerprint
+            matchingSampleCount = 1
+            sequenceStartTimeMs = sampleTimeMs
+            lastStrongGeneration = strongEventGeneration
+            lastSampleTimeMs = sampleTimeMs
+            sameFingerprintSampleCount = 1
+            return StabilityDecision.CONTINUE
+        }
+
+        // Cumulative stability evidence, independent of sequence resets.
+        sameFingerprintSampleCount =
+            if (fingerprint == previousFingerprint) sameFingerprintSampleCount + 1 else 1
+
+        // Rule 2: clock went backwards — restart the sequence.
+        if (sampleTimeMs < lastSampleTimeMs) {
+            resetSequence(fingerprint, sampleTimeMs, strongEventGeneration)
+            return StabilityDecision.CONTINUE
+        }
+
+        // Rule 3: a strong event arrived since the last sample.
+        if (strongEventGeneration != lastStrongGeneration) {
+            // Noise tolerance: the tree has stayed identical across many
+            // samples while strong events kept arriving — the "event first,
+            // tree later" race window (one sample period) is long past, so
+            // the event is treated as noise and stability is granted.
+            if (fingerprint == previousFingerprint && noiseToleranceActive()) {
+                return StabilityDecision.SEMANTIC_STABLE
+            }
+            resetSequence(fingerprint, sampleTimeMs, strongEventGeneration)
+            return StabilityDecision.CONTINUE
+        }
+
+        // Rule 4: the semantic fingerprint changed — restart.
+        if (fingerprint != previousFingerprint) {
+            resetSequence(fingerprint, sampleTimeMs, strongEventGeneration)
+            return StabilityDecision.CONTINUE
+        }
+
+        // Rule 5: same fingerprint and no strong event — extend the run.
+        matchingSampleCount += 1
+        lastSampleTimeMs = sampleTimeMs
+        val stable = matchingSampleCount >= requiredSemanticMatches &&
+            sampleTimeMs - sequenceStartTimeMs >= requiredSemanticSpanMs
+        return if (stable) StabilityDecision.SEMANTIC_STABLE else StabilityDecision.CONTINUE
+    }
+
+    private fun resetSequence(
+        fingerprint: Long,
+        sampleTimeMs: Long,
+        strongEventGeneration: Long,
+    ) {
+        previousFingerprint = fingerprint
+        matchingSampleCount = 1
+        sequenceStartTimeMs = sampleTimeMs
+        lastStrongGeneration = strongEventGeneration
+        lastSampleTimeMs = sampleTimeMs
+    }
+}

--- a/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationAccessibilityBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/nexus/agentic/chat/agentic/buildin/impl/ScreenOperationAccessibilityBuiltin.kt
@@ -46,8 +46,8 @@ class ScreenOperationAccessibilityBuiltin : TextResultBuiltinTool() {
                 "Returns matched nodes with index + version header.\n\n" +
                 "If read returns root-only or empty tree: app likely uses non-native UI " +
                 "(Flutter/Unity/WebView) — stop, do not retry.\n\n" +
-                "wait_mode (default \"stable\"): \"stable\" detects when the UI actually settles " +
-                "(event idle + tree hash) and returns early — use for taps, scrolls, text input. " +
+                "wait_mode (default \"stable\"): \"stable\" detects when the model-visible UI tree settles " +
+                "and tolerates non-semantic accessibility event noise — use for taps, scrolls, text input. " +
                 "\"delay\" does a blind fixed wait — use for search/refresh where data arrives " +
                 "asynchronously and the UI may appear stable before results load. " +
                 "Must be \"stable\" or \"delay\".\n" +

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/accessibility/TreeFormatterTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/accessibility/TreeFormatterTest.kt
@@ -1,19 +1,23 @@
 package com.niki914.nexus.agentic.chat.agentic.accessibility
 
+import android.view.accessibility.AccessibilityNodeInfo
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.Mockito
 
 /**
  * YAML-output-format tests for the [TreeFormatter] YAML generation logic.
  *
  * NOTE: [TreeFormatter.format] requires an
  * [android.view.accessibility.AccessibilityNodeInfo], which is a **final**
- * Android framework class.  The current project does not include Mockito or
- * Robolectric, so we cannot construct real or mock instances in a unit-test
- * environment.  Consequently, the tests here **replicate** the public YAML
+ * Android framework class.  The core tests here **replicate** the public YAML
  * serialisation contract via helper functions that operate on [NodeInfo]
- * trees only.
+ * trees only.  One Mockito smoke test (mockito-core 5.x inline mock maker)
+ * additionally drives the real [TreeFormatter.format] with mocked
+ * AccessibilityNodeInfo instances.
  *
  * What is tested:
  *   - [NodeInfo] -> YAML line structure, quoting, escaping, truncation markers
@@ -563,6 +567,310 @@ class TreeFormatterTest {
         assertFalse(
             "must not contain intermediate container at index 0",
             yaml.contains("""{i: 0, t: container""")
+        )
+    }
+
+    // ---------------------------------------------------------------
+    // computeSemanticFingerprint — pure-function tests (replicate mode)
+    // ---------------------------------------------------------------
+
+    private fun rootNode(children: List<NodeInfo>): NodeInfo = NodeInfo(
+        index = -1,
+        semanticType = SemanticType.CONTAINER,
+        text = "",
+        contentDesc = "",
+        bounds = Rect(0, 0, 1080, 2400),
+        isClickable = false,
+        isLongClickable = false,
+        isEditable = false,
+        isScrollable = false,
+        isChecked = false,
+        children = children,
+        moreSummary = emptyList(),
+    )
+
+    private fun leafNode(
+        index: Int = 0,
+        semanticType: SemanticType = SemanticType.BUTTON,
+        text: String = "OK",
+        contentDesc: String = "",
+        bounds: Rect = Rect(100, 200, 300, 400),
+        clickable: Boolean = true,
+        editable: Boolean = false,
+        scrollable: Boolean = false,
+        checked: Boolean = false,
+        moreSummary: List<String> = emptyList(),
+    ): NodeInfo = NodeInfo(
+        index = index,
+        semanticType = semanticType,
+        text = text,
+        contentDesc = contentDesc,
+        bounds = bounds,
+        isClickable = clickable,
+        isLongClickable = false,
+        isEditable = editable,
+        isScrollable = scrollable,
+        isChecked = checked,
+        children = emptyList(),
+        moreSummary = moreSummary,
+    )
+
+    private fun fingerprint(
+        root: NodeInfo,
+        screenWidth: Int = 1080,
+        screenHeight: Int = 2400,
+        appPackage: String = "test.package",
+        truncatedMaxNodes: Boolean = false,
+        truncatedMaxDepth: Boolean = false,
+    ): Long = TreeFormatter.computeSemanticFingerprint(
+        root, screenWidth, screenHeight, appPackage, truncatedMaxNodes, truncatedMaxDepth,
+    )
+
+    @Test
+    fun fingerprint_sameSemanticTreeSameFingerprint() {
+        // computeSemanticFingerprint has no version parameter — the fingerprint
+        // is inherently version-independent. Node index (the i field in YAML)
+        // is likewise not a semantic stability condition (PRD F-01): two nodes
+        // differing only in index must produce the same fingerprint.
+        val idx0 = rootNode(children = listOf(leafNode(index = 0)))
+        val idx5 = rootNode(children = listOf(leafNode(index = 5)))
+        assertEquals(
+            "node index must not affect the fingerprint",
+            fingerprint(idx0),
+            fingerprint(idx5),
+        )
+    }
+
+    @Test
+    fun fingerprint_changesWhenTextChanges() {
+        val base = rootNode(children = listOf(leafNode(index = 0, text = "OK")))
+        val changed = rootNode(children = listOf(leafNode(index = 0, text = "Cancel")))
+        assertTrue(
+            "text change must change the fingerprint",
+            fingerprint(base) != fingerprint(changed),
+        )
+    }
+
+    @Test
+    fun fingerprint_changesWhenContentDescChanges() {
+        val base = rootNode(children = listOf(leafNode(index = 0, contentDesc = "")))
+        val changed = rootNode(children = listOf(leafNode(index = 0, contentDesc = "description")))
+        assertTrue(
+            "contentDesc change must change the fingerprint",
+            fingerprint(base) != fingerprint(changed),
+        )
+    }
+
+    @Test
+    fun fingerprint_changesWhenCheckedChanges() {
+        val base = rootNode(children = listOf(leafNode(index = 0, checked = false)))
+        val changed = rootNode(children = listOf(leafNode(index = 0, checked = true)))
+        assertTrue(
+            "checked change must change the fingerprint",
+            fingerprint(base) != fingerprint(changed),
+        )
+    }
+
+    @Test
+    fun fingerprint_changesWhenBoundsChange() {
+        val base = rootNode(children = listOf(leafNode(index = 0, bounds = Rect(100, 200, 300, 400))))
+        val changed = rootNode(children = listOf(leafNode(index = 0, bounds = Rect(110, 200, 300, 400))))
+        assertTrue(
+            "bounds change must change the fingerprint",
+            fingerprint(base) != fingerprint(changed),
+        )
+    }
+
+    @Test
+    fun fingerprint_changesWhenBooleanFlagsChange() {
+        val baseFp = fingerprint(rootNode(children = listOf(leafNode(index = 0))))
+        val notClickable = rootNode(children = listOf(leafNode(index = 0, clickable = false)))
+        val editable = rootNode(children = listOf(leafNode(index = 0, editable = true)))
+        val scrollable = rootNode(children = listOf(leafNode(index = 0, scrollable = true)))
+        assertTrue(
+            "clickable change must change the fingerprint",
+            baseFp != fingerprint(notClickable),
+        )
+        assertTrue(
+            "editable change must change the fingerprint",
+            baseFp != fingerprint(editable),
+        )
+        assertTrue(
+            "scrollable change must change the fingerprint",
+            baseFp != fingerprint(scrollable),
+        )
+    }
+
+    @Test
+    fun fingerprint_changesWhenMoreSummaryChanges() {
+        val base = rootNode(children = listOf(leafNode(index = 0, moreSummary = emptyList())))
+        val changed = rootNode(children = listOf(leafNode(index = 0, moreSummary = listOf("item8"))))
+        assertTrue(
+            "moreSummary change must change the fingerprint",
+            fingerprint(base) != fingerprint(changed),
+        )
+    }
+
+    @Test
+    fun fingerprint_unaffectedByPrunedEmptyShell() {
+        // Nodes satisfying PruningRules.isEmptyShell (no text/desc/flags/
+        // children) are pruned by buildTree and never reach the fingerprint.
+        // Two raw trees that differ only in such a node's unrendered
+        // attributes reduce to the same post-pruning tree.
+        val shellA = NodeInfo(
+            index = 1, semanticType = SemanticType.TEXT,
+            text = "", contentDesc = "", bounds = Rect(0, 0, 50, 50),
+            isClickable = false, isLongClickable = false, isEditable = false,
+            isScrollable = false, isChecked = false,
+            children = emptyList(), moreSummary = emptyList(),
+        )
+        val shellB = NodeInfo(
+            index = 1, semanticType = SemanticType.BUTTON,
+            text = "", contentDesc = "", bounds = Rect(100, 100, 250, 250),
+            isClickable = false, isLongClickable = false, isEditable = false,
+            isScrollable = false, isChecked = false,
+            children = emptyList(), moreSummary = emptyList(),
+        )
+        assertTrue("shellA must satisfy isEmptyShell", PruningRules.isEmptyShell(shellA))
+        assertTrue("shellB must satisfy isEmptyShell", PruningRules.isEmptyShell(shellB))
+        assertTrue(
+            "shell with text must NOT satisfy isEmptyShell",
+            !PruningRules.isEmptyShell(shellA.copy(text = "x")),
+        )
+
+        val button = leafNode(index = 2)
+        // Sanity: had the shells NOT been pruned, their bounds would have
+        // entered the fingerprint — stability comes from pruning, not from
+        // fingerprint insensitivity.
+        assertTrue(
+            "un-pruned empty shells with different bounds must differ",
+            fingerprint(rootNode(children = listOf(shellA, button))) !=
+                fingerprint(rootNode(children = listOf(shellB, button))),
+        )
+        // Reverse boundary (AC-02): once a node gains model-visible text it is
+        // no longer a prunable shell, and that text must change the fingerprint.
+        assertTrue(
+            "shell gaining text must change the fingerprint",
+            fingerprint(rootNode(children = listOf(shellA, button))) !=
+                fingerprint(rootNode(children = listOf(shellA.copy(text = "x"), button))),
+        )
+    }
+
+    @Test
+    fun fingerprint_changesWhenTruncationFlagsFlip() {
+        val tree = rootNode(children = listOf(leafNode(index = 0)))
+        val baseFp = fingerprint(tree)
+        assertTrue(
+            "truncatedMaxNodes must change the fingerprint",
+            baseFp != fingerprint(tree, truncatedMaxNodes = true),
+        )
+        assertTrue(
+            "truncatedMaxDepth must change the fingerprint",
+            baseFp != fingerprint(tree, truncatedMaxDepth = true),
+        )
+    }
+
+    @Test
+    fun fingerprint_computationLeavesYamlUntouched() {
+        // computeSemanticFingerprint is a pure function over the pruned tree:
+        // computing it must not change the YAML produced for the same tree.
+        val tree = rootNode(children = listOf(leafNode(index = 0)))
+        val yamlBefore = yamlFromNodeInfo(tree)
+        fingerprint(tree)
+        fingerprint(tree)
+        val yamlAfter = yamlFromNodeInfo(tree)
+        assertEquals(
+            "fingerprint computation must not alter YAML output",
+            yamlBefore,
+            yamlAfter,
+        )
+    }
+
+    // ---------------------------------------------------------------
+    // Mockito smoke test — real format() pipeline with mocked nodes
+    // ---------------------------------------------------------------
+
+    @Test
+    fun format_mockitoSmoke_returnsFormattedTree() {
+        // Smoke test: mock the final AccessibilityNodeInfo class (mockito-core
+        // 5.x inline mock maker) and drive the real buildTree + toYaml +
+        // computeSemanticFingerprint pipeline through TreeFormatter.format.
+        val button = Mockito.mock(AccessibilityNodeInfo::class.java)
+        Mockito.doReturn("android.widget.Button").`when`(button).className
+        Mockito.doReturn("OK").`when`(button).text
+        Mockito.doReturn("").`when`(button).contentDescription
+        Mockito.doReturn(true).`when`(button).isClickable
+        Mockito.doReturn(false).`when`(button).isLongClickable
+        Mockito.doReturn(false).`when`(button).isEditable
+        Mockito.doReturn(false).`when`(button).isScrollable
+        Mockito.doReturn(false).`when`(button).isChecked
+        Mockito.doReturn(0).`when`(button).childCount
+        Mockito.doAnswer { inv ->
+            // android.graphics.Rect methods are not mocked in local unit
+            // tests; its bounds fields are public, so assign them directly.
+            val rect = inv.getArgument<android.graphics.Rect>(0)
+            rect.left = 100
+            rect.top = 200
+            rect.right = 300
+            rect.bottom = 400
+            null
+        }.`when`(button).getBoundsInScreen(Mockito.any())
+
+        val label = Mockito.mock(AccessibilityNodeInfo::class.java)
+        Mockito.doReturn("android.widget.TextView").`when`(label).className
+        Mockito.doReturn("Label").`when`(label).text
+        Mockito.doReturn("").`when`(label).contentDescription
+        Mockito.doReturn(false).`when`(label).isClickable
+        Mockito.doReturn(false).`when`(label).isLongClickable
+        Mockito.doReturn(false).`when`(label).isEditable
+        Mockito.doReturn(false).`when`(label).isScrollable
+        Mockito.doReturn(false).`when`(label).isChecked
+        Mockito.doReturn(0).`when`(label).childCount
+        Mockito.doAnswer { inv ->
+            val rect = inv.getArgument<android.graphics.Rect>(0)
+            rect.left = 400
+            rect.top = 500
+            rect.right = 600
+            rect.bottom = 700
+            null
+        }.`when`(label).getBoundsInScreen(Mockito.any())
+
+        val root = Mockito.mock(AccessibilityNodeInfo::class.java)
+        Mockito.doReturn("android.widget.FrameLayout").`when`(root).className
+        Mockito.doReturn("").`when`(root).text
+        Mockito.doReturn("").`when`(root).contentDescription
+        Mockito.doReturn(false).`when`(root).isClickable
+        Mockito.doReturn(false).`when`(root).isLongClickable
+        Mockito.doReturn(false).`when`(root).isEditable
+        Mockito.doReturn(false).`when`(root).isScrollable
+        Mockito.doReturn(false).`when`(root).isChecked
+        Mockito.doReturn(2).`when`(root).childCount
+        Mockito.doReturn(button).`when`(root).getChild(0)
+        Mockito.doReturn(label).`when`(root).getChild(1)
+        Mockito.doAnswer { inv ->
+            val rect = inv.getArgument<android.graphics.Rect>(0)
+            rect.left = 0
+            rect.top = 0
+            rect.right = 1080
+            rect.bottom = 2400
+            null
+        }.`when`(root).getBoundsInScreen(Mockito.any())
+
+        val formatted = TreeFormatter.format(root, 1080, 2400, "test.package", "0000")
+
+        assertTrue("yaml must contain container node", formatted.yaml.contains("""{i: 0, t: container"""))
+        assertTrue("yaml must contain button node", formatted.yaml.contains("""{i: 1, t: button"""))
+        assertTrue("yaml must contain button text", formatted.yaml.contains("txt: OK"))
+        assertTrue("yaml must contain tap flag", formatted.yaml.contains("tap: true"))
+        assertTrue("yaml must contain text node", formatted.yaml.contains("""{i: 2, t: text"""))
+        assertTrue("yaml must contain label text", formatted.yaml.contains("txt: Label"))
+        assertNotEquals("fingerprint must not be a fixed value", 0L, formatted.semanticFingerprint)
+
+        val again = TreeFormatter.format(root, 1080, 2400, "test.package", "0000")
+        assertEquals(
+            "repeated format must be deterministic",
+            formatted.semanticFingerprint,
+            again.semanticFingerprint,
         )
     }
 }

--- a/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/accessibility/UiStabilityTrackerTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/nexus/agentic/chat/agentic/accessibility/UiStabilityTrackerTest.kt
@@ -1,0 +1,260 @@
+package com.niki914.nexus.agentic.chat.agentic.accessibility
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Tests for [UiStabilityTracker] (8 state-machine cases) and
+ * [UiEventClassifier] (10 classification cases).
+ *
+ * Classification tests use magic bit values, independent of direct Android
+ * constant references; the values mirror the compileSdk (37) constants that
+ * the production code uses:
+ *   TEXT = 0x0002, CONTENT_DESCRIPTION = 0x0004, CHECKED = 0x2000,
+ *   SUBTREE = 0x0001, UNDEFINED = 0.
+ */
+class UiStabilityTrackerTest {
+
+    // Magic event-type values (AccessibilityEvent constants, kept local so
+    // the tests stay independent of the Android framework).
+    private val TYPE_WINDOW_STATE_CHANGED = 32
+    private val TYPE_VIEW_TEXT_CHANGED = 16
+    private val TYPE_WINDOW_CONTENT_CHANGED = 2048
+    private val TYPE_WINDOWS_CHANGED = 4194304
+    private val TYPE_VIEW_SCROLLED = 4096
+
+    // Magic content-change bit values (mirroring compileSdk 37 constants:
+    // SUBTREE=0x0001, TEXT=0x0002, CONTENT_DESCRIPTION=0x0004, CHECKED=0x2000).
+    private val BIT_TEXT = 0x0002
+    private val BIT_CONTENT_DESCRIPTION = 0x0004
+    private val BIT_CHECKED = 0x2000
+    private val BIT_SUBTREE = 0x0001
+
+    // ---------------------------------------------------------------
+    // UiStabilityTracker — state machine (8 cases)
+    // ---------------------------------------------------------------
+
+    @Test
+    fun firstSample_continues() {
+        val tracker = UiStabilityTracker()
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1000L, 0L))
+    }
+
+    @Test
+    fun twoIdenticalSamplesSameTimestamp_continues() {
+        val tracker = UiStabilityTracker()
+        tracker.addSample(1L, 1000L, 0L)
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1000L, 0L))
+    }
+
+    @Test
+    fun threeIdenticalSamplesSpanBelow150ms_continues() {
+        val tracker = UiStabilityTracker()
+        tracker.addSample(1L, 1000L, 0L)
+        tracker.addSample(1L, 1050L, 0L)
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1100L, 0L))
+    }
+
+    @Test
+    fun threeIdenticalSamplesSpanAtLeast150ms_semanticStable() {
+        val tracker = UiStabilityTracker()
+        tracker.addSample(1L, 1000L, 0L)
+        tracker.addSample(1L, 1100L, 0L)
+        assertEquals(StabilityDecision.SEMANTIC_STABLE, tracker.addSample(1L, 1200L, 0L))
+    }
+
+    @Test
+    fun fingerprintChange_resetsSequence() {
+        val tracker = UiStabilityTracker()
+        tracker.addSample(1L, 1000L, 0L)
+        tracker.addSample(2L, 1050L, 0L) // fingerprint change -> new sequence
+        // count=2 and span=100ms: without the reset this would already be
+        // SEMANTIC_STABLE (count=3, span=150ms).
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(2L, 1150L, 0L))
+    }
+
+    @Test
+    fun generationChangeSameFingerprint_resetsSequence() {
+        val tracker = UiStabilityTracker()
+        tracker.addSample(1L, 1000L, 0L)
+        tracker.addSample(1L, 1050L, 0L)
+        tracker.addSample(1L, 1100L, 1L) // strong event arrived -> new sequence
+        // count=2 and span=100ms: without the reset this would already be
+        // SEMANTIC_STABLE (count=4, span=200ms).
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1200L, 1L))
+    }
+
+    @Test
+    fun generationUnchanged_weakEventNoiseDoesNotBlockStability() {
+        val tracker = UiStabilityTracker()
+        tracker.addSample(1L, 1000L, 0L)
+        tracker.addSample(1L, 1100L, 0L) // generation unchanged (weak events only)
+        assertEquals(StabilityDecision.SEMANTIC_STABLE, tracker.addSample(1L, 1200L, 0L))
+    }
+
+    // ---------------------------------------------------------------
+    // UiStabilityTracker — noise tolerance (5 cases)
+    // ---------------------------------------------------------------
+
+    @Test
+    fun sustainedGenerationChanges_stableFingerprint_grantsStableAfterTolerance() {
+        // One strong event per sample while the tree never changes: the
+        // cumulative same-fingerprint evidence reaches the tolerance window
+        // (6) and stability is granted despite the ongoing generation bumps.
+        val tracker = UiStabilityTracker()
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1000L, 0L))
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1100L, 1L))
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1200L, 2L))
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1300L, 3L))
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1400L, 4L))
+        assertEquals(StabilityDecision.SEMANTIC_STABLE, tracker.addSample(1L, 1500L, 5L))
+    }
+
+    @Test
+    fun sustainedGenerationChanges_belowTolerance_continues() {
+        val tracker = UiStabilityTracker()
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1000L, 0L))
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1100L, 1L))
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1200L, 2L))
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1300L, 3L))
+        // sameCount == 5 < 6: tolerance not yet active, still resetting.
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1400L, 4L))
+    }
+
+    @Test
+    fun noiseToleranceDisabled_generationAlwaysResets() {
+        val tracker = UiStabilityTracker(noiseToleranceMatches = 0)
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1000L, 0L))
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1100L, 1L))
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1200L, 2L))
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1300L, 3L))
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1400L, 4L))
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1500L, 5L))
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1600L, 6L))
+    }
+
+    @Test
+    fun noiseToleranceGranted_fingerprintChangeStillResets() {
+        // After a tolerance grant, a real tree change must still reset the
+        // evidence and the sequence.
+        val tracker = UiStabilityTracker()
+        tracker.addSample(1L, 1000L, 0L)
+        tracker.addSample(1L, 1100L, 1L)
+        tracker.addSample(1L, 1200L, 2L)
+        tracker.addSample(1L, 1300L, 3L)
+        tracker.addSample(1L, 1400L, 4L)
+        assertEquals(StabilityDecision.SEMANTIC_STABLE, tracker.addSample(1L, 1500L, 5L))
+        // Fingerprint changed and the generation still differs: reset, not grant.
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(2L, 1600L, 5L))
+    }
+
+    @Test
+    fun noiseToleranceActive_flagReflectsThreshold() {
+        val tracker = UiStabilityTracker()
+        tracker.addSample(1L, 1000L, 0L)
+        assertEquals(false, tracker.noiseToleranceActive())
+        tracker.addSample(1L, 1100L, 1L)
+        tracker.addSample(1L, 1200L, 2L)
+        tracker.addSample(1L, 1300L, 3L)
+        tracker.addSample(1L, 1400L, 4L)
+        assertEquals(false, tracker.noiseToleranceActive()) // sameCount == 5
+        tracker.addSample(1L, 1500L, 5L)
+        assertEquals(true, tracker.noiseToleranceActive()) // sameCount == 6
+    }
+
+    @Test
+    fun timeRegression_resetsSequence() {
+        val tracker = UiStabilityTracker()
+        tracker.addSample(1L, 1000L, 0L)
+        tracker.addSample(1L, 1100L, 0L)
+        tracker.addSample(1L, 900L, 0L) // clock went backwards -> new sequence
+        tracker.addSample(1L, 950L, 0L)
+        // count=3 but span=100ms: without the reset this would already be
+        // SEMANTIC_STABLE (count=5).
+        assertEquals(StabilityDecision.CONTINUE, tracker.addSample(1L, 1000L, 0L))
+    }
+
+    // ---------------------------------------------------------------
+    // UiEventClassifier — event classification (10 cases)
+    // ---------------------------------------------------------------
+
+    @Test
+    fun classify_windowStateChanged_strong() {
+        assertEquals(
+            UiEventSignificance.STRONG,
+            UiEventClassifier.classify(TYPE_WINDOW_STATE_CHANGED, 0),
+        )
+    }
+
+    @Test
+    fun classify_windowsChanged_strong() {
+        assertEquals(
+            UiEventSignificance.STRONG,
+            UiEventClassifier.classify(TYPE_WINDOWS_CHANGED, 0),
+        )
+    }
+
+    @Test
+    fun classify_viewScrolled_strong() {
+        assertEquals(
+            UiEventSignificance.STRONG,
+            UiEventClassifier.classify(TYPE_VIEW_SCROLLED, 0),
+        )
+    }
+
+    @Test
+    fun classify_viewTextChanged_strong() {
+        assertEquals(
+            UiEventSignificance.STRONG,
+            UiEventClassifier.classify(TYPE_VIEW_TEXT_CHANGED, 0),
+        )
+    }
+
+    @Test
+    fun classify_contentChangedWithTextBit_strong() {
+        assertEquals(
+            UiEventSignificance.STRONG,
+            UiEventClassifier.classify(TYPE_WINDOW_CONTENT_CHANGED, BIT_TEXT),
+        )
+    }
+
+    @Test
+    fun classify_contentChangedWithContentDescriptionBit_strong() {
+        assertEquals(
+            UiEventSignificance.STRONG,
+            UiEventClassifier.classify(TYPE_WINDOW_CONTENT_CHANGED, BIT_CONTENT_DESCRIPTION),
+        )
+    }
+
+    @Test
+    fun classify_contentChangedWithCheckedBit_strong() {
+        assertEquals(
+            UiEventSignificance.STRONG,
+            UiEventClassifier.classify(TYPE_WINDOW_CONTENT_CHANGED, BIT_CHECKED),
+        )
+    }
+
+    @Test
+    fun classify_contentChangedWithSubtreeBit_weak() {
+        assertEquals(
+            UiEventSignificance.WEAK,
+            UiEventClassifier.classify(TYPE_WINDOW_CONTENT_CHANGED, BIT_SUBTREE),
+        )
+    }
+
+    @Test
+    fun classify_contentChangedUndefined_weak() {
+        assertEquals(
+            UiEventSignificance.WEAK,
+            UiEventClassifier.classify(TYPE_WINDOW_CONTENT_CHANGED, 0),
+        )
+    }
+
+    @Test
+    fun classify_contentChangedSubtreeOrText_strong() {
+        assertEquals(
+            UiEventSignificance.STRONG,
+            UiEventClassifier.classify(TYPE_WINDOW_CONTENT_CHANGED, BIT_SUBTREE or BIT_TEXT),
+        )
+    }
+}

--- a/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/model/ProviderSpec.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/app/ui/nexus/model/ProviderSpec.kt
@@ -69,7 +69,7 @@ private data object DeepSeekSpec : ProviderSpec {
     override val id: String = "deepseek"
     override val brandName: String = "DeepSeek"
     override val officialEndpoint: String = "https://api.deepseek.com/chat/completions"
-    override val exampleModelId: String = "deepseek-v4-pro"
+    override val exampleModelId: String = "deepseek-v4-flash"
     override val showEndpointConfigInOnboarding: Boolean = false
     override val iconRes: Int = R.drawable.deepseek
     override val tintIcon: Boolean = true

--- a/app/src/main/java/com/niki914/nexus/agentic/mod/feat/NexusAccessibilityService.kt
+++ b/app/src/main/java/com/niki914/nexus/agentic/mod/feat/NexusAccessibilityService.kt
@@ -9,6 +9,7 @@ import android.view.accessibility.AccessibilityNodeInfo
 import com.niki914.nexus.agentic.app.overlay.PointerOverlay
 import com.niki914.nexus.agentic.chat.agentic.accessibility.AccessibilityController
 import com.niki914.nexus.agentic.chat.agentic.accessibility.IAccessibility
+import com.niki914.nexus.agentic.chat.agentic.accessibility.UiEventClassifier
 
 class NexusAccessibilityService : AccessibilityService(), IAccessibility {
 
@@ -29,7 +30,8 @@ class NexusAccessibilityService : AccessibilityService(), IAccessibility {
             || type == AccessibilityEvent.TYPE_VIEW_SCROLLED
             || type == AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED
         ) {
-            AccessibilityController.recordUiEvent()
+            val significance = UiEventClassifier.classify(type, event.contentChangeTypes)
+            AccessibilityController.recordUiEvent(significance, type, event.contentChangeTypes)
         }
     }
 


### PR DESCRIPTION
## What

`waitForStable()` 双通道语义稳定判定（viewtree 耗时优化）：

- **通道 A（事件静默）**：相邻采样 fingerprint 一致 + 事件流静默 ≥300ms → 保留 Settings 等低事件 app 的原有行为
- **通道 B（语义稳定）**：3 个相同 semantic fingerprint 跨 ≥150ms → 容忍弱事件噪声
- **噪声容忍（方案 B，用户拍板）**：fingerprint 连续 6 样本不变时，强事件持续也放行 → 修复 Spotify 播放页"树不变但强事件刷"导致每步 timeout 的问题
- `TreeFormatter` 一次裁剪同时产出 YAML + 64 位 FNV-1a semantic fingerprint（与模型可见 YAML 同源，忽略 index/version/className）
- 稳定/超时都直接返回已判样本，不二次抓树

## Measured（RMX3850 / Spotify，QA 2026-08-02/03）

| 场景 | 旧实现 | 本分支 |
|---|---|---|
| 普通点击（无持续事件） | 2000ms（打满 timeout） | ~950ms |
| 播放页（强事件刷、树不变） | 2–5s（每步 TIMEOUT） | ~1.1s |
| progressbar 更新进入 YAML | 2000ms | 2000ms（**未解决**，PRD §10.4 按设计） |

附带收益：退出不再带 `# Note: settle timed out` → 模型对 `wait_ms` 的通胀（QA 实测 3–5s）会自然回落。

## Status: WIP — blocked on logging infra

**合入前必须完成：**

1. 日志基建（**新设计，非 xevent，设计未定**）落地后，横评有/无本 PR 的耗时 + 正确率。指标定义、无 PR 基线（`1d13338`）获取方式、待定决策清单见 `docs/.asc_task/wait_stable_semantic/handover.md`（工作区文件，未提交）
2. 定噪声容忍阈值：当前 6，候选 3（与语义窗口 3×150ms 同保证，播放页可降到 ~500ms）
3. 删 QA 诊断代码（`computeDebugChannels`/`sampleClassSignatures` 等，已标 Temporary diagnostic），保留 F-09 单行日志
4. 移出无关的 `ProviderSpec.kt` deepseek-v4-flash 改动
5. 修订 PRD F-04/F-05（方案 B 偏离"强事件必须重置"）或在 PR 描述声明偏离

## Known limitation

progressbar 更新进入模型可见 YAML（时间文本 / bounds 变化）→ fingerprint 持续变化 → 仍 2s timeout。不做 class/app 特判（已否决）；唯一出路是重构 fingerprint 语义（忽略不可操作节点的几何变化，属新设计，另行决策）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)