### PR TITLE
Replace haze blur with alpha-animated top bar, add collapsible title mode

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,7 +92,6 @@ dependencies {
     compileOnly("de.robv.android.xposed:api:82")
 
     // Third-party UI
-    implementation("dev.chrisbanes.haze:haze:1.7.2")
     implementation("com.mikepenz:multiplatform-markdown-renderer-m3:0.37.0")
 
     // Material & AndroidX

--- a/app/src/main/java/com/niki914/zafiro/app/ui/ZafiroApp.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/ZafiroApp.kt
@@ -109,9 +109,10 @@ fun ZafiroApp(
         currentLeftAction != null && (currentLeftAction.onClick != null || controller.canGoBack)
     val showRightButton = currentRightAction != null
     val currentTitle = resolveTitle(currentChrome.titleSpec ?: currentPage.titleSpec)
+    val isTitleCollapsible = currentPage.titleMode == TitleBarMode.Collapsible
     val screenState = rememberLiquidScreenState(
         title = currentTitle,
-        isTitleCollapsible = currentPage.titleMode == TitleBarMode.Collapsible,
+        isTitleCollapsible = isTitleCollapsible,
         showLeftButton = showLeftButton,
         showRightButton = showRightButton,
         showBlurLayer = currentPage.showBlurLayer,
@@ -200,7 +201,7 @@ fun ZafiroApp(
         when (controller.lastDirection) {
             TitleDirection.Forward -> screenState.navigateForward(
                 title = currentTitle,
-                isTitleCollapsible = currentPage.titleMode == TitleBarMode.Collapsible,
+                isTitleCollapsible = isTitleCollapsible,
                 showLeftButton = showLeftButton,
                 showRightButton = showRightButton,
                 showBlurLayer = currentPage.showBlurLayer,
@@ -210,7 +211,7 @@ fun ZafiroApp(
 
             TitleDirection.Back -> screenState.navigateBack(
                 title = currentTitle,
-                isTitleCollapsible = currentPage.titleMode == TitleBarMode.Collapsible,
+                isTitleCollapsible = isTitleCollapsible,
                 showLeftButton = showLeftButton,
                 showRightButton = showRightButton,
                 showBlurLayer = currentPage.showBlurLayer,
@@ -220,7 +221,7 @@ fun ZafiroApp(
 
             TitleDirection.None -> screenState.update(
                 title = currentTitle,
-                isTitleCollapsible = currentPage.titleMode == TitleBarMode.Collapsible,
+                isTitleCollapsible = isTitleCollapsible,
                 showLeftButton = showLeftButton,
                 showRightButton = showRightButton,
                 showBlurLayer = currentPage.showBlurLayer,
@@ -310,33 +311,33 @@ fun ZafiroApp(
                     ) {
                         saveableStateHolder.SaveableStateProvider(entry.id) {
                             ZafiroPageContent(
-                            entry = entry,
-                            startupAssistantUi = startupAssistantUi,
-                            onPush = ::push,
-                            onPushFromLeft = ::pushFromLeft,
-                            onPop = { navigator.pop() },
-                            onPopMultiple = { navigator.popMultiple(it) },
-                            onPopToRight = ::popToRight,
-                            onResetTo = ::resetTo,
-                            selectedConversationId = selectedConversationId,
-                            onConversationSelected = { id ->
-                                selectedConversationId = id
-                            },
-                            onConversationSelectionConsumed = { id ->
-                                if (selectedConversationId == id) {
-                                    selectedConversationId = null
-                                }
-                            },
-                            activeConversationId = activeConversationId,
-                            activeConversationTitle = activeConversationTitle,
-                            onActiveConversationChanged = { id, title ->
-                                activeConversationId = id
-                                activeConversationTitle = title
-                            },
-                            onCurrentConversationDeleted = { id ->
-                                deleteActiveConversation(id)
-                            },
-                        )
+                                entry = entry,
+                                startupAssistantUi = startupAssistantUi,
+                                onPush = ::push,
+                                onPushFromLeft = ::pushFromLeft,
+                                onPop = { navigator.pop() },
+                                onPopMultiple = { navigator.popMultiple(it) },
+                                onPopToRight = ::popToRight,
+                                onResetTo = ::resetTo,
+                                selectedConversationId = selectedConversationId,
+                                onConversationSelected = { id ->
+                                    selectedConversationId = id
+                                },
+                                onConversationSelectionConsumed = { id ->
+                                    if (selectedConversationId == id) {
+                                        selectedConversationId = null
+                                    }
+                                },
+                                activeConversationId = activeConversationId,
+                                activeConversationTitle = activeConversationTitle,
+                                onActiveConversationChanged = { id, title ->
+                                    activeConversationId = id
+                                    activeConversationTitle = title
+                                },
+                                onCurrentConversationDeleted = { id ->
+                                    deleteActiveConversation(id)
+                                },
+                            )
                         }
                     }
                 }

--- a/app/src/main/java/com/niki914/zafiro/app/ui/ZafiroApp.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/ZafiroApp.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -47,6 +48,7 @@ import com.niki914.uikit.infra.LiquidScreen
 import com.niki914.uikit.infra.LiquidScreenSwipeContent
 import com.niki914.uikit.infra.TitleDirection
 import com.niki914.uikit.infra.nav.LocalNavigationEntry
+import com.niki914.uikit.infra.nav.LocalPageTitle
 import com.niki914.uikit.infra.nav.rememberNavigationController
 import com.niki914.uikit.infra.rememberLiquidScreenState
 import com.niki914.zafiro.app.ui.model.AppLaunchDecision
@@ -58,6 +60,7 @@ import com.niki914.zafiro.app.ui.nav.NoTitle
 import com.niki914.zafiro.app.ui.nav.PageTitleSpec
 import com.niki914.zafiro.app.ui.nav.ResTitle
 import com.niki914.zafiro.app.ui.nav.TextTitle
+import com.niki914.zafiro.app.ui.nav.TitleBarMode
 import com.niki914.zafiro.app.ui.nav.TopBarActionSpec
 
 @Composable
@@ -81,6 +84,7 @@ fun ZafiroApp(
     val initialPage = launchDecision.initialPage
     val controller = rememberNavigationController<ZafiroPage>(initialPage = initialPage)
     val navigator = controller.navigator
+    val saveableStateHolder = rememberSaveableStateHolder()
     val currentEntry = controller.currentEntry
     val currentPage = currentEntry.page
     val currentChrome = pageChromeHost.stateFor(currentEntry.id)
@@ -107,6 +111,7 @@ fun ZafiroApp(
     val currentTitle = resolveTitle(currentChrome.titleSpec ?: currentPage.titleSpec)
     val screenState = rememberLiquidScreenState(
         title = currentTitle,
+        isTitleCollapsible = currentPage.titleMode == TitleBarMode.Collapsible,
         showLeftButton = showLeftButton,
         showRightButton = showRightButton,
         showBlurLayer = currentPage.showBlurLayer,
@@ -195,6 +200,7 @@ fun ZafiroApp(
         when (controller.lastDirection) {
             TitleDirection.Forward -> screenState.navigateForward(
                 title = currentTitle,
+                isTitleCollapsible = currentPage.titleMode == TitleBarMode.Collapsible,
                 showLeftButton = showLeftButton,
                 showRightButton = showRightButton,
                 showBlurLayer = currentPage.showBlurLayer,
@@ -204,6 +210,7 @@ fun ZafiroApp(
 
             TitleDirection.Back -> screenState.navigateBack(
                 title = currentTitle,
+                isTitleCollapsible = currentPage.titleMode == TitleBarMode.Collapsible,
                 showLeftButton = showLeftButton,
                 showRightButton = showRightButton,
                 showBlurLayer = currentPage.showBlurLayer,
@@ -213,6 +220,7 @@ fun ZafiroApp(
 
             TitleDirection.None -> screenState.update(
                 title = currentTitle,
+                isTitleCollapsible = currentPage.titleMode == TitleBarMode.Collapsible,
                 showLeftButton = showLeftButton,
                 showRightButton = showRightButton,
                 showBlurLayer = currentPage.showBlurLayer,
@@ -298,8 +306,10 @@ fun ZafiroApp(
                     CompositionLocalProvider(
                         LocalNavigationEntry provides entry,
                         LocalPageChrome provides pageChromeRegistrar,
+                        LocalPageTitle provides resolveTitle(entry.page.titleSpec),
                     ) {
-                        ZafiroPageContent(
+                        saveableStateHolder.SaveableStateProvider(entry.id) {
+                            ZafiroPageContent(
                             entry = entry,
                             startupAssistantUi = startupAssistantUi,
                             onPush = ::push,
@@ -327,6 +337,7 @@ fun ZafiroApp(
                                 deleteActiveConversation(id)
                             },
                         )
+                        }
                     }
                 }
 

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/ConversationHistoryPageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/ConversationHistoryPageContent.kt
@@ -28,7 +28,6 @@ import com.niki914.uikit.infra.ConfirmationLiquidDialog
 import com.niki914.uikit.infra.ProvideLiquidScreenContentForPreview
 import com.niki914.uikit.infra.component.SettingsGroupCard
 import com.niki914.uikit.infra.component.SwipeDismissSettingsItemCard
-import com.niki914.uikit.infra.liquidScreenHazeSource
 import com.niki914.uikit.infra.liquidScreenTopPadding
 import com.niki914.uikit.base.BaseTheme
 
@@ -106,8 +105,7 @@ private fun ConversationHistoryListContent(
 
     LazyColumn(
         modifier = modifier
-            .fillMaxSize()
-            .liquidScreenHazeSource(),
+            .fillMaxSize(),
         contentPadding = PaddingValues(
             start = 20.dp,
             top = liquidScreenTopPadding(24.dp),
@@ -154,7 +152,6 @@ private fun ConversationHistoryMessageContent(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .liquidScreenHazeSource()
             .padding(horizontal = 20.dp)
             .padding(top = liquidScreenTopPadding(24.dp), bottom = 24.dp),
         contentAlignment = Alignment.TopCenter,

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/DonePageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/DonePageContent.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.niki914.zafiro.app.R
 import com.niki914.uikit.infra.component.TintLiquidButton
-import com.niki914.uikit.infra.liquidScreenHazeSource
 import com.niki914.uikit.infra.liquidScreenTopPadding
 
 @Composable
@@ -30,7 +29,6 @@ fun DonePageContent(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .liquidScreenHazeSource()
             .padding(top = liquidScreenTopPadding())
             .padding(horizontal = 24.dp, vertical = 24.dp),
     ) {

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
@@ -62,7 +62,6 @@ import com.niki914.zafiro.app.R
 import com.niki914.uikit.infra.ConfirmationLiquidDialog
 import com.niki914.uikit.infra.LocalLiquidViewportAvoidanceController
 import com.niki914.uikit.infra.ProvideLiquidScreenContentForPreview
-import com.niki914.uikit.infra.liquidScreenHazeSource
 import com.niki914.uikit.infra.liquidScreenTopPadding
 import com.niki914.uikit.infra.nav.pageViewModel
 import com.niki914.zafiro.app.ui.PageChromeContribution
@@ -340,7 +339,6 @@ private fun HomePageContentBody(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .liquidScreenHazeSource(),
     ) {
         LazyColumn(
             state = listState,

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/ModelConfigSettingsContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/ModelConfigSettingsContent.kt
@@ -1,11 +1,5 @@
 package com.niki914.zafiro.app.ui.content
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.runtime.Composable
@@ -20,10 +14,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.niki914.uikit.infra.ConfirmationLiquidDialog
-import com.niki914.uikit.infra.component.SettingsDetailPageDefaults
 import com.niki914.uikit.infra.component.SettingsGroupCard
+import com.niki914.uikit.infra.component.SettingsListPageContent
 import com.niki914.uikit.infra.component.SettingExpandableTextItem
-import com.niki914.uikit.infra.liquidScreenTopPadding
 import com.niki914.uikit.infra.nav.pageViewModel
 import com.niki914.zafiro.app.R
 import com.niki914.zafiro.app.ui.model.ConfigureIntent
@@ -78,18 +71,7 @@ fun ModelConfigSettingsContent(
             onClick = onOpenProviderPick,
         ),
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = SettingsDetailPageDefaults.HorizontalPadding)
-                .padding(
-                    top = liquidScreenTopPadding(SettingsDetailPageDefaults.VerticalPadding),
-                    bottom = SettingsDetailPageDefaults.VerticalPadding +
-                            SettingsDetailPageDefaults.RootVerticalSpacing,
-                ),
-            verticalArrangement = Arrangement.spacedBy(SettingsDetailPageDefaults.ContentVerticalSpacing),
-        ) {
+        SettingsListPageContent {
             SettingsGroupCard {
                 var promptExpanded by rememberSaveable { mutableStateOf(false) }
                 SettingExpandableTextItem(

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/SelectionPageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/SelectionPageContent.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.niki914.zafiro.app.R
 import com.niki914.uikit.infra.component.TintLiquidButton
-import com.niki914.uikit.infra.liquidScreenHazeSource
 import com.niki914.uikit.infra.liquidScreenTopPadding
 
 data class SelectionOption(
@@ -42,7 +41,6 @@ fun SelectionPageContent(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .liquidScreenHazeSource()
             .verticalScroll(rememberScrollState())
             .padding(top = liquidScreenTopPadding())
             .padding(horizontal = 20.dp, vertical = 24.dp),

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/SkillDetailContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/SkillDetailContent.kt
@@ -21,7 +21,6 @@ import com.niki914.uikit.infra.ConfirmationLiquidDialog
 import com.niki914.uikit.infra.component.PageDescriptionText
 import com.niki914.uikit.infra.component.SettingsDetailPageDefaults
 import com.niki914.uikit.infra.component.TintLiquidButton
-import com.niki914.uikit.infra.liquidScreenHazeSource
 import com.niki914.uikit.infra.liquidScreenTopPadding
 import com.niki914.uikit.infra.nav.pageViewModel
 import com.niki914.zafiro.app.ui.model.SkillDeleteConfirmationState
@@ -109,7 +108,6 @@ private fun SkillDetailContentBody(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .liquidScreenHazeSource(),
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/TODOPageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/TODOPageContent.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.niki914.zafiro.app.R
-import com.niki914.uikit.infra.liquidScreenHazeSource
 import com.niki914.uikit.infra.liquidScreenTopPadding
 
 @Composable
@@ -23,7 +22,6 @@ fun TODOPageContent() {
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .liquidScreenHazeSource()
             .padding(top = liquidScreenTopPadding())
             .padding(horizontal = 24.dp, vertical = 24.dp),
         contentAlignment = Alignment.Center,

--- a/app/src/main/java/com/niki914/zafiro/app/ui/nav/ZafiroPages.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/nav/ZafiroPages.kt
@@ -34,7 +34,16 @@ sealed interface ZafiroPage : Page {
     val rightAction: TopBarActionSpec?
     val showBlurLayer: Boolean
         get() = true
+
+    /**
+     * 顶栏标题模式：Pinned = 小标题常驻（到顶时背景透明但标题照常显示）；
+     * Collapsible = 大标题在内容顶部，随滚动切换为小标题（设置 spec 页）。
+     */
+    val titleMode: TitleBarMode
+        get() = TitleBarMode.Pinned
 }
+
+enum class TitleBarMode { Pinned, Collapsible }
 
 data object StartupPage : ZafiroPage {
     override val routeKey: String = "startup"
@@ -118,6 +127,7 @@ data object SettingsHomePage : ZafiroPage {
     override val leftAction: TopBarActionSpec =
         TopBarActionSpec(Icons.AutoMirrored.Filled.ArrowBack)
     override val rightAction: TopBarActionSpec? = null
+    override val titleMode: TitleBarMode = TitleBarMode.Collapsible
 }
 
 data class SettingsDetailPage(
@@ -129,6 +139,9 @@ data class SettingsDetailPage(
     override val leftAction: TopBarActionSpec =
         TopBarActionSpec(Icons.AutoMirrored.Filled.ArrowBack)
     override val rightAction: TopBarActionSpec? = null
+
+    // 全部组均渲染大标题页（ModelConfig 已迁移到 SettingsListPageContent）。
+    override val titleMode: TitleBarMode = TitleBarMode.Collapsible
 }
 
 data class McpServerDetailPage(
@@ -205,4 +218,5 @@ data class BuiltinToolGroupDetailPage(
     override val leftAction: TopBarActionSpec =
         TopBarActionSpec(Icons.AutoMirrored.Filled.ArrowBack)
     override val rightAction: TopBarActionSpec? = null
+    override val titleMode: TitleBarMode = TitleBarMode.Collapsible
 }

--- a/ui-kit/build.gradle.kts
+++ b/ui-kit/build.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
     // UI infra
     implementation("com.github.Kyant0:Capsule:2.1.0")
     implementation("io.github.kyant0:backdrop:2.0.0-alpha03")
-    implementation("dev.chrisbanes.haze:haze:1.7.2")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
 
     // Material & AndroidX

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreen.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
@@ -27,6 +28,7 @@ import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -39,8 +41,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
@@ -52,10 +59,6 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import com.kyant.backdrop.backdrops.layerBackdrop
 import com.kyant.backdrop.backdrops.rememberLayerBackdrop
-import dev.chrisbanes.haze.HazeProgressive
-import dev.chrisbanes.haze.HazeTint
-import dev.chrisbanes.haze.hazeEffect
-import dev.chrisbanes.haze.rememberHazeState
 import kotlinx.coroutines.delay
 
 @Composable
@@ -69,7 +72,6 @@ fun LiquidScreen(
 ) {
     val isDarkTheme = isSystemInDarkTheme()
     val density = LocalDensity.current
-    val hazeState = rememberHazeState(blurEnabled = true)
     val chromeBackdrop = rememberLayerBackdrop()
     val dialogHostState = remember { LiquidDialogHostState() }
     val topInset = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
@@ -81,6 +83,63 @@ fun LiquidScreen(
     val imeBottomPx = WindowInsets.ime.getBottom(density)
     val navigationBottomPx = WindowInsets.navigationBars.getBottom(density)
     var screenHeightPx by remember { mutableStateOf(0) }
+
+    // 内容滚动观测：被动判定内容是否离开顶部。
+    // 用于顶栏背景色/小标题的布尔动画：离开顶部 → 渐显，回到顶部 → 渐隐。
+    // 不可滚动页面不会产生任何滚动事件，恒为 false（顶栏全透明）。
+    var isContentScrolled by remember { mutableStateOf(false) }
+    val scrollConnection = remember {
+        object : NestedScrollConnection {
+            override fun onPostScroll(
+                consumed: Offset,
+                available: Offset,
+                source: NestedScrollSource,
+            ): Offset {
+                if (available.y > 0f) {
+                    // 内容已在顶部仍继续下拉（顶部过滚动）：已回到顶部。
+                    isContentScrolled = false
+                } else if (consumed.y < 0f) {
+                    // finger 上滑、内容向下滚：已离开顶部。
+                    isContentScrolled = true
+                }
+                return Offset.Zero
+            }
+        }
+    }
+    // 导航（前进/后退）时重置：Pinned 页的滚动状态均为 remember（非 saveable），
+    // 重建后必在顶部；Collapsible 页不读这个布尔，由页面自报（snapshotFlow）。
+    LaunchedEffect(state.title, state.titleDirection) {
+        when (state.titleDirection) {
+            TitleDirection.Forward, TitleDirection.Back -> isContentScrolled = false
+            TitleDirection.None -> {}
+        }
+    }
+    val titleCollapseState = remember { TitleBarCollapseState() }
+    // 动画时长与 action bar 左右按钮显隐动画一致，页面切换时两页滚动状态
+    // 不同也不会闪变：alpha 总是从当前值动画到目标值。
+    val collapseAnimSpec = tween<Float>(durationMillis = 280, easing = LinearOutSlowInEasing)
+    // 背景与小标题共用同一信号源，保证两者同步动画：
+    // Collapsible 页由页面自报（与大标题同一阈值）；Pinned 页由嵌套滚动观测驱动。
+    val barTarget = if (state.isTitleCollapsible) {
+        titleCollapseState.isCollapsed
+    } else {
+        isContentScrolled
+    }
+    val titleTarget = if (state.isTitleCollapsible) {
+        titleCollapseState.isCollapsed
+    } else {
+        true
+    }
+    val barAlpha by animateFloatAsState(
+        targetValue = if (barTarget) 1f else 0f,
+        animationSpec = collapseAnimSpec,
+        label = "topBarAlpha",
+    )
+    val titleAlpha by animateFloatAsState(
+        targetValue = if (titleTarget) 1f else 0f,
+        animationSpec = collapseAnimSpec,
+        label = "topBarTitleAlpha",
+    )
     val targetAvoidanceOffsetPx = with(density) {
         calculateLiquidViewportAvoidanceOffsetPx(
             screenHeightPx = screenHeightPx.toFloat(),
@@ -111,14 +170,15 @@ fun LiquidScreen(
         CompositionLocalProvider(
             LocalLiquidScreenContentContext provides LiquidScreenContentContext(
                 topPadding = actionBarHeight,
-                hazeState = hazeState,
             ),
+            LocalTitleBarCollapseState provides titleCollapseState,
             LocalLiquidViewportAvoidanceController provides state.viewportAvoidanceController,
             LocalLiquidDialogHostState provides dialogHostState,
         ) {
             Box(
                 modifier = Modifier
                     .fillMaxSize()
+                    .nestedScroll(scrollConnection)
                     .graphicsLayer {
                         translationY = avoidanceOffsetPx
                     },
@@ -127,7 +187,7 @@ fun LiquidScreen(
             }
         }
 
-        // Layer 2: action bar progressive blur background
+        // Layer 2: action bar background，颜色随内容滚动渐显。
         AnimatedVisibility(
             visible = state.showBlurLayer,
             modifier = Modifier
@@ -141,17 +201,9 @@ fun LiquidScreen(
                     .fillMaxWidth()
                     .height(chromeHeight)
                     .layerBackdrop(chromeBackdrop)
-                    .hazeEffect(state = hazeState) {
-                        tints = listOf(
-                            HazeTint(
-                                if (isDarkTheme) Color.Black else Color.White
-                            )
-                        )
-                        progressive = HazeProgressive.verticalGradient(
-                            startIntensity = 1f,
-                            endIntensity = 0f
-                        )
-                    }
+                    .background(
+                        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = barAlpha)
+                    ),
             )
         }
 
@@ -236,7 +288,9 @@ fun LiquidScreen(
                 label = "title",
             ) { title ->
                 Box(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .alpha(titleAlpha),
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreen.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreen.kt
@@ -166,7 +166,7 @@ fun LiquidScreen(
             .fillMaxSize()
             .onSizeChanged { size -> screenHeightPx = size.height },
     ) {
-        // Layer 1: page content owns the haze source placement.
+        // Layer 1: page content.
         CompositionLocalProvider(
             LocalLiquidScreenContentContext provides LiquidScreenContentContext(
                 topPadding = actionBarHeight,

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreenContentContext.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreenContentContext.kt
@@ -43,6 +43,9 @@ class TitleBarCollapseState {
     var isCollapsed: Boolean by mutableStateOf(false)
 }
 
+// ponytail: 折叠信号有 Pinned（根部嵌套滚动观测）与 Collapsible（页面自报）两条通道；
+// 再出现第三个 Collapsible 容器时，应把大标题收敛进 LiquidScreen 统一渲染，删除双通道。
+
 val LocalTitleBarCollapseState: ProvidableCompositionLocal<TitleBarCollapseState> =
     staticCompositionLocalOf { TitleBarCollapseState() }
 

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreenContentContext.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreenContentContext.kt
@@ -5,17 +5,17 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.hazeSource
-import dev.chrisbanes.haze.rememberHazeState
 
 @Stable
 class LiquidScreenContentContext internal constructor(
     val topPadding: Dp,
-    val hazeState: HazeState,
 )
 
 /**
@@ -32,14 +32,23 @@ val LocalLiquidScreenContentContext: ProvidableCompositionLocal<LiquidScreenCont
         )
     }
 
+/**
+ * Collapsible 页（`ZafiroPage.titleMode == Collapsible`）向 `LiquidScreen` 回报
+ * 「内容是否已滚离顶部」的通道：true = 大标题已滚走（小标题浮现、背景实色）。
+ * 默认 false = 假定在顶部（大标题展示中）。Pinned 页不写此状态。
+ */
+@Stable
+class TitleBarCollapseState {
+    /** true = 内容已滚过大标题（小标题应浮现）；非滚动页恒为 false（顶栏全透明）。 */
+    var isCollapsed: Boolean by mutableStateOf(false)
+}
+
+val LocalTitleBarCollapseState: ProvidableCompositionLocal<TitleBarCollapseState> =
+    staticCompositionLocalOf { TitleBarCollapseState() }
+
 @Composable
 fun liquidScreenTopPadding(extra: Dp = 0.dp): Dp {
     return LocalLiquidScreenContentContext.current.topPadding + extra
-}
-
-@Composable
-fun Modifier.liquidScreenHazeSource(): Modifier {
-    return hazeSource(LocalLiquidScreenContentContext.current.hazeState)
 }
 
 @Composable
@@ -47,12 +56,11 @@ fun ProvideLiquidScreenContentForPreview(
     topPadding: Dp = 0.dp,
     content: @Composable () -> Unit,
 ) {
-    val hazeState = rememberHazeState(blurEnabled = true)
     CompositionLocalProvider(
         LocalLiquidScreenContentContext provides LiquidScreenContentContext(
             topPadding = topPadding,
-            hazeState = hazeState,
         ),
+        LocalTitleBarCollapseState provides TitleBarCollapseState(),
         content = content,
     )
 }

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreenState.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreenState.kt
@@ -15,6 +15,7 @@ enum class TitleDirection { Forward, Back, None }
 @Stable
 class LiquidScreenState(
     initialTitle: String = "",
+    initialIsTitleCollapsible: Boolean = false,
     initialShowLeftButton: Boolean = true,
     initialShowRightButton: Boolean = true,
     initialShowBlurLayer: Boolean = true,
@@ -26,6 +27,7 @@ class LiquidScreenState(
     val viewportAvoidanceController = LiquidViewportAvoidanceController()
 
     internal var title by mutableStateOf(initialTitle)
+    internal var isTitleCollapsible by mutableStateOf(initialIsTitleCollapsible)
     internal var showLeftButton by mutableStateOf(initialShowLeftButton)
     internal var showRightButton by mutableStateOf(initialShowRightButton)
     internal var showBlurLayer by mutableStateOf(initialShowBlurLayer)
@@ -41,6 +43,7 @@ class LiquidScreenState(
 
     fun navigateForward(
         title: String,
+        isTitleCollapsible: Boolean = this.isTitleCollapsible,
         showLeftButton: Boolean = this.showLeftButton,
         showRightButton: Boolean = this.showRightButton,
         showBlurLayer: Boolean = this.showBlurLayer,
@@ -48,11 +51,12 @@ class LiquidScreenState(
         onRightClick: (() -> Unit)? = this.onRightClick,
     ) {
         titleDirection = TitleDirection.Forward
-        apply(title, showLeftButton, showRightButton, showBlurLayer, onLeftClick, onRightClick)
+        apply(title, isTitleCollapsible, showLeftButton, showRightButton, showBlurLayer, onLeftClick, onRightClick)
     }
 
     fun navigateBack(
         title: String,
+        isTitleCollapsible: Boolean = this.isTitleCollapsible,
         showLeftButton: Boolean = this.showLeftButton,
         showRightButton: Boolean = this.showRightButton,
         showBlurLayer: Boolean = this.showBlurLayer,
@@ -60,11 +64,12 @@ class LiquidScreenState(
         onRightClick: (() -> Unit)? = this.onRightClick,
     ) {
         titleDirection = TitleDirection.Back
-        apply(title, showLeftButton, showRightButton, showBlurLayer, onLeftClick, onRightClick)
+        apply(title, isTitleCollapsible, showLeftButton, showRightButton, showBlurLayer, onLeftClick, onRightClick)
     }
 
     fun update(
         title: String,
+        isTitleCollapsible: Boolean = this.isTitleCollapsible,
         showLeftButton: Boolean = this.showLeftButton,
         showRightButton: Boolean = this.showRightButton,
         showBlurLayer: Boolean = this.showBlurLayer,
@@ -72,11 +77,12 @@ class LiquidScreenState(
         onRightClick: (() -> Unit)? = this.onRightClick,
     ) {
         titleDirection = TitleDirection.None
-        apply(title, showLeftButton, showRightButton, showBlurLayer, onLeftClick, onRightClick)
+        apply(title, isTitleCollapsible, showLeftButton, showRightButton, showBlurLayer, onLeftClick, onRightClick)
     }
 
     private fun apply(
         title: String,
+        isTitleCollapsible: Boolean,
         showLeftButton: Boolean,
         showRightButton: Boolean,
         showBlurLayer: Boolean,
@@ -84,6 +90,7 @@ class LiquidScreenState(
         onRightClick: (() -> Unit)?,
     ) {
         this.title = title
+        this.isTitleCollapsible = isTitleCollapsible
         this.showLeftButton = showLeftButton
         this.showRightButton = showRightButton
         this.showBlurLayer = showBlurLayer
@@ -95,6 +102,7 @@ class LiquidScreenState(
 @Composable
 fun rememberLiquidScreenState(
     title: String = "",
+    isTitleCollapsible: Boolean = false,
     showLeftButton: Boolean = true,
     showRightButton: Boolean = true,
     showBlurLayer: Boolean = true,
@@ -104,6 +112,7 @@ fun rememberLiquidScreenState(
     return remember {
         LiquidScreenState(
             initialTitle = title,
+            initialIsTitleCollapsible = isTitleCollapsible,
             initialShowLeftButton = showLeftButton,
             initialShowRightButton = showRightButton,
             initialShowBlurLayer = showBlurLayer,

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsDetailFormScaffold.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsDetailFormScaffold.kt
@@ -7,16 +7,16 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
-import com.niki914.uikit.infra.liquidScreenHazeSource
 import com.niki914.uikit.infra.liquidScreenTopPadding
 
 /**
@@ -39,7 +39,7 @@ fun SettingsDetailFormScaffold(
     actionButtonLightContentColor: Color = Color.Unspecified,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    val scrollState = rememberScrollState()
+    val scrollState = rememberSaveable(saver = ScrollState.Saver, init = { ScrollState(initial = 0) })
     val contentModifier = if (onBackgroundTap != null) {
         Modifier.pointerInput(onBackgroundTap) {
             detectTapGestures(onTap = { onBackgroundTap() })
@@ -50,8 +50,7 @@ fun SettingsDetailFormScaffold(
 
     Box(
         modifier = modifier
-            .fillMaxSize()
-            .liquidScreenHazeSource(),
+            .fillMaxSize(),
     ) {
         Column(
             modifier = contentModifier

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsItemSurface.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsItemSurface.kt
@@ -37,7 +37,7 @@ fun SettingsItemSurface(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     minHeight: Dp = 64.dp,
-    contentPadding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 14.dp),
+    contentPadding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 20.dp),
     hapticFeedbackType: HapticFeedbackType? = HapticFeedbackType.ContextClick,
     highlightPulseKey: Any? = null,
     highlightPulseDurationMillis: Int = 500,

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsListItem.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsListItem.kt
@@ -36,9 +36,9 @@ fun SettingsListItem(
     onClick: (() -> Unit)? = null,
 ) {
     val contentPadding = if (leadingContent != null) {
-        PaddingValues(start = 20.dp, top = 14.dp, end = 16.dp, bottom = 14.dp)
+        PaddingValues(start = 20.dp, top = 20.dp, end = 16.dp, bottom = 20.dp)
     } else {
-        PaddingValues(horizontal = 16.dp, vertical = 14.dp)
+        PaddingValues(horizontal = 16.dp, vertical = 20.dp)
     }
 
     SettingsItemSurface(
@@ -56,7 +56,7 @@ fun SettingsListItem(
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 if (leadingContent != null) {
                     leadingContent()
@@ -109,7 +109,7 @@ fun SettingsListItem(
                             imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                             contentDescription = null,
                             tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.size(20.dp),
+                            modifier = Modifier.size(24.dp),
                         )
                     }
                 }

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsListPageContent.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsListPageContent.kt
@@ -4,17 +4,35 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.niki914.uikit.infra.liquidScreenHazeSource
+import androidx.compose.foundation.ScrollState
+import com.niki914.uikit.infra.nav.LocalPageTitle
+import com.niki914.uikit.infra.LocalTitleBarCollapseState
 import com.niki914.uikit.infra.liquidScreenTopPadding
 
 /**
  * 设置列表页容器，必须运行在 `LiquidScreen` 内容树内。
+ *
+ * 内容顶部渲染页面大标题（`LocalPageTitle`，由页面宿主按 entry 提供），
+ * 随滚动淡出并把折叠比例写回 `LocalTitleBarCollapseState`，
+ * 由 `LiquidScreen` 驱动顶栏小标题浮现与背景色渐显。
  *
  * Preview 或独立样例请用 `ProvideLiquidScreenContentForPreview` 提供壳层上下文。
  */
@@ -24,15 +42,42 @@ fun SettingsListPageContent(
     modifier: Modifier = Modifier,
     content: @Composable ColumnScope.() -> Unit,
 ) {
+    val scrollState = rememberSaveable(saver = ScrollState.Saver, init = { ScrollState(initial = 0) })
+    val collapseRangePx = with(LocalDensity.current) { 96.dp.toPx() }
+    // 大标题完全滚离的布尔判定；derivedStateOf 避免逐帧重组。
+    val isCollapsed by remember { derivedStateOf { scrollState.value > collapseRangePx } }
+
+    val titleCollapseState = LocalTitleBarCollapseState.current
+    // 用 snapshotFlow 订阅 derivedState：composition 不读它，不能用 SideEffect（不会重组重跑）。
+    // snapshotFlow 启动时先发射当前值：返回本页时立即纠正共享状态，
+    // 因此不需要 onDispose 重置（转场期间退场页写入后不会再次发射，不会覆盖新页的正确值）。
+    LaunchedEffect(titleCollapseState) {
+        snapshotFlow { isCollapsed }.collect { titleCollapseState.isCollapsed = it }
+    }
+
     Column(
         modifier = modifier
             .fillMaxSize()
-            .liquidScreenHazeSource()
-            .verticalScroll(rememberScrollState())
+            .verticalScroll(scrollState)
             .padding(top = liquidScreenTopPadding())
             .padding(horizontal = 20.dp, vertical = 24.dp),
         verticalArrangement = Arrangement.spacedBy(20.dp),
     ) {
+        val pageTitle = LocalPageTitle.current
+        if (pageTitle.isNotBlank()) {
+            Text(
+                text = pageTitle,
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .graphicsLayer {
+                        // 大标题随滚动连续淡出（跟随内容移动，与顶栏布尔动画互补）。
+                        alpha = 1f - (scrollState.value / collapseRangePx).coerceIn(0f, 1f)
+                    },
+            )
+        }
         if (!description.isNullOrBlank()) {
             PageDescriptionText(text = description)
         }

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsToggleListItemCard.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsToggleListItemCard.kt
@@ -60,7 +60,7 @@ private fun SettingsToggleListItemRow(
         SettingsItemSurface(
             modifier = Modifier.weight(1f),
             enabled = enabled,
-            contentPadding = PaddingValues(start = 16.dp, top = 14.dp, end = 0.dp, bottom = 14.dp),
+            contentPadding = PaddingValues(start = 16.dp, top = 20.dp, end = 0.dp, bottom = 20.dp),
             onClick = onClick,
         ) {
             Column(

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/component/settings/SettingsSpecPageContent.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/component/settings/SettingsSpecPageContent.kt
@@ -190,14 +190,14 @@ private fun SettingsRowLeadingIconContent(icon: SettingsRowLeadingIcon) {
             imageVector = icon.imageVector,
             contentDescription = null,
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.size(20.dp),
+            modifier = Modifier.size(28.dp),
         )
 
         is SettingsRowLeadingIcon.PainterResource -> Icon(
             painter = painterResource(id = icon.drawableResId),
             contentDescription = null,
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.size(20.dp),
+            modifier = Modifier.size(28.dp),
         )
     }
 }

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/nav/Page.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/nav/Page.kt
@@ -1,5 +1,13 @@
 package com.niki914.uikit.infra.nav
 
+import androidx.compose.runtime.compositionLocalOf
+
 interface Page {
     val routeKey: String
 }
+
+/**
+ * 当前导航 entry 解析后的页面标题字符串，由页面宿主按 entry 提供。
+ * 供需要复用页面标题的容器（如设置页大标题）消费，避免二次维护文案。
+ */
+val LocalPageTitle = compositionLocalOf { "" }


### PR DESCRIPTION
## Summary
- Remove the haze dependency; the top bar background is now a solid `surfaceContainerHigh` layer with alpha animation driven by content scroll state
- Add `TitleBarMode` (`Pinned` / `Collapsible`): Collapsible pages render a large in-content title via `SettingsListPageContent` that fades on scroll and reports collapse state through `LocalTitleBarCollapseState`
- Pinned pages use a root `NestedScrollConnection` to toggle the top bar background / small title
- Wrap page content in `SaveableStateProvider(entry.id)` and make scroll states saveable, so page state survives navigation
- Migrate `ModelConfigSettingsContent` to `SettingsListPageContent`; remove scattered `liquidScreenHazeSource` modifiers
- Misc: extract `isTitleCollapsible` val in `ZafiroApp`, item padding/chevron size adjustments, indentation fix

## Test plan
- [ ] Navigate Settings home → detail pages: large title scrolls out, small title + bar background fade in
- [ ] Back navigation restores scroll position and collapse state on Collapsible pages
- [ ] Pinned pages (home, conversation history): bar background appears only after leaving top