### PR TITLE
UI optimization: theme picker, liquid composer, bolder settings

### DIFF
--- a/app/src/main/java/com/niki914/zafiro/app/MainActivity.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/MainActivity.kt
@@ -9,7 +9,7 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import com.niki914.zafiro.app.ui.ZafiroApp
 import com.niki914.zafiro.app.ui.model.AppLaunchDecision
-import com.niki914.uikit.base.BaseTheme
+import com.niki914.zafiro.app.ui.model.ThemeController
 import kotlinx.coroutines.runBlocking
 
 // tag:niki914 | tag:nexus-x-log | message:niki914 | message:nexus-x-log
@@ -37,17 +37,18 @@ class MainActivity : AppCompatActivity() {
         NotificationPermissionGate.init(notificationPermissionLauncher)
         val startupAssistantUi = resolveStartupAssistantUi()
         val launchDecision = runBlocking {
-            AppLaunchDecision.resolve(startupAssistantUi)
+            val decision = AppLaunchDecision.resolve(startupAssistantUi)
+            // 同步读主题偏好：深色模式冷启动首帧不能闪白
+            ThemeController.load()
+            decision
         }
         applyLanguageTag(launchDecision.languageTag)
 
         setContent {
-            BaseTheme {
-                ZafiroApp(
-                    startupAssistantUi = startupAssistantUi,
-                    launchDecision = launchDecision,
-                )
-            }
+            ZafiroApp(
+                startupAssistantUi = startupAssistantUi,
+                launchDecision = launchDecision,
+            )
         }
     }
 

--- a/app/src/main/java/com/niki914/zafiro/app/ui/ZafiroApp.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/ZafiroApp.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModelProvider
 import com.niki914.zafiro.app.R
+import com.niki914.uikit.base.BaseTheme
 import com.niki914.uikit.infra.LiquidScreen
 import com.niki914.uikit.infra.LiquidScreenSwipeContent
 import com.niki914.uikit.infra.TitleDirection
@@ -57,6 +58,7 @@ import com.niki914.zafiro.app.ui.model.StartupAssistantUi
 import com.niki914.zafiro.app.ui.nav.HomePage
 import com.niki914.zafiro.app.ui.nav.ZafiroPage
 import com.niki914.zafiro.app.ui.nav.NoTitle
+import com.niki914.zafiro.app.ui.model.ThemeController
 import com.niki914.zafiro.app.ui.nav.PageTitleSpec
 import com.niki914.zafiro.app.ui.nav.ResTitle
 import com.niki914.zafiro.app.ui.nav.TextTitle
@@ -70,7 +72,9 @@ fun ZafiroApp(
 ) {
     val context = LocalContext.current
     val activity = context as? Activity
-    val isDarkTheme = isSystemInDarkTheme()
+    val systemDarkTheme = isSystemInDarkTheme()
+    val themePrefs = ThemeController.prefs
+    val isDarkTheme = themePrefs.resolveDarkTheme(systemDarkTheme)
     val actionIconTint = if (isDarkTheme) Color.White else Color.Black
     val rootBackToHomeWindowMillis = 2_000L
     val rootBackToHomeHint = stringResource(R.string.ui_root_back_to_home_hint)
@@ -231,140 +235,148 @@ fun ZafiroApp(
         }
     }
 
+    val seedColor = themePrefs.seedColor?.let { Color(it) }
+
     Box(modifier = Modifier.fillMaxSize()) {
-        LiquidScreen(
-            state = screenState,
-            actionsEnabled = !isPageTransitioning,
-            leftButton = currentLeftAction?.let { action ->
-                {
-                    AnimatedContent(
-                        targetState = action.icon,
-                        transitionSpec = {
-                            val iconAnimationSpec = tween<Float>(
-                                durationMillis = 280,
-                                easing = FastOutSlowInEasing,
-                            )
-                            (scaleIn(
-                                initialScale = 1.18f,
-                                animationSpec = iconAnimationSpec,
-                            ) + fadeIn(animationSpec = iconAnimationSpec)).togetherWith(
-                                scaleOut(
-                                    targetScale = 0.78f,
-                                    animationSpec = iconAnimationSpec,
-                                ) + fadeOut(animationSpec = iconAnimationSpec)
-                            )
-                        },
-                        label = "leftActionIcon",
-                    ) { imageVector ->
-                        ActionBarVectorIcon(
-                            imageVector = imageVector,
-                            tint = actionIconTint,
-                        )
-                    }
-                }
-            },
-            rightButton = currentRightAction?.let { action ->
-                {
-                    AnimatedContent(
-                        targetState = action.icon,
-                        transitionSpec = {
-                            val iconAnimationSpec = tween<Float>(
-                                durationMillis = 280,
-                                easing = FastOutSlowInEasing,
-                            )
-                            (scaleIn(
-                                initialScale = 1.18f,
-                                animationSpec = iconAnimationSpec,
-                            ) + fadeIn(animationSpec = iconAnimationSpec)).togetherWith(
-                                scaleOut(
-                                    targetScale = 0.78f,
-                                    animationSpec = iconAnimationSpec,
-                                ) + fadeOut(animationSpec = iconAnimationSpec)
-                            )
-                        },
-                        label = "rightActionIcon",
-                    ) { imageVector ->
-                        ActionBarVectorIcon(
-                            imageVector = imageVector,
-                            tint = actionIconTint,
-                        )
-                    }
-                }
-            },
+        BaseTheme(
+            darkTheme = isDarkTheme,
+            dynamicColor = themePrefs.seedColor == null,
+            seedColor = seedColor,
         ) {
-            Box(modifier = Modifier.fillMaxSize()) {
-                LiquidScreenSwipeContent(
-                    targetState = currentEntry,
-                    direction = controller.lastDirection,
-                    modifier = Modifier.fillMaxSize(),
-                    onTransitionActiveChanged = { active ->
-                        isPageTransitioning = active
-                    },
-                ) { entry ->
-                    val pageChromeRegistrar = remember(entry.id, pageChromeHost) {
-                        pageChromeHost.registrarFor(entry.id)
-                    }
-                    CompositionLocalProvider(
-                        LocalNavigationEntry provides entry,
-                        LocalPageChrome provides pageChromeRegistrar,
-                        LocalPageTitle provides resolveTitle(entry.page.titleSpec),
-                    ) {
-                        saveableStateHolder.SaveableStateProvider(entry.id) {
-                            ZafiroPageContent(
-                                entry = entry,
-                                startupAssistantUi = startupAssistantUi,
-                                onPush = ::push,
-                                onPushFromLeft = ::pushFromLeft,
-                                onPop = { navigator.pop() },
-                                onPopMultiple = { navigator.popMultiple(it) },
-                                onPopToRight = ::popToRight,
-                                onResetTo = ::resetTo,
-                                selectedConversationId = selectedConversationId,
-                                onConversationSelected = { id ->
-                                    selectedConversationId = id
-                                },
-                                onConversationSelectionConsumed = { id ->
-                                    if (selectedConversationId == id) {
-                                        selectedConversationId = null
-                                    }
-                                },
-                                activeConversationId = activeConversationId,
-                                activeConversationTitle = activeConversationTitle,
-                                onActiveConversationChanged = { id, title ->
-                                    activeConversationId = id
-                                    activeConversationTitle = title
-                                },
-                                onCurrentConversationDeleted = { id ->
-                                    deleteActiveConversation(id)
-                                },
+            LiquidScreen(
+                state = screenState,
+                actionsEnabled = !isPageTransitioning,
+                leftButton = currentLeftAction?.let { action ->
+                    {
+                        AnimatedContent(
+                            targetState = action.icon,
+                            transitionSpec = {
+                                val iconAnimationSpec = tween<Float>(
+                                    durationMillis = 280,
+                                    easing = FastOutSlowInEasing,
+                                )
+                                (scaleIn(
+                                    initialScale = 1.18f,
+                                    animationSpec = iconAnimationSpec,
+                                ) + fadeIn(animationSpec = iconAnimationSpec)).togetherWith(
+                                    scaleOut(
+                                        targetScale = 0.78f,
+                                        animationSpec = iconAnimationSpec,
+                                    ) + fadeOut(animationSpec = iconAnimationSpec)
+                                )
+                            },
+                            label = "leftActionIcon",
+                        ) { imageVector ->
+                            ActionBarVectorIcon(
+                                imageVector = imageVector,
+                                tint = actionIconTint,
                             )
                         }
                     }
-                }
-
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(top = screenState.actionBarHeight.value, end = 12.dp),
-                ) {
-                    DropdownMenu(
-                        expanded = chromeMenuExpanded && currentChrome.menuItems.isNotEmpty(),
-                        onDismissRequest = ::closeChromeMenu,
-                    ) {
-                        currentChrome.menuItems.forEach { item ->
-                            DropdownMenuItem(
-                                text = { Text(item.title) },
-                                onClick = {
-                                    closeChromeMenu()
-                                    item.onClick()
-                                },
+                },
+                rightButton = currentRightAction?.let { action ->
+                    {
+                        AnimatedContent(
+                            targetState = action.icon,
+                            transitionSpec = {
+                                val iconAnimationSpec = tween<Float>(
+                                    durationMillis = 280,
+                                    easing = FastOutSlowInEasing,
+                                )
+                                (scaleIn(
+                                    initialScale = 1.18f,
+                                    animationSpec = iconAnimationSpec,
+                                ) + fadeIn(animationSpec = iconAnimationSpec)).togetherWith(
+                                    scaleOut(
+                                        targetScale = 0.78f,
+                                        animationSpec = iconAnimationSpec,
+                                    ) + fadeOut(animationSpec = iconAnimationSpec)
+                                )
+                            },
+                            label = "rightActionIcon",
+                        ) { imageVector ->
+                            ActionBarVectorIcon(
+                                imageVector = imageVector,
+                                tint = actionIconTint,
                             )
+                        }
+                    }
+                },
+            ) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    LiquidScreenSwipeContent(
+                        targetState = currentEntry,
+                        direction = controller.lastDirection,
+                        modifier = Modifier.fillMaxSize(),
+                        onTransitionActiveChanged = { active ->
+                            isPageTransitioning = active
+                        },
+                    ) { entry ->
+                        val pageChromeRegistrar = remember(entry.id, pageChromeHost) {
+                            pageChromeHost.registrarFor(entry.id)
+                        }
+                        CompositionLocalProvider(
+                            LocalNavigationEntry provides entry,
+                            LocalPageChrome provides pageChromeRegistrar,
+                            LocalPageTitle provides resolveTitle(entry.page.titleSpec),
+                        ) {
+                            saveableStateHolder.SaveableStateProvider(entry.id) {
+                                ZafiroPageContent(
+                                    entry = entry,
+                                    startupAssistantUi = startupAssistantUi,
+                                    onPush = ::push,
+                                    onPushFromLeft = ::pushFromLeft,
+                                    onPop = { navigator.pop() },
+                                    onPopMultiple = { navigator.popMultiple(it) },
+                                    onPopToRight = ::popToRight,
+                                    onResetTo = ::resetTo,
+                                    selectedConversationId = selectedConversationId,
+                                    onConversationSelected = { id ->
+                                        selectedConversationId = id
+                                    },
+                                    onConversationSelectionConsumed = { id ->
+                                        if (selectedConversationId == id) {
+                                            selectedConversationId = null
+                                        }
+                                    },
+                                    activeConversationId = activeConversationId,
+                                    activeConversationTitle = activeConversationTitle,
+                                    onActiveConversationChanged = { id, title ->
+                                        activeConversationId = id
+                                        activeConversationTitle = title
+                                    },
+                                    onCurrentConversationDeleted = { id ->
+                                        deleteActiveConversation(id)
+                                    },
+                                )
+                            }
+                        }
+                    }
+
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(top = screenState.actionBarHeight.value, end = 12.dp),
+                    ) {
+                        DropdownMenu(
+                            expanded = chromeMenuExpanded && currentChrome.menuItems.isNotEmpty(),
+                            onDismissRequest = ::closeChromeMenu,
+                        ) {
+                            currentChrome.menuItems.forEach { item ->
+                                DropdownMenuItem(
+                                    text = { Text(item.title) },
+                                    onClick = {
+                                        closeChromeMenu()
+                                        item.onClick()
+                                    },
+                                )
+                            }
                         }
                     }
                 }
             }
+            currentChrome.overlay?.invoke()
         }
-        currentChrome.overlay?.invoke()
     }
 }
 

--- a/app/src/main/java/com/niki914/zafiro/app/ui/ZafiroPageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/ZafiroPageContent.kt
@@ -18,6 +18,7 @@ import com.niki914.zafiro.app.ui.nav.SavedConfigDetailPage
 import com.niki914.zafiro.app.ui.nav.SettingsDetailPage
 import com.niki914.zafiro.app.ui.nav.SettingsHomePage
 import com.niki914.zafiro.app.ui.nav.SettingsProviderPickPage
+import com.niki914.zafiro.app.ui.nav.ThemeSettingsPage
 import com.niki914.zafiro.app.ui.nav.SkillDetailPage
 import com.niki914.zafiro.app.ui.nav.CustomPyToolDetailPage
 import com.niki914.zafiro.app.ui.nav.CustomPyToolsPage
@@ -35,6 +36,7 @@ import com.niki914.zafiro.app.ui.route.SavedConfigDetailRoute
 import com.niki914.zafiro.app.ui.route.SettingsDetailPageRoute
 import com.niki914.zafiro.app.ui.route.SettingsHomePageRoute
 import com.niki914.zafiro.app.ui.route.SettingsProviderPickPageRoute
+import com.niki914.zafiro.app.ui.route.ThemeSettingsPageRoute
 import com.niki914.zafiro.app.ui.route.SkillDetailRoute
 import com.niki914.zafiro.app.ui.route.StartupPageRoute
 import com.niki914.zafiro.app.ui.route.TakeoverRuleDetailRoute
@@ -70,6 +72,8 @@ fun ZafiroPageContent(
         SettingsProviderPickPage -> SettingsProviderPickPageRoute(
             onPush = onPush,
         )
+
+        ThemeSettingsPage -> ThemeSettingsPageRoute()
 
         is ConfigurePage -> ConfigurePageRoute(
             page = page,

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/ConversationHistoryPageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/ConversationHistoryPageContent.kt
@@ -107,9 +107,9 @@ private fun ConversationHistoryListContent(
         modifier = modifier
             .fillMaxSize(),
         contentPadding = PaddingValues(
-            start = 20.dp,
+            start = 16.dp,
             top = liquidScreenTopPadding(24.dp),
-            end = 20.dp,
+            end = 16.dp,
             bottom = 24.dp,
         ),
         verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -152,7 +152,7 @@ private fun ConversationHistoryMessageContent(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .padding(horizontal = 20.dp)
+            .padding(horizontal = 16.dp)
             .padding(top = liquidScreenTopPadding(24.dp), bottom = 24.dp),
         contentAlignment = Alignment.TopCenter,
     ) {

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/GeneralSettingsContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/GeneralSettingsContent.kt
@@ -18,6 +18,10 @@ import com.niki914.uikit.infra.component.settings.SettingsRowSpec
 import com.niki914.uikit.infra.component.settings.SettingsSectionLayout
 import com.niki914.uikit.infra.component.settings.SettingsSectionSpec
 import com.niki914.uikit.infra.component.settings.SettingsSpecPageContent
+import com.niki914.zafiro.app.ui.model.ThemeController
+import com.niki914.zafiro.app.ui.model.ThemeMode
+import com.niki914.zafiro.app.ui.nav.ThemeSettingsPage
+import com.niki914.zafiro.app.ui.nav.ZafiroPage
 import com.niki914.zafiro.repo.XRepo
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -27,6 +31,7 @@ import kotlinx.coroutines.runBlocking
  * 容器与 About 同款（SettingsSpecPageContent + GroupedCard）。
  */
 private const val LANGUAGE_ROW_ID = "general.language"
+private const val APPEARANCE_ROW_ID = "general.appearance"
 private const val LOAD_LAST_ROW_ID = "general.load_last"
 
 private const val LANGUAGE_TAG_ZH_CN = "zh-CN"
@@ -55,7 +60,7 @@ private fun languageOptions(): List<LanguageOption> {
 }
 
 @Composable
-fun GeneralSettingsContent() {
+fun GeneralSettingsContent(onPush: (ZafiroPage) -> Unit = {}) {
     val scope = rememberCoroutineScope()
     var savedLanguageTag by rememberSaveable { mutableStateOf<String?>(null) }
     var loadLastConversation by rememberSaveable { mutableStateOf(false) }
@@ -86,6 +91,11 @@ fun GeneralSettingsContent() {
                         title = stringResource(R.string.ui_settings_general_language),
                         currentState = selectedLabel,
                     ),
+                    SettingsRowSpec.Navigation(
+                        id = APPEARANCE_ROW_ID,
+                        title = stringResource(R.string.ui_settings_appearance),
+                        currentState = appearanceSummary(),
+                    ),
                     SettingsRowSpec.Toggle(
                         id = LOAD_LAST_ROW_ID,
                         title = stringResource(R.string.ui_settings_general_load_last_conversation),
@@ -103,6 +113,8 @@ fun GeneralSettingsContent() {
                 is SettingsRowAction.Navigate ->
                     if (action.id == LANGUAGE_ROW_ID) {
                         showLanguageDialog = true
+                    } else if (action.id == APPEARANCE_ROW_ID) {
+                        onPush(ThemeSettingsPage)
                     }
 
                 is SettingsRowAction.ToggleChanged ->
@@ -143,4 +155,19 @@ fun GeneralSettingsContent() {
                 )
             },
         )
+}
+
+@Composable
+private fun appearanceSummary(): String {
+    val prefs = ThemeController.prefs
+    val modeLabel = when (prefs.mode) {
+        ThemeMode.System -> stringResource(R.string.ui_theme_mode_system)
+        ThemeMode.Light -> stringResource(R.string.ui_theme_mode_light)
+        ThemeMode.Dark -> stringResource(R.string.ui_theme_mode_dark)
+    }
+    val colorLabel = prefs.seedColor
+        ?.let { seed -> ThemeSeedColors.indexOf(seed).takeIf { it >= 0 } }
+        ?.let { stringResource(ThemeColorLabelRes[it]) }
+        ?: stringResource(R.string.ui_theme_color_dynamic)
+    return "$modeLabel · $colorLabel"
 }

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/HomeChatComponents.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/HomeChatComponents.kt
@@ -16,10 +16,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.CallSplit
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.Send
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
@@ -34,6 +32,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
@@ -48,6 +47,7 @@ import com.mikepenz.markdown.m3.Markdown
 import com.mikepenz.markdown.m3.markdownTypography
 import com.mikepenz.markdown.model.rememberMarkdownState
 import com.niki914.zafiro.app.R
+import com.niki914.uikit.infra.ActionBarButton
 import com.niki914.uikit.infra.component.LiquidTextField
 import com.niki914.uikit.infra.shape.G2BubbleShape
 import com.niki914.uikit.infra.shape.G2CardShape
@@ -407,13 +407,13 @@ fun LiquidChatComposer(
         enabled = true,
         singleLine = false,
         maxLines = maxLines,
+        minHeight = 68.dp,
         modifier = modifier.fillMaxWidth(),
         trailingContent = {
             CompositionLocalProvider(LocalContentColor provides contentColor) {
-                IconButton(
+                ActionBarButton(
                     onClick = if (isGenerating) onStopClick else onSendClick,
                     enabled = buttonEnabled,
-                    modifier = Modifier.size(40.dp),
                 ) {
                     if (isGenerating) {
                         LoadingIndicator(
@@ -426,7 +426,7 @@ fun LiquidChatComposer(
                         )
                     } else {
                         Icon(
-                            imageVector = Icons.Default.Send,
+                            painter = painterResource(R.drawable.ic_arrow_up),
                             contentDescription = stringResource(
                                 R.string.ui_home_send_content_description
                             ),

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.unit.dp
 import com.niki914.zafiro.app.R
 import com.niki914.uikit.infra.ConfirmationLiquidDialog
 import com.niki914.uikit.infra.LocalLiquidViewportAvoidanceController
+import com.niki914.uikit.infra.LocalTitleBarCollapseState
 import com.niki914.uikit.infra.ProvideLiquidScreenContentForPreview
 import com.niki914.uikit.infra.liquidScreenTopPadding
 import com.niki914.uikit.infra.nav.pageViewModel
@@ -117,6 +118,18 @@ fun HomePageContent(
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
     val listState = rememberLazyListState()
+
+    // Home Chat 是可 saveable 恢复滚动位置的 Pinned 页：自报滚动状态给顶栏，
+    // 使返回时（scroll 恢复但不产生滚动事件）背景板能立即回到实色。
+    val titleBarCollapseState = LocalTitleBarCollapseState.current
+    LaunchedEffect(titleBarCollapseState, listState) {
+        snapshotFlow {
+            listState.firstVisibleItemIndex > 0 || listState.firstVisibleItemScrollOffset > 0
+        }.collect { scrolled ->
+            titleBarCollapseState.hasReporter = true
+            titleBarCollapseState.isCollapsed = scrolled
+        }
+    }
     val imeBottom = with(density) { WindowInsets.ime.getBottom(this).toDp() }
     val navigationBottom = with(density) { WindowInsets.navigationBars.getBottom(this).toDp() }
     var isComposerFocused by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/SelectionPageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/SelectionPageContent.kt
@@ -2,16 +2,19 @@ package com.niki914.zafiro.app.ui.content
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -20,12 +23,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.niki914.zafiro.app.R
+import com.niki914.uikit.base.LocalAppDarkTheme
 import com.niki914.uikit.infra.component.SettingsGroupCard
 import com.niki914.uikit.infra.component.SettingsItemDivider
 import com.niki914.uikit.infra.component.SettingsListItem
@@ -34,14 +39,107 @@ import com.niki914.uikit.infra.liquidScreenTopPadding
 data class SelectionOption(
     val id: String,
     val title: String,
-    @DrawableRes val leadingIconRes: Int,
+    @DrawableRes val leadingIconRes: Int? = null,
     val tintLeadingIcon: Boolean = true,
+    /** 非空时 leading 渲染为该颜色的圆形色板（优先于 leadingIconRes）。 */
+    val leadingSwatchColor: Color? = null,
+    /** Vector 图标（与 leadingIconRes 二选一）。 */
+    val leadingIconVector: ImageVector? = null,
     val darkContainerColor: Color? = null,
     val lightContainerColor: Color? = null,
     val darkContentColor: Color? = null,
     val lightContentColor: Color? = null,
+    /** 选中态：trailing 渲染对勾，不渲染 chevron。 */
+    val selected: Boolean = false,
     val onClick: () -> Unit,
 )
+
+/** 单个选项行：56dp 圆形 leading（色板或图标）+ 选中对勾。 */
+@Composable
+internal fun SelectionOptionRow(
+    option: SelectionOption,
+    isDarkTheme: Boolean,
+) {
+    val brandContainer = if (isDarkTheme) option.darkContainerColor else option.lightContainerColor
+    val brandContent = if (isDarkTheme) option.darkContentColor else option.lightContentColor
+    SettingsListItem(
+        title = option.title,
+        showChevron = !option.selected,
+        enabled = true,
+        trailingContent = if (option.selected) {
+            {
+                Icon(
+                    imageVector = Icons.Rounded.Check,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(24.dp),
+                )
+            }
+        } else {
+            null
+        },
+        leadingContent = {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(CircleShape)
+                    .background(
+                        option.leadingSwatchColor
+                            ?: brandContainer
+                            ?: MaterialTheme.colorScheme.surfaceContainerHighest
+                    ),
+            ) {
+                val iconRes = option.leadingIconRes
+                val iconVector = option.leadingIconVector
+                if (iconRes != null) {
+                    Icon(
+                        painter = painterResource(iconRes),
+                        contentDescription = null,
+                        tint = when {
+                            !option.tintLeadingIcon -> Color.Unspecified
+                            brandContent != null -> brandContent
+                            else -> MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                        modifier = Modifier.size(24.dp),
+                    )
+                } else if (iconVector != null) {
+                    Icon(
+                        imageVector = iconVector,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(24.dp),
+                    )
+                } else if (option.leadingSwatchColor != null && option.selected) {
+                    Icon(
+                        imageVector = Icons.Rounded.Check,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimary,
+                        modifier = Modifier.size(24.dp),
+                    )
+                }
+            }
+        },
+        onClick = option.onClick,
+    )
+}
+
+/** 分组卡片形式的选项列表：组内 divider 分隔。 */
+@Composable
+internal fun SelectionGroupCard(
+    options: List<SelectionOption>,
+    isDarkTheme: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    SettingsGroupCard(modifier = modifier) {
+        options.forEachIndexed { index, option ->
+            SelectionOptionRow(option, isDarkTheme)
+            if (index != options.lastIndex) {
+                SettingsItemDivider()
+            }
+        }
+    }
+}
 
 @Composable
 fun SelectionPageContent(
@@ -65,44 +163,6 @@ fun SelectionPageContent(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
 
-        SettingsGroupCard {
-            val isDarkTheme = isSystemInDarkTheme()
-            options.forEachIndexed { index, option ->
-                val brandContainer = if (isDarkTheme) option.darkContainerColor else option.lightContainerColor
-                val brandContent = if (isDarkTheme) option.darkContentColor else option.lightContentColor
-                SettingsListItem(
-                    title = option.title,
-                    showChevron = true,
-                    enabled = true,
-                    leadingContent = {
-                        Box(
-                            contentAlignment = Alignment.Center,
-                            modifier = Modifier
-                                .size(56.dp)
-                                .clip(CircleShape)
-                                .background(
-                                    brandContainer
-                                        ?: MaterialTheme.colorScheme.surfaceContainerHighest
-                                ),
-                        ) {
-                            Icon(
-                                painter = painterResource(option.leadingIconRes),
-                                contentDescription = null,
-                                tint = when {
-                                    !option.tintLeadingIcon -> Color.Unspecified
-                                    brandContent != null -> brandContent
-                                    else -> MaterialTheme.colorScheme.onSurfaceVariant
-                                },
-                                modifier = Modifier.size(24.dp),
-                            )
-                        }
-                    },
-                    onClick = option.onClick,
-                )
-                if (index != options.lastIndex) {
-                    SettingsItemDivider()
-                }
-            }
-        }
+        SelectionGroupCard(options = options, isDarkTheme = LocalAppDarkTheme.current)
     }
 }

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/SelectionPageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/SelectionPageContent.kt
@@ -1,25 +1,34 @@
 package com.niki914.zafiro.app.ui.content
 
 import androidx.annotation.DrawableRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.niki914.zafiro.app.R
-import com.niki914.uikit.infra.component.TintLiquidButton
+import com.niki914.uikit.infra.component.SettingsGroupCard
+import com.niki914.uikit.infra.component.SettingsItemDivider
+import com.niki914.uikit.infra.component.SettingsListItem
 import com.niki914.uikit.infra.liquidScreenTopPadding
 
 data class SelectionOption(
@@ -27,10 +36,10 @@ data class SelectionOption(
     val title: String,
     @DrawableRes val leadingIconRes: Int,
     val tintLeadingIcon: Boolean = true,
-    val darkContainerColor: Color = Color.Unspecified,
-    val lightContainerColor: Color = Color.Unspecified,
-    val darkContentColor: Color = Color.Unspecified,
-    val lightContentColor: Color = Color.Unspecified,
+    val darkContainerColor: Color? = null,
+    val lightContainerColor: Color? = null,
+    val darkContentColor: Color? = null,
+    val lightContentColor: Color? = null,
     val onClick: () -> Unit,
 )
 
@@ -43,7 +52,7 @@ fun SelectionPageContent(
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
             .padding(top = liquidScreenTopPadding())
-            .padding(horizontal = 20.dp, vertical = 24.dp),
+            .padding(horizontal = 16.dp, vertical = 24.dp),
         verticalArrangement = Arrangement.spacedBy(20.dp),
     ) {
         Text(
@@ -56,19 +65,44 @@ fun SelectionPageContent(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
 
-        options.forEach { option ->
-            TintLiquidButton(
-                text = option.title,
-                leadingIconRes = option.leadingIconRes,
-                trailingIcon = Icons.AutoMirrored.Filled.ArrowForward,
-                tintLeadingIcon = option.tintLeadingIcon,
-                buttonHeight = 52.dp,
-                darkContainerColor = option.darkContainerColor,
-                lightContainerColor = option.lightContainerColor,
-                darkContentColor = option.darkContentColor,
-                lightContentColor = option.lightContentColor,
-                onClick = option.onClick,
-            )
+        SettingsGroupCard {
+            val isDarkTheme = isSystemInDarkTheme()
+            options.forEachIndexed { index, option ->
+                val brandContainer = if (isDarkTheme) option.darkContainerColor else option.lightContainerColor
+                val brandContent = if (isDarkTheme) option.darkContentColor else option.lightContentColor
+                SettingsListItem(
+                    title = option.title,
+                    showChevron = true,
+                    enabled = true,
+                    leadingContent = {
+                        Box(
+                            contentAlignment = Alignment.Center,
+                            modifier = Modifier
+                                .size(56.dp)
+                                .clip(CircleShape)
+                                .background(
+                                    brandContainer
+                                        ?: MaterialTheme.colorScheme.surfaceContainerHighest
+                                ),
+                        ) {
+                            Icon(
+                                painter = painterResource(option.leadingIconRes),
+                                contentDescription = null,
+                                tint = when {
+                                    !option.tintLeadingIcon -> Color.Unspecified
+                                    brandContent != null -> brandContent
+                                    else -> MaterialTheme.colorScheme.onSurfaceVariant
+                                },
+                                modifier = Modifier.size(24.dp),
+                            )
+                        }
+                    },
+                    onClick = option.onClick,
+                )
+                if (index != options.lastIndex) {
+                    SettingsItemDivider()
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/SettingsDetailPageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/SettingsDetailPageContent.kt
@@ -70,7 +70,7 @@ fun SettingsDetailPageContent(
     }
 
     if (group == ZafiroSettingsGroup.GeneralSettings) {
-        GeneralSettingsContent()
+        GeneralSettingsContent(onPush = onPush)
         return
     }
 

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/StartupPageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/StartupPageContent.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import com.niki914.zafiro.animation.PointerCurveMath
 import com.niki914.zafiro.app.R
+import com.niki914.uikit.base.LocalAppDarkTheme
 import com.niki914.uikit.infra.component.MaterialTintLiquidButton
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
@@ -215,7 +216,7 @@ fun StartupPageContent(
     }
 
     val bgColor = MaterialTheme.colorScheme.background
-    val isDarkTheme = isSystemInDarkTheme()
+    val isDarkTheme = LocalAppDarkTheme.current
 
     val letterGradientColors = if (isDarkTheme) {
         listOf(Color(0xFFE8ECF2), Color(0xFFB8BFC8), Color(0xFF6E747C))

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/ThemeSettingsContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/ThemeSettingsContent.kt
@@ -1,0 +1,93 @@
+package com.niki914.zafiro.app.ui.content
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.BrightnessAuto
+import androidx.compose.material.icons.rounded.DarkMode
+import androidx.compose.material.icons.rounded.LightMode
+import androidx.compose.material.icons.rounded.Palette
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import com.niki914.uikit.base.LocalAppDarkTheme
+import com.niki914.uikit.infra.component.SettingsListPageContent
+import com.niki914.zafiro.app.R
+import com.niki914.zafiro.app.ui.model.ThemeController
+import com.niki914.zafiro.app.ui.model.ThemeMode
+import kotlinx.coroutines.launch
+
+/** 主题预设种子色（ARGB），顺序与 [themeColorLabelRes] 一一对应。 */
+internal val ThemeSeedColors: List<Int> = listOf(
+    0xFFFEB4A7.toInt(), 0xFFFFB3C0.toInt(), 0xFFFCAAFF.toInt(), 0xFFB9C3FF.toInt(),
+    0xFF62D3FF.toInt(), 0xFF44D9F1.toInt(), 0xFF52DBC9.toInt(), 0xFF78DD77.toInt(),
+    0xFF9FD75C.toInt(), 0xFFC1D02D.toInt(), 0xFFFABD00.toInt(), 0xFFFFB86E.toInt(),
+)
+
+internal val ThemeColorLabelRes: List<Int> = listOf(
+    R.string.ui_theme_color_rose,
+    R.string.ui_theme_color_blossom,
+    R.string.ui_theme_color_lavender,
+    R.string.ui_theme_color_blue,
+    R.string.ui_theme_color_sky,
+    R.string.ui_theme_color_cyan,
+    R.string.ui_theme_color_mint,
+    R.string.ui_theme_color_green,
+    R.string.ui_theme_color_lime,
+    R.string.ui_theme_color_lemon,
+    R.string.ui_theme_color_amber,
+    R.string.ui_theme_color_sunset,
+)
+
+@Composable
+fun ThemeSettingsContent() {
+    val scope = rememberCoroutineScope()
+    val prefs = ThemeController.prefs
+    val isDarkTheme = LocalAppDarkTheme.current
+
+    val modeOptions = listOf(
+        Triple(ThemeMode.System, Icons.Rounded.BrightnessAuto, R.string.ui_theme_mode_system),
+        Triple(ThemeMode.Light, Icons.Rounded.LightMode, R.string.ui_theme_mode_light),
+        Triple(ThemeMode.Dark, Icons.Rounded.DarkMode, R.string.ui_theme_mode_dark),
+    )
+
+    SettingsListPageContent {
+        SelectionGroupCard(
+            options = modeOptions.map { (mode, icon, labelRes) ->
+                SelectionOption(
+                    id = mode.storageKey,
+                    title = stringResource(labelRes),
+                    selected = prefs.mode == mode,
+                    onClick = { scope.launch { ThemeController.setMode(mode) } },
+                    leadingIconVector = icon,
+                )
+            },
+            isDarkTheme = isDarkTheme,
+        )
+
+        SelectionGroupCard(
+            options = buildList {
+                add(
+                    SelectionOption(
+                        id = "dynamic",
+                        title = stringResource(R.string.ui_theme_color_dynamic),
+                        selected = prefs.seedColor == null,
+                        onClick = { scope.launch { ThemeController.setSeedColor(null) } },
+                        leadingIconVector = Icons.Rounded.Palette,
+                    )
+                )
+                ThemeSeedColors.forEachIndexed { index, argb ->
+                    add(
+                        SelectionOption(
+                            id = "seed-$argb",
+                            title = stringResource(ThemeColorLabelRes[index]),
+                            leadingSwatchColor = Color(argb),
+                            selected = prefs.seedColor == argb,
+                            onClick = { scope.launch { ThemeController.setSeedColor(argb) } },
+                        )
+                    )
+                }
+            },
+            isDarkTheme = isDarkTheme,
+        )
+    }
+}

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/ProviderSpec.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/ProviderSpec.kt
@@ -21,8 +21,6 @@ sealed interface ProviderSpec {
 
 data class ProviderVisualTokens(
     val button: ProviderButtonTokens,
-    val iconBadge: ProviderIconBadgeTokens? = null,
-    val page: ProviderPageTokens? = null,
 )
 
 data class ProviderButtonTokens(
@@ -31,26 +29,6 @@ data class ProviderButtonTokens(
     @ColorRes val darkContentColorRes: Int? = null,
     @ColorRes val lightContentColorRes: Int? = null,
 )
-
-data class ProviderIconBadgeTokens(
-    @ColorRes val darkContainerColorRes: Int?,
-    @ColorRes val lightContainerColorRes: Int?,
-    @ColorRes val darkContentColorRes: Int?,
-    @ColorRes val lightContentColorRes: Int?,
-)
-
-data class ProviderPageTokens(
-    @ColorRes val preferredAccentColorRes: Int? = null,
-    val suggestedOnAccentMode: OnAccentMode? = null,
-    @ColorRes val reservedDarkBackgroundColorRes: Int? = null,
-    @ColorRes val reservedLightBackgroundColorRes: Int? = null,
-)
-
-enum class OnAccentMode {
-    Light,
-    Dark,
-    AutoContrast,
-}
 
 object ProviderSpecs {
     val default: ProviderSpec = DeepSeekSpec

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/ThemeController.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/ThemeController.kt
@@ -1,0 +1,65 @@
+package com.niki914.zafiro.app.ui.model
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.niki914.logging.Logger
+import com.niki914.zafiro.repo.XRepo
+
+/** 深浅色模式。 */
+enum class ThemeMode(val storageKey: String) {
+    System("system"),
+    Light("light"),
+    Dark("dark");
+
+    companion object {
+        fun fromStorageKey(value: String?): ThemeMode =
+            entries.firstOrNull { it.storageKey == value } ?: System
+    }
+}
+
+/** 主题偏好：深浅色模式 + 种子色（空 = 跟随壁纸动态色）。 */
+data class ThemePrefs(
+    val mode: ThemeMode = ThemeMode.System,
+    /** ARGB int；null = 壁纸动态色。 */
+    val seedColor: Int? = null,
+) {
+    fun resolveDarkTheme(systemDark: Boolean): Boolean = when (mode) {
+        ThemeMode.System -> systemDark
+        ThemeMode.Light -> false
+        ThemeMode.Dark -> true
+    }
+}
+
+/**
+ * 全局主题状态单一来源：MainActivity 冷启动时 [load]，主题设置页经 [setMode]/[setSeedColor]
+ * 更新内存并落盘（调用方用组合作用域 launch），ZafiroApp 据此驱动 BaseTheme。
+ */
+object ThemeController {
+    var prefs by mutableStateOf(ThemePrefs())
+        private set
+
+    suspend fun load() {
+        runCatching {
+            prefs = ThemePrefs(
+                mode = ThemeMode.fromStorageKey(XRepo.themeMode()),
+                seedColor = XRepo.themeSeedColor().takeIf { it.isNotBlank() }?.toLongOrNull(16)?.toInt(),
+            )
+        }.onFailure {
+            Logger.w("niki914_nexus_ThemeController", "load failed ${it.message}")
+        }
+    }
+
+    suspend fun setMode(mode: ThemeMode) {
+        prefs = prefs.copy(mode = mode)
+        runCatching { XRepo.setThemeMode(mode.storageKey) }
+            .onFailure { Logger.w("niki914_nexus_ThemeController", "persist mode failed ${it.message}") }
+    }
+
+    suspend fun setSeedColor(argb: Int?) {
+        prefs = prefs.copy(seedColor = argb)
+        val hex = argb?.let { "%08X".format(it) } ?: ""
+        runCatching { XRepo.setThemeSeedColor(hex) }
+            .onFailure { Logger.w("niki914_nexus_ThemeController", "persist seed failed ${it.message}") }
+    }
+}

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/ThemeController.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/ThemeController.kt
@@ -20,9 +20,9 @@ enum class ThemeMode(val storageKey: String) {
 
 /** 主题偏好：深浅色模式 + 种子色（空 = 跟随壁纸动态色）。 */
 data class ThemePrefs(
-    val mode: ThemeMode = ThemeMode.System,
+    val mode: ThemeMode = ThemeMode.Dark,
     /** ARGB int；null = 壁纸动态色。 */
-    val seedColor: Int? = null,
+    val seedColor: Int? = 0xFF52DBC9.toInt(),
 ) {
     fun resolveDarkTheme(systemDark: Boolean): Boolean = when (mode) {
         ThemeMode.System -> systemDark

--- a/app/src/main/java/com/niki914/zafiro/app/ui/nav/ZafiroPages.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/nav/ZafiroPages.kt
@@ -121,6 +121,15 @@ data object ConversationHistoryPage : ZafiroPage {
     override val rightAction: TopBarActionSpec? = null
 }
 
+data object ThemeSettingsPage : ZafiroPage {
+    override val routeKey: String = "theme-settings"
+    override val titleSpec: PageTitleSpec = ResTitle(R.string.ui_settings_appearance)
+    override val leftAction: TopBarActionSpec =
+        TopBarActionSpec(Icons.AutoMirrored.Filled.ArrowBack)
+    override val rightAction: TopBarActionSpec? = null
+    override val titleMode: TitleBarMode = TitleBarMode.Collapsible
+}
+
 data object SettingsHomePage : ZafiroPage {
     override val routeKey: String = "settings-home"
     override val titleSpec: PageTitleSpec = ResTitle(R.string.ui_settings_title)

--- a/app/src/main/java/com/niki914/zafiro/app/ui/route/ProviderPickPageRoute.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/route/ProviderPickPageRoute.kt
@@ -14,16 +14,16 @@ internal fun ProviderPickPageRoute(
 ) {
     SelectionPageContent(
         options = ProviderSpecs.all.map { spec ->
-            val colors = providerButtonColors(spec)
+            val colors = providerButtonColorsOrNull(spec)
             SelectionOption(
                 id = spec.id,
                 title = spec.brandName,
                 leadingIconRes = spec.iconRes,
                 tintLeadingIcon = spec.tintIcon,
-                darkContainerColor = colors.darkContainerColor,
-                lightContainerColor = colors.lightContainerColor,
-                darkContentColor = colors.darkContentColor,
-                lightContentColor = colors.lightContentColor,
+                darkContainerColor = colors?.darkContainerColor,
+                lightContainerColor = colors?.lightContainerColor,
+                darkContentColor = colors?.darkContentColor,
+                lightContentColor = colors?.lightContentColor,
                 onClick = {
                     onPush(
                         ConfigurePage(

--- a/app/src/main/java/com/niki914/zafiro/app/ui/route/ProviderRouteColors.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/route/ProviderRouteColors.kt
@@ -19,6 +19,15 @@ internal fun providerButtonColors(spec: ProviderSpec): ProviderButtonColors {
     return spec.visualTokens.button.toProviderButtonColors()
 }
 
+/** 无显式品牌色（如 Gemini）时返回 null，调用方回退到中性圆底。 */
+@Composable
+internal fun providerButtonColorsOrNull(spec: ProviderSpec): ProviderButtonColors? {
+    val button = spec.visualTokens.button
+    val hasExplicitColors = button.darkContainerColorRes != null ||
+            button.lightContainerColorRes != null
+    return if (hasExplicitColors) button.toProviderButtonColors() else null
+}
+
 @Composable
 internal fun ProviderButtonTokens.toProviderButtonColors(): ProviderButtonColors {
     val colorScheme = MaterialTheme.colorScheme

--- a/app/src/main/java/com/niki914/zafiro/app/ui/route/SettingsProviderPickPageRoute.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/route/SettingsProviderPickPageRoute.kt
@@ -6,7 +6,6 @@ import com.niki914.zafiro.app.ui.content.SelectionPageContent
 import com.niki914.zafiro.app.ui.model.ProviderSpecs
 import com.niki914.zafiro.app.ui.nav.ZafiroPage
 import com.niki914.zafiro.app.ui.nav.SavedConfigDetailPage
-import com.niki914.zafiro.app.ui.nav.TextTitle
 
 @Composable
 internal fun SettingsProviderPickPageRoute(
@@ -14,16 +13,16 @@ internal fun SettingsProviderPickPageRoute(
 ) {
     SelectionPageContent(
         options = ProviderSpecs.all.map { spec ->
-            val colors = providerButtonColors(spec)
+            val colors = providerButtonColorsOrNull(spec)
             SelectionOption(
                 id = spec.id,
                 title = spec.brandName,
                 leadingIconRes = spec.iconRes,
                 tintLeadingIcon = spec.tintIcon,
-                darkContainerColor = colors.darkContainerColor,
-                lightContainerColor = colors.lightContainerColor,
-                darkContentColor = colors.darkContentColor,
-                lightContentColor = colors.lightContentColor,
+                darkContainerColor = colors?.darkContainerColor,
+                lightContainerColor = colors?.lightContainerColor,
+                darkContentColor = colors?.darkContentColor,
+                lightContentColor = colors?.lightContentColor,
                 onClick = {
                     onPush(
                         SavedConfigDetailPage(

--- a/app/src/main/java/com/niki914/zafiro/app/ui/route/ThemeSettingsPageRoute.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/route/ThemeSettingsPageRoute.kt
@@ -1,0 +1,9 @@
+package com.niki914.zafiro.app.ui.route
+
+import androidx.compose.runtime.Composable
+import com.niki914.zafiro.app.ui.content.ThemeSettingsContent
+
+@Composable
+internal fun ThemeSettingsPageRoute() {
+    ThemeSettingsContent()
+}

--- a/app/src/main/java/com/niki914/zafiro/repo/AppStateSettingsCodec.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/AppStateSettingsCodec.kt
@@ -14,11 +14,11 @@ internal data class AppStateSettings(
     /** BCP-47 tag；空串 = 跟随系统语言。 */
     val languageTag: String = "",
     /** 冷启动是否恢复上次会话；false = 默认进入新对话。 */
-    val loadLastConversationOnStartup: Boolean = false,
+    val loadLastConversationOnStartup: Boolean = true,
     /** 主题深浅色模式；system/light/dark。 */
-    val themeMode: String = "system",
+    val themeMode: String = "dark",
     /** 主题种子色 ARGB hex；空串 = 跟随壁纸动态色。 */
-    val themeSeedColor: String = "",
+    val themeSeedColor: String = "FF52DBC9",
 )
 
 internal object AppStateSettingsCodec {
@@ -32,10 +32,10 @@ internal object AppStateSettingsCodec {
             languageTag = root.string(LANGUAGE_TAG_KEY),
             loadLastConversationOnStartup = root.boolean(
                 LOAD_LAST_CONVERSATION_KEY,
-                default = false
+                default = true
             ),
-            themeMode = root.string(THEME_MODE_KEY).ifBlank { "system" },
-            themeSeedColor = root.string(THEME_SEED_COLOR_KEY),
+            themeMode = root.string(THEME_MODE_KEY).ifBlank { "dark" },
+            themeSeedColor = root.string(THEME_SEED_COLOR_KEY).ifBlank { "FF52DBC9" },
         )
     }
 

--- a/app/src/main/java/com/niki914/zafiro/repo/AppStateSettingsCodec.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/AppStateSettingsCodec.kt
@@ -15,6 +15,10 @@ internal data class AppStateSettings(
     val languageTag: String = "",
     /** 冷启动是否恢复上次会话；false = 默认进入新对话。 */
     val loadLastConversationOnStartup: Boolean = false,
+    /** 主题深浅色模式；system/light/dark。 */
+    val themeMode: String = "system",
+    /** 主题种子色 ARGB hex；空串 = 跟随壁纸动态色。 */
+    val themeSeedColor: String = "",
 )
 
 internal object AppStateSettingsCodec {
@@ -30,6 +34,8 @@ internal object AppStateSettingsCodec {
                 LOAD_LAST_CONVERSATION_KEY,
                 default = false
             ),
+            themeMode = root.string(THEME_MODE_KEY).ifBlank { "system" },
+            themeSeedColor = root.string(THEME_SEED_COLOR_KEY),
         )
     }
 
@@ -42,6 +48,8 @@ internal object AppStateSettingsCodec {
                 LAST_OPENED_CONVERSATION_ID_KEY to JsonPrimitive(state.lastOpenedConversationId),
                 LANGUAGE_TAG_KEY to JsonPrimitive(state.languageTag),
                 LOAD_LAST_CONVERSATION_KEY to JsonPrimitive(state.loadLastConversationOnStartup),
+                THEME_MODE_KEY to JsonPrimitive(state.themeMode),
+                THEME_SEED_COLOR_KEY to JsonPrimitive(state.themeSeedColor),
             )
         ).toString()
     }
@@ -52,4 +60,6 @@ internal object AppStateSettingsCodec {
     private const val LAST_OPENED_CONVERSATION_ID_KEY = "last_opened_conversation_id"
     private const val LANGUAGE_TAG_KEY = "language_tag"
     private const val LOAD_LAST_CONVERSATION_KEY = "load_last_conversation_on_startup"
+    private const val THEME_MODE_KEY = "theme_mode"
+    private const val THEME_SEED_COLOR_KEY = "theme_seed_color"
 }

--- a/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
@@ -273,6 +273,29 @@ object XRepo {
         }
     }
 
+    suspend fun themeMode(): String {
+        return AppStateSettingsCodec.parse(readJson(StoreDescriptorRegistry.APP_STATE_ID)).themeMode
+    }
+
+    suspend fun setThemeMode(mode: String) {
+        updateJson(StoreDescriptorRegistry.APP_STATE_ID) { json ->
+            val current = AppStateSettingsCodec.parse(json)
+            AppStateSettingsCodec.encode(current.copy(themeMode = mode))
+        }
+    }
+
+    suspend fun themeSeedColor(): String {
+        return AppStateSettingsCodec.parse(readJson(StoreDescriptorRegistry.APP_STATE_ID))
+            .themeSeedColor
+    }
+
+    suspend fun setThemeSeedColor(hex: String) {
+        updateJson(StoreDescriptorRegistry.APP_STATE_ID) { json ->
+            val current = AppStateSettingsCodec.parse(json)
+            AppStateSettingsCodec.encode(current.copy(themeSeedColor = hex))
+        }
+    }
+
     // Seed custom py tool: web search via DuckDuckGo HTML endpoint. Code/schema are the
     // reflection cache written by the same pipeline py_meta_tools write uses.
     private val CODE_WEB_SEARCH = """

--- a/app/src/main/res/drawable/ic_arrow_up.xml
+++ b/app/src/main/res/drawable/ic_arrow_up.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M12,17L12,7M12,7L7,12M12,7L17,12"
+        android:strokeWidth="2"
+        android:strokeColor="#FFFFFF"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+</vector>

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -354,4 +354,22 @@
     <string name="notif_unsupported_issue_title">[BUG] 宿主版本未適配</string>
     <string name="notif_unsupported_issue_body">## 問題描述\n當前%1$s版本還未被 Zafiro 支援\n宿主版本：%2$s\n\n## 復現步驟\n\n\n## 設備資訊\n- 助手：%1$s\n- 助手版本：%2$s\n- 模組版本：</string>
     <string name="feedback_bug_template">## 問題描述\n\n## 復現步驟\n\n## 預期行為\n\n## 實際行為\n\n## 設備資訊\n- Android 版本：\n- 助手（小布或其他）：\n- 模組版本：\n\n## 更多\n可以補充日誌、截圖錄屏等資訊，以便於我們理解</string>
+
+    <string name="ui_settings_appearance">外觀</string>
+    <string name="ui_theme_mode_system">跟隨系統</string>
+    <string name="ui_theme_mode_light">淺色</string>
+    <string name="ui_theme_mode_dark">深色</string>
+    <string name="ui_theme_color_dynamic">動態色（桌布取色）</string>
+    <string name="ui_theme_color_rose">玫瑰粉</string>
+    <string name="ui_theme_color_blossom">櫻花粉</string>
+    <string name="ui_theme_color_lavender">薰衣草紫</string>
+    <string name="ui_theme_color_blue">遠山藍</string>
+    <string name="ui_theme_color_sky">天青</string>
+    <string name="ui_theme_color_cyan">青碧</string>
+    <string name="ui_theme_color_mint">薄荷綠</string>
+    <string name="ui_theme_color_green">草綠</string>
+    <string name="ui_theme_color_lime">嫩芽綠</string>
+    <string name="ui_theme_color_lemon">檸檬黃</string>
+    <string name="ui_theme_color_amber">琥珀</string>
+    <string name="ui_theme_color_sunset">落日橙</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -370,4 +370,22 @@
     <string name="ui_settings_configure_name_placeholder">e.g. DeepSeek primary</string>
     <string name="ui_settings_configure_protocol_label">Protocol</string>
     <string name="ui_settings_configure_protocol_hint">After switching protocols, confirm the endpoint matches the protocol.</string>
+
+    <string name="ui_settings_appearance">Appearance</string>
+    <string name="ui_theme_mode_system">Follow system</string>
+    <string name="ui_theme_mode_light">Light</string>
+    <string name="ui_theme_mode_dark">Dark</string>
+    <string name="ui_theme_color_dynamic">Dynamic (from wallpaper)</string>
+    <string name="ui_theme_color_rose">Rose</string>
+    <string name="ui_theme_color_blossom">Blossom</string>
+    <string name="ui_theme_color_lavender">Lavender</string>
+    <string name="ui_theme_color_blue">Blue</string>
+    <string name="ui_theme_color_sky">Sky</string>
+    <string name="ui_theme_color_cyan">Cyan</string>
+    <string name="ui_theme_color_mint">Mint</string>
+    <string name="ui_theme_color_green">Green</string>
+    <string name="ui_theme_color_lime">Lime</string>
+    <string name="ui_theme_color_lemon">Lemon</string>
+    <string name="ui_theme_color_amber">Amber</string>
+    <string name="ui_theme_color_sunset">Sunset</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -370,4 +370,22 @@
     <string name="ui_settings_configure_name_placeholder">Ejemplo: DeepSeek Principal</string>
     <string name="ui_settings_configure_protocol_label">Protocolo</string>
     <string name="ui_settings_configure_protocol_hint">Tras cambiar el protocolo, asegúrese de que el endpoint sea compatible con dicho protocolo.</string>
+
+    <string name="ui_settings_appearance">Apariencia</string>
+    <string name="ui_theme_mode_system">Según el sistema</string>
+    <string name="ui_theme_mode_light">Claro</string>
+    <string name="ui_theme_mode_dark">Oscuro</string>
+    <string name="ui_theme_color_dynamic">Dinámico (del fondo)</string>
+    <string name="ui_theme_color_rose">Rosa</string>
+    <string name="ui_theme_color_blossom">Flor</string>
+    <string name="ui_theme_color_lavender">Lavanda</string>
+    <string name="ui_theme_color_blue">Azul</string>
+    <string name="ui_theme_color_sky">Cielo</string>
+    <string name="ui_theme_color_cyan">Cian</string>
+    <string name="ui_theme_color_mint">Menta</string>
+    <string name="ui_theme_color_green">Verde</string>
+    <string name="ui_theme_color_lime">Lima</string>
+    <string name="ui_theme_color_lemon">Limón</string>
+    <string name="ui_theme_color_amber">Ámbar</string>
+    <string name="ui_theme_color_sunset">Atardecer</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -369,4 +369,22 @@
     <string name="ui_settings_configure_name_placeholder">例：DeepSeek メイン</string>
     <string name="ui_settings_configure_protocol_label">プロトコル</string>
     <string name="ui_settings_configure_protocol_hint">プロトコル切り替え後、エンドポイントがプロトコルと一致しているか確認してください。</string>
+
+    <string name="ui_settings_appearance">外観</string>
+    <string name="ui_theme_mode_system">システムに従う</string>
+    <string name="ui_theme_mode_light">ライト</string>
+    <string name="ui_theme_mode_dark">ダーク</string>
+    <string name="ui_theme_color_dynamic">ダイナミックカラー（壁紙から）</string>
+    <string name="ui_theme_color_rose">ローズ</string>
+    <string name="ui_theme_color_blossom">桜</string>
+    <string name="ui_theme_color_lavender">ラベンダー</string>
+    <string name="ui_theme_color_blue">ブルー</string>
+    <string name="ui_theme_color_sky">スカイ</string>
+    <string name="ui_theme_color_cyan">シアン</string>
+    <string name="ui_theme_color_mint">ミント</string>
+    <string name="ui_theme_color_green">グリーン</string>
+    <string name="ui_theme_color_lime">ライム</string>
+    <string name="ui_theme_color_lemon">レモン</string>
+    <string name="ui_theme_color_amber">アンバー</string>
+    <string name="ui_theme_color_sunset">サンセット</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -369,4 +369,22 @@
     <string name="ui_settings_configure_name_placeholder">例如：DeepSeek 主力</string>
     <string name="ui_settings_configure_protocol_label">协议</string>
     <string name="ui_settings_configure_protocol_hint">切换协议后，请确认端点与协议匹配。</string>
+
+    <string name="ui_settings_appearance">外观</string>
+    <string name="ui_theme_mode_system">跟随系统</string>
+    <string name="ui_theme_mode_light">浅色</string>
+    <string name="ui_theme_mode_dark">深色</string>
+    <string name="ui_theme_color_dynamic">动态色（壁纸取色）</string>
+    <string name="ui_theme_color_rose">玫瑰粉</string>
+    <string name="ui_theme_color_blossom">樱花粉</string>
+    <string name="ui_theme_color_lavender">薰衣草紫</string>
+    <string name="ui_theme_color_blue">远山蓝</string>
+    <string name="ui_theme_color_sky">天青</string>
+    <string name="ui_theme_color_cyan">青碧</string>
+    <string name="ui_theme_color_mint">薄荷绿</string>
+    <string name="ui_theme_color_green">草绿</string>
+    <string name="ui_theme_color_lime">嫩芽绿</string>
+    <string name="ui_theme_color_lemon">柠檬黄</string>
+    <string name="ui_theme_color_amber">琥珀</string>
+    <string name="ui_theme_color_sunset">落日橙</string>
 </resources>

--- a/ui-kit/build.gradle.kts
+++ b/ui-kit/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     // Compose
     implementation("androidx.compose.material3:material3:1.5.0-alpha22")
     implementation("androidx.compose.material:material-icons-core:1.7.8")
+    implementation("com.materialkolor:material-kolor:2.1.1")
     implementation("androidx.compose.material:material-icons-extended:1.7.8")
     debugImplementation("androidx.compose.ui:ui-tooling:1.4.0")
     implementation("androidx.compose.ui:ui-tooling-preview-android:1.8.3")

--- a/ui-kit/src/main/java/com/niki914/uikit/base/BaseTheme.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/base/BaseTheme.kt
@@ -7,23 +7,37 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
+import com.materialkolor.rememberDynamicColorScheme
 import com.niki914.uikit.base.theme.DarkColorScheme
 import com.niki914.uikit.base.theme.LightColorScheme
 import com.niki914.uikit.base.theme.Typography
+
+/** 全局深色模式单一来源，由 BaseTheme 提供；所有深色判断必须读它而非 isSystemInDarkTheme。 */
+val LocalAppDarkTheme = staticCompositionLocalOf { true }
 
 @Composable
 fun BaseTheme(
     darkTheme: Boolean = isSystemInDarkTheme(), // 判断系统是否为深色模式
     // 动态颜色仅在 Android 12+ (SDK 31+) 可用
     dynamicColor: Boolean = true, // 启用动态颜色
-    content: @Composable () -> Unit // 实际要应用主题的 Composable 内容
+    /** 非空时从种子色生成 Material 色板，忽略 dynamicColor。 */
+    seedColor: Color? = null,
+    content: @Composable () -> Unit, // 实际要应用主题的 Composable 内容
 ) {
     // 根据条件选择颜色方案
     val colorScheme = when {
+        // 种子色优先：用户主动选定的主题颜色
+        seedColor != null ->
+            rememberDynamicColorScheme(seedColor = seedColor, isDark = darkTheme, isAmoled = false)
+
         // 如果启用动态颜色且 Android 版本 >= S (Android 12)
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             val context = LocalContext.current // 获取当前上下文
@@ -43,13 +57,17 @@ fun BaseTheme(
 //            window.statusBarColor = colorScheme.primary.toArgb() // 将状态栏颜色设置为主题主色
             // 控制状态栏图标颜色，根据主题亮暗调整
             WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
+            // 页面自身不画背景（透出 window），必须跟随应用主题而非系统 DayNight
+            window.decorView.setBackgroundColor(colorScheme.background.toArgb())
         }
     }
 
-    // 应用 MaterialTheme
-    MaterialTheme(
-        colorScheme = colorScheme, // 使用选择的颜色方案
-        typography = Typography, // 你的字体排版定义（通常在 Type.kt 中）
-        content = content // 渲染传入的内容
-    )
+    CompositionLocalProvider(LocalAppDarkTheme provides darkTheme) {
+        // 应用 MaterialTheme
+        MaterialTheme(
+            colorScheme = colorScheme, // 使用选择的颜色方案
+            typography = Typography, // 你的字体排版定义（通常在 Type.kt 中）
+            content = content // 渲染传入的内容
+        )
+    }
 }

--- a/ui-kit/src/main/java/com/niki914/uikit/base/theme/Typography.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/base/theme/Typography.kt
@@ -16,20 +16,4 @@ internal val Typography = Typography(
         lineHeight = 24.sp,
         letterSpacing = 0.5.sp
     )
-    /* Other default text styles to override
-    titleLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 22.sp,
-        lineHeight = 28.sp,
-        letterSpacing = 0.sp
-    ),
-    labelSmall = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Medium,
-        fontSize = 11.sp,
-        lineHeight = 16.sp,
-        letterSpacing = 0.5.sp
-    )
-    */
 )

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/ActionBarButton.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/ActionBarButton.kt
@@ -39,7 +39,7 @@ import com.niki914.uikit.infra.interaction.applyLiquidInteractiveTransform
 import kotlinx.coroutines.launch
 
 @Composable
-internal fun ActionBarButton(
+fun ActionBarButton(
     modifier: Modifier = Modifier,
     onClick: () -> Unit,
     enabled: Boolean = true,

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/ActionBarButton.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/ActionBarButton.kt
@@ -1,8 +1,8 @@
 package com.niki914.uikit.infra
 
+import com.niki914.uikit.base.LocalAppDarkTheme
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
@@ -57,7 +57,7 @@ fun ActionBarButton(
         compositingStrategy = CompositingStrategy.Offscreen
     }
     val density = LocalDensity.current
-    val isDarkTheme = isSystemInDarkTheme()
+    val isDarkTheme = LocalAppDarkTheme.current
     val interactionSource = remember { MutableInteractionSource() }
     val buttonShape = RoundedCornerShape(56.dp)
 

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreen.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -48,6 +49,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
@@ -106,21 +108,25 @@ fun LiquidScreen(
             }
         }
     }
-    // 导航（前进/后退）时重置：Pinned 页的滚动状态均为 remember（非 saveable），
-    // 重建后必在顶部；Collapsible 页不读这个布尔，由页面自报（snapshotFlow）。
+    val titleCollapseState = remember { TitleBarCollapseState() }
+    // 导航时重置事件通道与自报标记。Pinned 页若不自报（非 Saveable 滚动状态），
+    // 重建后必在顶部，重置后恒 false 即正确；可 saveable 恢复滚动位置的页（如 Home Chat）
+    // 应写入 collapse state 自报（hasReporter=true），返回时首帧立即纠正，不受重置影响。
     LaunchedEffect(state.title, state.titleDirection) {
         when (state.titleDirection) {
-            TitleDirection.Forward, TitleDirection.Back -> isContentScrolled = false
+            TitleDirection.Forward, TitleDirection.Back -> {
+                isContentScrolled = false
+                titleCollapseState.hasReporter = false
+            }
             TitleDirection.None -> {}
         }
     }
-    val titleCollapseState = remember { TitleBarCollapseState() }
     // 动画时长与 action bar 左右按钮显隐动画一致，页面切换时两页滚动状态
     // 不同也不会闪变：alpha 总是从当前值动画到目标值。
     val collapseAnimSpec = tween<Float>(durationMillis = 280, easing = LinearOutSlowInEasing)
     // 背景与小标题共用同一信号源，保证两者同步动画：
     // Collapsible 页由页面自报（与大标题同一阈值）；Pinned 页由嵌套滚动观测驱动。
-    val barTarget = if (state.isTitleCollapsible) {
+    val barTarget = if (state.isTitleCollapsible || titleCollapseState.hasReporter) {
         titleCollapseState.isCollapsed
     } else {
         isContentScrolled
@@ -214,6 +220,9 @@ fun LiquidScreen(
                 .align(Alignment.TopCenter)
                 .fillMaxWidth()
                 .height(chromeHeight)
+                // 吞掉顶栏区域的点按，防止穿透到下层内容（如滚动到顶栏下方的列表行）。
+                // detectTapGestures 只消费 tap 不消费拖动，从顶栏起手的滚动仍能落到下层滚动容器。
+                .pointerInput(Unit) { detectTapGestures { } }
                 .padding(horizontal = 4.dp),
         ) {
             // Title — always centered in the full bar width

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreen.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreen.kt
@@ -1,5 +1,6 @@
 package com.niki914.uikit.infra
 
+import com.niki914.uikit.base.LocalAppDarkTheme
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ContentTransform
@@ -16,7 +17,6 @@ import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -70,7 +70,7 @@ fun LiquidScreen(
     rightButton: (@Composable () -> Unit)? = null,
     content: @Composable () -> Unit,
 ) {
-    val isDarkTheme = isSystemInDarkTheme()
+    val isDarkTheme = LocalAppDarkTheme.current
     val density = LocalDensity.current
     val chromeBackdrop = rememberLayerBackdrop()
     val dialogHostState = remember { LiquidDialogHostState() }

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreen.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreen.kt
@@ -297,8 +297,8 @@ fun LiquidScreen(
                         text = title,
                         modifier = Modifier.fillMaxWidth(),
                         style = TextStyle(
-                            fontSize = 18.sp,
-                            fontWeight = FontWeight.Medium,
+                            fontSize = 20.sp,
+                            fontWeight = FontWeight.SemiBold,
                             color = if (isDarkTheme) Color.White else Color.Black
                         ),
                         textAlign = TextAlign.Center,

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreenContentContext.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreenContentContext.kt
@@ -41,6 +41,10 @@ val LocalLiquidScreenContentContext: ProvidableCompositionLocal<LiquidScreenCont
 class TitleBarCollapseState {
     /** true = 内容已滚过大标题（小标题应浮现）；非滚动页恒为 false（顶栏全透明）。 */
     var isCollapsed: Boolean by mutableStateOf(false)
+
+    /** 是否有页面在本帧接管了回报。导航时由 LiquidScreen 清零，
+     * 防止上一页的 isCollapsed 残值泄漏给不自报的页面。 */
+    var hasReporter: Boolean by mutableStateOf(false)
 }
 
 // ponytail: 折叠信号有 Pinned（根部嵌套滚动观测）与 Collapsible（页面自报）两条通道；

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/component/LiquidTextField.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/component/LiquidTextField.kt
@@ -3,6 +3,8 @@ package com.niki914.uikit.infra.component
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun LiquidTextField(
@@ -15,6 +17,7 @@ fun LiquidTextField(
     minLines: Int = 1,
     maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
     moveCursorToEndOnFocus: Boolean = false,
+    minHeight: Dp = 52.dp,
     trailingContent: (@Composable RowScope.() -> Unit)? = null,
 ) {
     LiquidTextFieldContainer(
@@ -27,6 +30,7 @@ fun LiquidTextField(
         minLines = minLines,
         maxLines = maxLines,
         moveCursorToEndOnFocus = moveCursorToEndOnFocus,
+        minHeight = minHeight,
         trailingContent = trailingContent,
     )
 }

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/component/LiquidTextFieldContainer.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/component/LiquidTextFieldContainer.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
@@ -38,6 +39,7 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.kyant.backdrop.backdrops.rememberLayerBackdrop
 import com.kyant.backdrop.drawBackdrop
@@ -68,13 +70,11 @@ internal fun LiquidTextFieldContainer(
     maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
     moveCursorToEndOnFocus: Boolean = false,
     visualTransformation: VisualTransformation = VisualTransformation.None,
+    minHeight: Dp = 52.dp,
     trailingContent: (@Composable RowScope.() -> Unit)? = null,
 ) {
     val backdrop = rememberLayerBackdrop()
     val animationScope = rememberCoroutineScope()
-    val interactiveHighlight = remember(animationScope) {
-        InteractiveHighlight(animationScope = animationScope)
-    }
     val focusManager = LocalFocusManager.current
     val density = LocalDensity.current
     val viewportAvoidanceController = LocalLiquidViewportAvoidanceController.current
@@ -82,6 +82,18 @@ internal fun LiquidTextFieldContainer(
     var isFocused by remember { mutableStateOf(false) }
     var imeWasVisibleWhileFocused by remember { mutableStateOf(false) }
     var boundsInRoot by remember { mutableStateOf<Rect?>(null) }
+    var trailingBoundsInRoot by remember { mutableStateOf<Rect?>(null) }
+    val interactiveHighlight = remember(animationScope) {
+        InteractiveHighlight(
+            animationScope = animationScope,
+            isDragStartIgnored = { position ->
+                val trailing = trailingBoundsInRoot
+                val field = boundsInRoot
+                trailing != null && field != null &&
+                        Rect(trailing.topLeft - field.topLeft, trailing.size).contains(position)
+            },
+        )
+    }
     var textFieldValue by remember {
         mutableStateOf(
             TextFieldValue(
@@ -92,7 +104,7 @@ internal fun LiquidTextFieldContainer(
     }
     val interactiveEffectsEnabled = enabled && (!isFocused || textFieldValue.text.isEmpty())
     val imeVisible = WindowInsets.ime.getBottom(density) > 0
-    val fieldShape = G2FieldShape(28.dp)
+    val fieldShape = G2FieldShape(36.dp)
 
     LaunchedEffect(value) {
         if (value != textFieldValue.text) {
@@ -175,7 +187,7 @@ internal fun LiquidTextFieldContainer(
         },
         modifier = modifier
             .fillMaxWidth()
-            .heightIn(min = 52.dp)
+            .heightIn(min = minHeight)
             .onFocusChanged { focusState ->
                 isFocused = focusState.isFocused
                 if (moveCursorToEndOnFocus && focusState.isFocused) {
@@ -260,7 +272,13 @@ internal fun LiquidTextFieldContainer(
 
                 if (trailingContent != null) {
                     CompositionLocalProvider(LocalContentColor provides trailingColor) {
-                        trailingContent()
+                        Box(
+                            modifier = Modifier.onGloballyPositioned { coordinates ->
+                                trailingBoundsInRoot = coordinates.boundsInRoot()
+                            },
+                        ) {
+                            trailingContent?.invoke(this@Row)
+                        }
                     }
                 }
             }

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingExpandableTextItem.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingExpandableTextItem.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 @Composable
 fun SettingExpandableTextItem(
@@ -159,7 +160,7 @@ internal fun SettingExpandableTextItemContent(
         ) {
             Text(
                 text = title,
-                style = MaterialTheme.typography.bodyLarge,
+                style = MaterialTheme.typography.titleMedium.copy(fontSize = 18.sp),
                 color = titleColor,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
@@ -181,7 +182,7 @@ internal fun SettingExpandableTextItemContent(
             Spacer(modifier = Modifier.height(4.dp))
             Text(
                 text = description,
-                style = MaterialTheme.typography.bodySmall,
+                style = MaterialTheme.typography.bodyMedium,
                 color = secondaryTextColor,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingToggleItem.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingToggleItem.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 /**
  * 组内开关子项：保持整行切换和透明 item 语义，由外层容器提供卡片边界。
@@ -39,7 +40,7 @@ fun SettingToggleItem(
         ) {
             Text(
                 text = title,
-                style = MaterialTheme.typography.bodyLarge,
+                style = MaterialTheme.typography.titleMedium.copy(fontSize = 18.sp),
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
@@ -47,7 +48,7 @@ fun SettingToggleItem(
             if (description != null) {
                 Text(
                     text = description,
-                    style = MaterialTheme.typography.bodySmall,
+                    style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsDetailFormScaffold.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsDetailFormScaffold.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
 import com.niki914.uikit.infra.liquidScreenTopPadding
 
 /**
@@ -91,6 +92,7 @@ fun SettingsDetailFormScaffold(
             text = actionText,
             enabled = actionEnabled,
             onClick = onActionClick,
+            buttonHeight = 56.dp,
             darkContainerColor = actionButtonDarkContainerColor,
             lightContainerColor = actionButtonLightContainerColor,
             darkContentColor = actionButtonDarkContentColor,

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsListItem.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsListItem.kt
@@ -36,11 +36,8 @@ fun SettingsListItem(
     trailingContent: (@Composable RowScope.() -> Unit)? = null,
     onClick: (() -> Unit)? = null,
 ) {
-    val contentPadding = if (leadingContent != null) {
-        PaddingValues(start = 20.dp, top = 20.dp, end = 16.dp, bottom = 20.dp)
-    } else {
-        PaddingValues(horizontal = 16.dp, vertical = 20.dp)
-    }
+    // 无图标行的文字起点与有图标行的圆底左缘齐平（20dp），竖向视觉对齐。
+    val contentPadding = PaddingValues(start = 20.dp, top = 20.dp, end = 16.dp, bottom = 20.dp)
 
     SettingsItemSurface(
         modifier = modifier,

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsListItem.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsListItem.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 @Composable
 fun SettingsListItem(
@@ -68,7 +69,7 @@ fun SettingsListItem(
                 ) {
                     Text(
                         text = title,
-                        style = MaterialTheme.typography.bodyLarge,
+                        style = MaterialTheme.typography.titleMedium.copy(fontSize = 18.sp),
                         color = MaterialTheme.colorScheme.onSurface,
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
@@ -76,7 +77,7 @@ fun SettingsListItem(
                     if (!summary.isNullOrBlank()) {
                         Text(
                             text = summary,
-                            style = MaterialTheme.typography.bodySmall,
+                            style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             maxLines = 2,
                             overflow = TextOverflow.Ellipsis,

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsListPageContent.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsListPageContent.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.foundation.ScrollState
 import com.niki914.uikit.infra.nav.LocalPageTitle
 import com.niki914.uikit.infra.LocalTitleBarCollapseState
@@ -60,14 +61,14 @@ fun SettingsListPageContent(
             .fillMaxSize()
             .verticalScroll(scrollState)
             .padding(top = liquidScreenTopPadding())
-            .padding(horizontal = 20.dp, vertical = 24.dp),
+            .padding(horizontal = 16.dp, vertical = 24.dp),
         verticalArrangement = Arrangement.spacedBy(20.dp),
     ) {
         val pageTitle = LocalPageTitle.current
         if (pageTitle.isNotBlank()) {
             Text(
                 text = pageTitle,
-                style = MaterialTheme.typography.headlineMedium,
+                style = MaterialTheme.typography.headlineMedium.copy(fontSize = 30.sp),
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsToggleListItemCard.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsToggleListItemCard.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 @Composable
 fun SettingsToggleListItemCard(
@@ -68,7 +69,7 @@ private fun SettingsToggleListItemRow(
             ) {
                 Text(
                     text = title,
-                    style = MaterialTheme.typography.bodyLarge,
+                    style = MaterialTheme.typography.titleMedium.copy(fontSize = 18.sp),
                     color = MaterialTheme.colorScheme.onSurface,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/component/SwipeDismissSettingsItemCard.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/component/SwipeDismissSettingsItemCard.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.niki914.uikit.infra.shape.G2CardShape
 import kotlin.math.abs
 import kotlin.math.absoluteValue
@@ -261,7 +262,7 @@ private fun SwipeDismissSettingsItemContent(
             ) {
                 Text(
                     text = title,
-                    style = MaterialTheme.typography.bodyLarge,
+                    style = MaterialTheme.typography.titleMedium.copy(fontSize = 18.sp),
                     color = contentColor,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
@@ -269,7 +270,7 @@ private fun SwipeDismissSettingsItemContent(
                 if (!summary.isNullOrBlank()) {
                     Text(
                         text = summary,
-                        style = MaterialTheme.typography.bodySmall,
+                        style = MaterialTheme.typography.bodyMedium,
                         color = summaryColor,
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/component/TintLiquidButton.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/component/TintLiquidButton.kt
@@ -1,7 +1,7 @@
 package com.niki914.uikit.infra.component
 
+import com.niki914.uikit.base.LocalAppDarkTheme
 import androidx.annotation.DrawableRes
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -49,7 +49,7 @@ fun TintLiquidButton(
     buttonHeight: Dp = 48.dp,
     isLoading: Boolean = false,
 ) {
-    val isDarkTheme = isSystemInDarkTheme()
+    val isDarkTheme = LocalAppDarkTheme.current
     val backdrop = rememberLayerBackdrop()
     val disabledContainerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.45f)
     val disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/component/settings/SettingsSpecPageContent.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/component/settings/SettingsSpecPageContent.kt
@@ -1,15 +1,20 @@
 package com.niki914.uikit.infra.component.settings
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -185,20 +190,28 @@ private fun SettingsRowContent(
 
 @Composable
 private fun SettingsRowLeadingIconContent(icon: SettingsRowLeadingIcon) {
-    when (icon) {
-        is SettingsRowLeadingIcon.Vector -> Icon(
-            imageVector = icon.imageVector,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.size(28.dp),
-        )
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .size(56.dp)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+    ) {
+        when (icon) {
+            is SettingsRowLeadingIcon.Vector -> Icon(
+                imageVector = icon.imageVector,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(24.dp),
+            )
 
-        is SettingsRowLeadingIcon.PainterResource -> Icon(
-            painter = painterResource(id = icon.drawableResId),
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.size(28.dp),
-        )
+            is SettingsRowLeadingIcon.PainterResource -> Icon(
+                painter = painterResource(id = icon.drawableResId),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(24.dp),
+            )
+        }
     }
 }
 

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/interaction/DragGestureInspector.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/interaction/DragGestureInspector.kt
@@ -16,11 +16,17 @@ suspend fun PointerInputScope.inspectDragGestures(
     onDragStart: (down: PointerInputChange) -> Unit = {},
     onDragEnd: (change: PointerInputChange) -> Unit = {},
     onDragCancel: () -> Unit = {},
+    isDragStartIgnored: (down: PointerInputChange) -> Boolean = { false },
     onDrag: (change: PointerInputChange, dragAmount: Offset) -> Unit
 ) {
     awaitEachGesture {
         val initialDown = awaitFirstDown(false, PointerEventPass.Initial)
         val down = awaitFirstDown(false)
+
+        // 落点属于内层液态控件（如按钮）时，外层容器不参与本次拖拽，避免双层位移。
+        if (isDragStartIgnored(down)) {
+            return@awaitEachGesture
+        }
 
         onDragStart(down)
         onDrag(initialDown, Offset.Zero)

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/interaction/InteractiveHighlight.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/interaction/InteractiveHighlight.kt
@@ -21,7 +21,8 @@ import kotlinx.coroutines.launch
 
 class InteractiveHighlight(
     val animationScope: CoroutineScope,
-    val position: (size: Size, offset: Offset) -> Offset = { _, offset -> offset }
+    val position: (size: Size, offset: Offset) -> Offset = { _, offset -> offset },
+    private val isDragStartIgnored: (position: Offset) -> Boolean = { false }
 ) {
     private val pressProgressAnimationSpec =
         spring(0.5f, 300f, 0.001f)
@@ -94,6 +95,7 @@ half4 main(float2 coord) {
     val gestureModifier: Modifier =
         Modifier.pointerInput(animationScope) {
             inspectDragGestures(
+                isDragStartIgnored = { down -> isDragStartIgnored(down.position) },
                 onDragStart = { down ->
                     startPosition = down.position
                     animationScope.launch {


### PR DESCRIPTION
## Summary

UI polish pass on the Zafiro main app (`com.niki914.uikit`). No business-logic changes.

## Changes

- **Theme system**: theme picker with seed colors + dark/light mode override; default to dark+mint; restore last conversation on startup
- **Composer**: liquid circle send button, larger chat input field
- **Settings UI**: bolder visuals aligned with PixelPlayer metrics; provider pick rows with brand-tinted badges; icon-less row text alignment fix; taller detail action button
- **Top bar**: replace haze blur with alpha-animated top bar; collapsible title mode; restore scrolled bar state on chat return

## Scope

53 files, +975 / -343, all under the uikit Compose UI layer.