### PR TITLE
fix: respect user scroll gestures and collapse stale auto-expanded thinking blocks

### DIFF
--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.layout.Box
@@ -33,6 +34,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -123,9 +125,6 @@ fun HomePageContent(
     val effectiveImeBottom = if (isComposerFocused) imeBottom else 0.dp
     val composerBottomPadding = (effectiveImeBottom + 12.dp).coerceAtLeast(navigationBottom + 20.dp)
     val bottomThresholdPx = with(density) { 24.dp.roundToPx() }
-    val isUserDragging by listState.interactionSource.collectIsDraggedAsState()
-    var shouldFollowBottom by remember { mutableStateOf(true) }
-    var hasPendingUserScrollDecision by remember { mutableStateOf(false) }
     val lastTurn = uiState.turns.lastOrNull()
     val bottomContentVersion = remember(
         uiState.turns.size,
@@ -150,6 +149,11 @@ fun HomePageContent(
                     lastVisibleItem.offset + lastVisibleItem.size <= viewportEnd + bottomThresholdPx
         }
     }
+    var shouldFollowBottom by rememberScrollFollowState(
+        interactionSource = listState.interactionSource,
+        isScrollInProgress = { listState.isScrollInProgress },
+        isAtEnd = { isAtBottom },
+    )
     val dismissInputFocus = remember(focusManager, keyboardController) {
         {
             keyboardController?.hide()
@@ -157,21 +161,9 @@ fun HomePageContent(
         }
     }
 
-    LaunchedEffect(isUserDragging) {
-        if (isUserDragging) {
-            hasPendingUserScrollDecision = true
-        }
-    }
-    LaunchedEffect(listState, isAtBottom) {
-        snapshotFlow { listState.isScrollInProgress }
-            .collectLatest { isScrollInProgress ->
-                if (!isScrollInProgress && hasPendingUserScrollDecision) {
-                    shouldFollowBottom = isAtBottom
-                    hasPendingUserScrollDecision = false
-                }
-            }
-    }
-    LaunchedEffect(bottomContentVersion, shouldFollowBottom) {
+    // 只在内容事件（bottomContentVersion）变化时跳转：恢复跟随本身不触发滚动，
+    // 避免「小幅上滚停在阈值内 → 恢复跟随 → 无内容也被拉回底部」
+    LaunchedEffect(bottomContentVersion) {
         if (shouldFollowBottom) {
             listState.scrollToItem(uiState.turns.size)
         }
@@ -680,6 +672,40 @@ private fun HomeChatTurnItem(
             )
         }
     }
+}
+
+/**
+ * 手势信任的贴底跟随状态机（外层聊天列表与内层 thinking/工具结果文本共用）。
+ * 用户开始拖拽立即暂停跟随——流式新内容不再抢占滚动；
+ * 滚动完全停止后按 [isAtEnd] 判定是否恢复跟随。
+ * 返回 MutableState：发送消息等场景可主动置回 true 恢复跟随。
+ */
+@Composable
+internal fun rememberScrollFollowState(
+    interactionSource: InteractionSource,
+    isScrollInProgress: () -> Boolean,
+    isAtEnd: () -> Boolean,
+): MutableState<Boolean> {
+    val follow = remember { mutableStateOf(true) }
+    var hasPendingUserScrollDecision by remember { mutableStateOf(false) }
+    val isUserDragging by interactionSource.collectIsDraggedAsState()
+
+    LaunchedEffect(isUserDragging) {
+        if (isUserDragging) {
+            follow.value = false
+            hasPendingUserScrollDecision = true
+        }
+    }
+    LaunchedEffect(interactionSource) {
+        snapshotFlow { isScrollInProgress() }
+            .collectLatest { isScrollInProgress ->
+                if (!isScrollInProgress && hasPendingUserScrollDecision) {
+                    follow.value = isAtEnd()
+                    hasPendingUserScrollDecision = false
+                }
+            }
+    }
+    return follow
 }
 
 @Preview(

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/ToolChain.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/ToolChain.kt
@@ -37,7 +37,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -371,18 +370,21 @@ internal fun ToolResultText(
     text: String,
     style: TextStyle,
     color: Color,
-    /** active 思考块流式更新时自动滚到底跟随；不锁手动滚动（不尊重用户位置，每次增长都回底）。 */
+    /** active 思考块流式更新时自动滚到底跟随；用户手动拖动后暂停，滚回底部后恢复。 */
     autoScrollToEnd: Boolean = false,
 ) {
     var overflow by remember { mutableStateOf(false) }
     val scrollState = rememberScrollState()
+    var shouldFollow by rememberScrollFollowState(
+        interactionSource = scrollState.interactionSource,
+        isScrollInProgress = { scrollState.isScrollInProgress },
+        isAtEnd = { !scrollState.canScrollForward },
+    )
 
     // maxValue 更新（内容增长/布局完成）即滚到底；autoScrollToEnd 置位瞬间先跟随当前尾部。
-    LaunchedEffect(autoScrollToEnd) {
-        if (autoScrollToEnd) {
-            snapshotFlow { scrollState.maxValue }
-                .distinctUntilChanged()
-                .collect { max -> scrollState.scrollTo(max) }
+    LaunchedEffect(autoScrollToEnd, shouldFollow, scrollState.maxValue) {
+        if (autoScrollToEnd && shouldFollow) {
+            scrollState.scrollTo(scrollState.maxValue)
         }
     }
 

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/HomeChatState.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/HomeChatState.kt
@@ -123,9 +123,9 @@ data class HomeChatUiState(
     /** 当前正在流式产生的思考块 key；仅驱动 thinking 块内滚动跟随。 */
     val activeThinkingKey: String? = null,
     /**
-     * 已自动展开过的思考块身份（"${turnId}_t${thinkingId}"）。
-     * Mapper 对 Delta 续接也重发 ThinkingStarted（同 id），此集合区分「新块首发」与「续接回声」：
-     * 首发自动展开；回声不重复展开，用户手动收起后不被续接重新撑开。
+     * 仍处于「自动展开、未被用户干预」的思考块 key（"${turnId}_${blockIndex}"）。
+     * 新块首发时收起本集合中的旧块再展开新块；用户 toggle 过的块移出本集合，不再被自动收起。
+     * （首发与续接回声的区分改用 turns 中是否已存在同 id Thinking 块判断，见 applyEvent。）
      */
     val autoExpandedThinking: Set<String> = emptySet(),
 )
@@ -262,6 +262,8 @@ class HomeChatViewModel internal constructor(
                 } else {
                     expandedThinking + key
                 },
+                // 用户干预：移出自动展开跟踪，后续新块不再自动收起它
+                autoExpandedThinking = autoExpandedThinking - key,
             )
         }
     }
@@ -401,11 +403,13 @@ class HomeChatViewModel internal constructor(
             }
 
             is LlmStreamEvent.ThinkingStarted -> {
-                // 首发自动展开 + 置 active；续接回声（同块 Delta 重发同 id）不重复展开，
-                // 手动收起后不复活；块完成后保持展开不收起（见 withClearedTransient）
                 updateState {
                     val turnIndex = turns.indexOfFirst { it.id == turnId }
                     if (turnIndex == -1) return@updateState this
+                    // 回声 = 同 id 块已存在（Mapper 对 Delta 续接重发同 id）；首发 = 块不存在
+                    val isEcho = turns[turnIndex].blocks.any {
+                        it is HomeChatBlock.Thinking && it.id == event.id
+                    }
                     val updated = turns[turnIndex].upsertThinking(event.id, event.text)
                     val thinkingIndex = updated.blocks.indexOfLast {
                         it is HomeChatBlock.Thinking && it.id == event.id
@@ -416,15 +420,18 @@ class HomeChatViewModel internal constructor(
                             turns = turns.toMutableList().also { it[turnIndex] = updated },
                         )
                     }
-                    val blockId = "${turnId}_t${event.id}"
+                    if (isEcho) {
+                        // 续接回声：只更新文本，不碰展开态（手动收起后不被续接重新撑开）
+                        return@updateState copy(
+                            turns = turns.toMutableList().also { it[turnIndex] = updated },
+                        )
+                    }
+                    // 新块首发：自动展开，并收起所有仍自动展开的旧块（autoExpandedThinking
+                    // 只含未被用户干预的块，用户手动展开的保留）
                     copy(
                         turns = turns.toMutableList().also { it[turnIndex] = updated },
-                        expandedThinking = if (blockId in autoExpandedThinking) {
-                            expandedThinking
-                        } else {
-                            expandedThinking + key
-                        },
-                        autoExpandedThinking = autoExpandedThinking + blockId,
+                        expandedThinking = (expandedThinking - autoExpandedThinking) + key,
+                        autoExpandedThinking = autoExpandedThinking + key,
                         activeThinkingKey = key,
                     )
                 }

--- a/app/src/test/java/com/niki914/zafiro/app/ui/model/HomeChatControllerTest.kt
+++ b/app/src/test/java/com/niki914/zafiro/app/ui/model/HomeChatControllerTest.kt
@@ -804,6 +804,92 @@ class HomeChatViewModelTest {
     }
 
     @Test
+    fun thinking_newBlockCollapsesPreviousAutoExpanded() = runTest {
+        val conversations = FakeHomeConversationStore()
+        val viewModel = HomeChatViewModel(
+            conversations = conversations,
+            runtime = FakeHomeChatRuntime(
+                stream = {
+                    flow {
+                        emit(LlmStreamEvent.RoundStarted)
+                        emit(LlmStreamEvent.ThinkingStarted(0, "first"))
+                        delay(10)
+                        emit(LlmStreamEvent.ThinkingStarted(1, "second"))
+                        delay(10)
+                        emit(LlmStreamEvent.Completed)
+                    }
+                },
+            ),
+        )
+        viewModel.sendIntent(HomeChatIntent.InputChanged("q"))
+        runCurrent()
+        viewModel.sendIntent(HomeChatIntent.Send)
+        runCurrent()
+        runCurrent()
+
+        // 首发：块 0 自动展开
+        var state = viewModel.uiStateFlow.value
+        assertTrue("0_0" in state.expandedThinking)
+        assertFalse("0_1" in state.expandedThinking)
+
+        // 新块到来：收起前面自动展开的块 0，展开块 1
+        advanceTimeBy(10)
+        runCurrent()
+        state = viewModel.uiStateFlow.value
+        assertTrue("0_1" in state.expandedThinking)
+        assertFalse("0_0" in state.expandedThinking)
+    }
+
+    @Test
+    fun thinking_userExpandedBlockSurvivesNewBlock() = runTest {
+        val conversations = FakeHomeConversationStore()
+        val viewModel = HomeChatViewModel(
+            conversations = conversations,
+            runtime = FakeHomeChatRuntime(
+                stream = {
+                    flow {
+                        emit(LlmStreamEvent.RoundStarted)
+                        emit(LlmStreamEvent.ThinkingStarted(0, "first"))
+                        delay(10)
+                        emit(LlmStreamEvent.ThinkingStarted(1, "second"))
+                        delay(10)
+                        emit(LlmStreamEvent.ThinkingStarted(2, "third"))
+                        delay(10)
+                        emit(LlmStreamEvent.Completed)
+                    }
+                },
+            ),
+        )
+        viewModel.sendIntent(HomeChatIntent.InputChanged("q"))
+        runCurrent()
+        viewModel.sendIntent(HomeChatIntent.Send)
+        runCurrent()
+        runCurrent()
+
+        // 块 1 自动展开（块 0 已被自动收起）
+        advanceTimeBy(10)
+        runCurrent()
+        var state = viewModel.uiStateFlow.value
+        assertTrue("0_1" in state.expandedThinking)
+        assertFalse("0_0" in state.expandedThinking)
+
+        // 用户手动展开块 0（接管）
+        viewModel.sendIntent(HomeChatIntent.ToggleThinking(0, 0))
+        runCurrent()
+        state = viewModel.uiStateFlow.value
+        assertTrue("0_0" in state.expandedThinking)
+        assertTrue("0_1" in state.expandedThinking)
+
+        // 块 2 到来：只收仍自动展开的块 1，用户展开的块 0 保留
+        advanceTimeBy(10)
+        runCurrent()
+        state = viewModel.uiStateFlow.value
+        assertTrue("0_2" in state.expandedThinking)
+        assertTrue("0_0" in state.expandedThinking)
+        assertFalse("0_1" in state.expandedThinking)
+    }
+
+    @Test
     fun loadConversation_clearsTransientThinkingAndActionState() = runTest {
         val conversations = FakeHomeConversationStore()
         conversations.createConversation("session-second", "second")
@@ -837,7 +923,7 @@ class HomeChatViewModelTest {
         runCurrent()
         val before = viewModel.uiStateFlow.value
         assertTrue("0_0" in before.expandedThinking)
-        assertTrue("0_t0" in before.autoExpandedThinking)
+        assertTrue("0_0" in before.autoExpandedThinking)
         assertEquals(0L, before.expandedActionTurnId)
 
         // 切换会话：全部瞬态清理，不跨会话复用（loadConversation 曾漏清 expandedThinking）


### PR DESCRIPTION
## 问题

1. **自动滚动不尊重用户手势**：聊天列表在用户拖拽期间 `shouldFollowBottom` 保持 `true`，流式新内容一到就 `scrollToItem` 抢占滚动，往上翻记录时被反复拽回底部。另有一处回归：恢复跟随的瞬间（`shouldFollowBottom` key 变化）也会立即拉回底部，即使 UI 完全没有新内容（如 Python 工具运行中）。
2. **thinking 块不自动收起**：每个 thinking 块首发都自动展开且从不收起，连续多个 thinking 块时列表被撑得越来越长。

## 改动

- 提取共享 helper `rememberScrollFollowState`（`HomePageContent.kt`）：拖拽开始立即暂停跟随，滚动完全停止后按是否在底部恢复；聊天列表与内层 thinking/工具结果文本共用。
- 跟随 effect 只由内容事件（`bottomContentVersion`）触发，恢复跟随不再触发跳转，消除"无内容也触底"。
- 内层 `ToolResultText`（`ToolChain.kt`）改用同一 helper：用户手动拖动后暂停跟随，滚回底部后恢复。
- thinking 块（`HomeChatState.kt`）：新块首发时收起所有仍自动展开的旧块；用户 toggle 过的块移出自动跟踪，不再被自动收起；首发与续接回声的区分改用 turns 中是否已存在同 id 块。

## 测试

- `HomeChatViewModelTest`：新增 2 个用例（新块收起旧自动展开块 / 用户展开块不被新块收起），更新 1 个断言（`autoExpandedThinking` 格式 blockId → key）。
- 全量 `:app:testDebugUnitTest` 通过。