### PR TITLE
feat: tool context, memory, and permission management

### DIFF
--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/LLMController.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/LLMController.kt
@@ -7,6 +7,7 @@ import com.niki914.zafiro.chat.agentic.LocalToolExecutor
 import com.niki914.zafiro.chat.agentic.accessibility.AccessibilityController
 import com.niki914.zafiro.chat.agentic.python.PyRuntime
 import com.niki914.zafiro.chat.agentic.shell.TerminalSessionPool
+import com.niki914.zafiro.chat.agentic.shell.ToolPermissionCoordinator
 import com.niki914.zafiro.chat.agentic.stream.LlmStreamEventMapper
 import com.niki914.zafiro.R
 import com.niki914.zafiro.settings.RuntimeEnvironment
@@ -297,7 +298,13 @@ object LLMController {
     suspend fun historySnapshot(): List<Message> =
         okia?.conversation?.value?.history?.map { it.message }.orEmpty()
 
-    fun stream(query: String, context: Context): Flow<LlmStreamEvent> = channelFlow {
+    fun stream(
+        query: String,
+        context: Context,
+        fromUserInterface: Boolean = false,
+    ): Flow<LlmStreamEvent> = channelFlow {
+        // 确认型执行规则按来源区分：UI 直连可弹窗；宿主路径默认拒绝（英文错误回给 Agent）
+        ToolPermissionCoordinator.canRequestUserConfirmation = fromUserInterface
         val defaultErrorMessage = context.getString(R.string.error_llm_request_failed)
         try {
             val state = try {

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/PromptComposer.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/PromptComposer.kt
@@ -37,6 +37,7 @@ class PromptComposer {
                 .takeIf { hasBuiltinTool(input, "load_skill") },
             TASK_COMPLETION_GUIDANCE.takeIf { hasAnyTool(input) },
             TOOL_USE_ENFORCEMENT_GUIDANCE.takeIf { hasAnyTool(input) },
+            EXECUTION_RULES_GUIDANCE.takeIf { hasAnyTool(input) },
             MEMORY_GUIDANCE.takeIf { hasBuiltinTool(input, "memory") },
             SKILLS_GUIDANCE.takeIf { hasBuiltinTool(input, "load_skill") },
         ).joinToString(separator = "\n\n")
@@ -160,6 +161,13 @@ class PromptComposer {
                 "your turn with a promise of future action — execute it now.\n" +
                 "Every response should either (a) contain tool calls that make progress, or " +
                 "(b) deliver a final result to the user."
+
+        internal const val EXECUTION_RULES_GUIDANCE =
+            "# Execution rules\n" +
+                "Tool actions may be blocked by Zafiro's app-level execution rules, which are " +
+                "user-configurable in Zafiro settings — not system restrictions. A block means " +
+                "the user declined the action or the rule is too strict; the user can adjust " +
+                "the rule in Zafiro settings. Do not describe blocks as system policy."
 
         internal const val MEMORY_GUIDANCE =
             "You have persistent memory across sessions. Save durable facts using the memory " +

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/PromptComposer.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/PromptComposer.kt
@@ -198,6 +198,9 @@ class PromptComposer {
                 "Load the skill even if you think you could handle the task with basic " +
                 "tools. Skills also encode the user's preferred approach, conventions, " +
                 "and quality standards — load them even for tasks you already know how " +
-                "to do, because the skill defines how it should be done here."
+                "to do, because the skill defines how it should be done here.\n" +
+                "load_skill returns the skill's SKILL.md content; if it exceeds the limit, " +
+                "the result ends with the absolute path to the file — use terminal to read " +
+                "the full content from there."
     }
 }

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/ExecutePythonBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/ExecutePythonBuiltin.kt
@@ -5,6 +5,7 @@ import com.niki914.zafiro.chat.agentic.buildin.TextResultBuiltinTool
 import com.niki914.zafiro.chat.agentic.buildin.TextToolResult
 import com.niki914.zafiro.chat.agentic.python.PyRuntime
 import com.niki914.zafiro.chat.agentic.shell.ShellCommandSafetyPolicy
+import com.niki914.zafiro.util.ToolOutputTruncator
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
@@ -91,13 +92,12 @@ Limits: timeout 30 s default, 120 s max; output capped at 50 KB.
         }
     }
 
-    private fun capOutput(output: String, maxBytes: Int = 50_000): String {
-        val bytes = output.encodeToByteArray()
-        if (bytes.size <= maxBytes) return output
-        val head = bytes.copyOf(maxBytes)
-        val suffix = "\n\n[output truncated at $maxBytes bytes]".encodeToByteArray()
-        return head.copyOf(maxBytes - suffix.size).decodeToString() +
-                suffix.decodeToString()
+    private fun capOutput(output: String, maxBytes: Int = ToolOutputTruncator.DEFAULT_MAX_BYTES): String {
+        val truncation = ToolOutputTruncator.truncateTail(output, maxBytes = maxBytes)
+        if (!truncation.truncated) return output
+        return truncation.content + "\n\n[Output truncated: showing last " +
+            truncation.content.count { it == '\n' } + " of " + truncation.totalLines +
+            " lines]"
     }
 
     private fun parseArgs(argumentsJson: String): ParseResult {

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/ExecutePythonBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/ExecutePythonBuiltin.kt
@@ -58,7 +58,7 @@ Limits: timeout 30 s default, 120 s max; output capped at 50 KB.
     }
 
     private suspend fun execute(code: String, timeoutMs: Long): TextToolResult {
-        val decision = safetyPolicy.evaluate(code)
+        val decision = safetyPolicy.evaluate(code, toolName = name)
         if (!decision.allowed) {
             return TextToolResult.failure(
                 code = "COMMAND_BLOCKED",

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/LoadSkillBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/LoadSkillBuiltin.kt
@@ -5,6 +5,7 @@ import com.niki914.zafiro.chat.agentic.buildin.TextResultBuiltinTool
 import com.niki914.zafiro.chat.agentic.buildin.TextToolResult
 import com.niki914.zafiro.settings.RuntimeEnvironment
 import com.niki914.zafiro.settings.model.RuntimeLoadedSkill
+import com.niki914.zafiro.util.ToolOutputTruncator
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
@@ -16,7 +17,9 @@ class LoadSkillBuiltin : TextResultBuiltinTool() {
     override val name: String = "load_skill"
 
     override val description: String =
-        "Load a Zafiro skill by id when its full SKILL.md content is needed."
+        "Load a Zafiro skill by id. Returns the skill's SKILL.md content; if it exceeds " +
+            "the limit, the result ends with the absolute path to the file — use terminal " +
+            "to read the full content from there."
 
     override val defaultEnabled: Boolean = true
 
@@ -56,7 +59,9 @@ class LoadSkillBuiltin : TextResultBuiltinTool() {
                         "Use an enabled id from the available_skills prompt block.",
                 )
             }
-            TextToolResult.success(skill.content)
+            TextToolResult.success(
+                truncateSkillContent(skill.content, skill.absolutePath)
+            )
         } catch (throwable: Throwable) {
             if (throwable is CancellationException) {
                 throw throwable
@@ -85,6 +90,21 @@ class LoadSkillBuiltin : TextResultBuiltinTool() {
 
     private fun JsonObject.stringOrNull(key: String): String? {
         return (this[key] as? JsonPrimitive)?.contentOrNull
+    }
+
+    /**
+     * 双限制（2000 行 / 50KB）head 截断（对齐 ToolOutputTruncator），截断时
+     * 在内容尾部附绝对路径提示，模型可用 terminal 自取全量。
+     */
+    private fun truncateSkillContent(content: String, absolutePath: String): String {
+        val truncation = ToolOutputTruncator.truncateHead(content)
+        if (!truncation.truncated) return content
+        return buildString {
+            append(truncation.content)
+            append("\n\n[Content truncated: full SKILL.md is at ")
+            append(absolutePath)
+            append(" — use terminal to read it.]")
+        }
     }
 
     private sealed interface SkillIdParseResult {

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/PyMetaToolsBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/PyMetaToolsBuiltin.kt
@@ -137,7 +137,7 @@ Store the result of a run by printing from main; stdout is returned.
                 fieldErrors = mapOf("name" to "reserved"),
             )
         }
-        safetyPolicy.evaluate(code).takeIf { !it.allowed }?.let { decision ->
+        safetyPolicy.evaluate(code, toolName = name).takeIf { !it.allowed }?.let { decision ->
             return BuiltinToolResult.failure(
                 code = "COMMAND_BLOCKED",
                 message = decision.reason.ifBlank { "Code blocked by safety policy." },
@@ -201,7 +201,7 @@ Store the result of a run by printing from main; stdout is returned.
                     message = "Provide either 'code' (draft test) or 'name' (existing tool), not both.",
                 )
             }
-            safetyPolicy.evaluate(draftCode).takeIf { !it.allowed }?.let { decision ->
+            safetyPolicy.evaluate(draftCode, toolName = name).takeIf { !it.allowed }?.let { decision ->
                 return BuiltinToolResult.failure(
                     code = "COMMAND_BLOCKED",
                     message = decision.reason.ifBlank { "Code blocked by safety policy." },

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/TerminalBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/TerminalBuiltin.kt
@@ -97,7 +97,7 @@ class TerminalBuiltin(
     private suspend fun handleCommand(args: TerminalArgs): String {
         val command = args.requireCommand()
         val timeoutSec = args.resolveTimeout()
-        val decision = safetyPolicy.evaluate(command)
+        val decision = safetyPolicy.evaluate(command, toolName = name)
         if (!decision.allowed) {
             return TerminalToolResponse.policyBlocked(decision)
         }

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/shell/ShellCommandSafetyPolicy.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/shell/ShellCommandSafetyPolicy.kt
@@ -21,7 +21,7 @@ class ShellCommandSafetyPolicy(
     },
     private val isUnlocked: suspend () -> Boolean = { LockState.isUnlocked() },
 ) {
-    suspend fun evaluate(command: String): ShellCommandPolicyDecision {
+    suspend fun evaluate(command: String, toolName: String): ShellCommandPolicyDecision {
         val rules = listExecutionRules()
         if (rules.isEmpty()) {
             return ShellCommandPolicyDecision(allowed = true)
@@ -32,31 +32,59 @@ class ShellCommandSafetyPolicy(
             true
         }
         val candidates = command.matchCandidates()
-        rules.asSequence()
-            .filter { it.isActive(unlocked) }
-            .forEach { rule ->
-                rule.patterns.asSequence()
-                    .map(String::trim)
-                    .filter(String::isNotBlank)
-                    .forEach { pattern ->
-                        if (candidates.any { candidate ->
-                                TextPatternMatcher.matches(
-                                    candidate,
-                                    pattern
-                                )
-                            }) {
-                            return ShellCommandPolicyDecision(
-                                allowed = false,
-                                code = "RULE_BLOCKED",
-                                reason = "Command blocked by execution rule '${rule.name}' with pattern '$pattern'.",
-                                matchedRuleId = rule.id,
-                                matchedRuleName = rule.name,
-                                matchedPattern = pattern,
-                            )
-                        }
+        for (rule in rules.filter { it.isActive(unlocked) }) {
+            val pattern = rule.patterns.asSequence()
+                .map(String::trim)
+                .filter(String::isNotBlank)
+                .firstOrNull { pattern ->
+                    candidates.any { candidate ->
+                        TextPatternMatcher.matches(
+                            candidate,
+                            pattern
+                        )
                     }
+                }
+                ?: continue
+            val blocked = ShellCommandPolicyDecision(
+                allowed = false,
+                code = "RULE_BLOCKED",
+                reason = "Command blocked by execution rule '${rule.name}' with pattern '$pattern'.",
+                matchedRuleId = rule.id,
+                matchedRuleName = rule.name,
+                matchedPattern = pattern,
+            )
+            when (rule.enabledMode) {
+                ExecutionRuleEnabledMode.ALWAYS, ExecutionRuleEnabledMode.LOCKED_ONLY -> return blocked
+                ExecutionRuleEnabledMode.DISABLED -> {}
+                ExecutionRuleEnabledMode.CONFIRM -> when (
+                    ToolPermissionCoordinator.confirm(blocked.toConfirmationRequest(command, toolName))
+                ) {
+                    ToolPermissionResponse.ALLOWED -> continue
+                    ToolPermissionResponse.DENIED_BY_USER -> return blocked.copy(
+                        code = "CONFIRM_DENIED",
+                        reason = "The user denied this operation.",
+                    )
+                    ToolPermissionResponse.DENIED_UNAVAILABLE -> return blocked.copy(
+                        code = "CONFIRM_UNAVAILABLE",
+                        reason = "Tool execution requires user confirmation, but this session " +
+                            "cannot request permission from the user. The operation was denied.",
+                    )
+                }
             }
+        }
         return ShellCommandPolicyDecision(allowed = true)
+    }
+
+    private fun ShellCommandPolicyDecision.toConfirmationRequest(
+        command: String,
+        toolName: String,
+    ): ToolPermissionRequest {
+        return ToolPermissionRequest(
+            id = java.util.UUID.randomUUID().toString(),
+            toolName = toolName,
+            command = command,
+            matchedRuleName = matchedRuleName.orEmpty(),
+        )
     }
 
     private fun String.shellLikeTokens(): List<String> {
@@ -163,7 +191,7 @@ class ShellCommandSafetyPolicy(
 
     private fun ExecutionRule.isActive(unlocked: Boolean): Boolean {
         return when (enabledMode) {
-            ExecutionRuleEnabledMode.ALWAYS -> true
+            ExecutionRuleEnabledMode.ALWAYS, ExecutionRuleEnabledMode.CONFIRM -> true
             ExecutionRuleEnabledMode.LOCKED_ONLY -> !unlocked
             ExecutionRuleEnabledMode.DISABLED -> false
         }

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/shell/TerminalSessionPool.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/shell/TerminalSessionPool.kt
@@ -15,6 +15,7 @@ import com.niki914.libterm.runtime.TerminalTextChunk
 import com.niki914.logging.Logger
 import com.niki914.zafiro.chat.agentic.shell.TerminalToolResponse.stdoutText
 import com.niki914.zafiro.chat.agentic.shell.TerminalToolResponse.stderrText
+import com.niki914.zafiro.util.ToolOutputTruncator
 import com.niki914.xposed.api.util.ContextProvider
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -923,7 +924,11 @@ object TerminalSessionPool {
     }
 
     private fun truncateOutput(text: String, maxBytes: Int): String {
-        return text.takeLast(maxBytes.coerceAtLeast(1))
+        val truncation = ToolOutputTruncator.truncateTail(text, maxBytes = maxBytes)
+        if (!truncation.truncated) return text
+        return truncation.content + "\n\n[Output truncated: showing last " +
+            truncation.content.count { it == '\n' } + " of " + truncation.totalLines +
+            " lines]"
     }
 
     private fun mergedOutput(result: CommandResult): String {

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/shell/ToolPermissionCoordinator.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/shell/ToolPermissionCoordinator.kt
@@ -1,0 +1,67 @@
+package com.niki914.zafiro.chat.agentic.shell
+
+import com.niki914.logging.Logger
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/** 一次工具执行确认请求（UI 展示字段）。 */
+data class ToolPermissionRequest(
+    val id: String,
+    val toolName: String,
+    val command: String,
+    val matchedRuleName: String,
+)
+
+/** 确认请求终态：允许 / 用户拒绝 / 无确认渠道（宿主路径）拒绝。 */
+enum class ToolPermissionResponse { ALLOWED, DENIED_BY_USER, DENIED_UNAVAILABLE }
+
+/**
+ * CONFIRM 型执行规则的用户确认协调器。
+ * - LLMController.stream 按来源设置 [canRequestUserConfirmation]：
+ *   UI 直连 = true；宿主 Binder = false（默认拒绝，Agent 收到英文错误）。
+ * - UI collect [pendingConfirmation] 渲染对话框，[respond] 解除挂起；
+ *   永不超时（用户明确决策，PRD §3）。
+ * - LLMController 单活跃回合，confirm/respond 无并发竞争。
+ */
+object ToolPermissionCoordinator {
+    private const val LOG_TAG = "niki914_nexus_ToolPermission"
+
+    @Volatile
+    var canRequestUserConfirmation: Boolean = false
+
+    private val pendingFlow = MutableStateFlow<ToolPermissionRequest?>(null)
+
+    /** 当前待确认请求；null = 无挂起确认。 */
+    val pendingConfirmation: StateFlow<ToolPermissionRequest?> = pendingFlow.asStateFlow()
+
+    private var deferred: CompletableDeferred<ToolPermissionResponse>? = null
+
+    suspend fun confirm(request: ToolPermissionRequest): ToolPermissionResponse {
+        if (!canRequestUserConfirmation) {
+            Logger.i(LOG_TAG, "confirm denied source=host id=${request.id}")
+            return ToolPermissionResponse.DENIED_UNAVAILABLE
+        }
+        Logger.i(LOG_TAG, "confirm requested id=${request.id} tool=${request.toolName}")
+        pendingFlow.value = request
+        val waiter = CompletableDeferred<ToolPermissionResponse>()
+        deferred = waiter
+        try {
+            return waiter.await()
+        } finally {
+            if (deferred === waiter) {
+                deferred = null
+                pendingFlow.value = null
+            }
+        }
+    }
+
+    /** UI 决策入口；requestId 与当前挂起请求不一致时忽略。 */
+    fun respond(requestId: String, allowed: Boolean) {
+        if (pendingFlow.value?.id != requestId) return
+        deferred?.complete(
+            if (allowed) ToolPermissionResponse.ALLOWED else ToolPermissionResponse.DENIED_BY_USER
+        )
+    }
+}

--- a/agent-runtime/src/main/java/com/niki914/zafiro/settings/model/RuntimeSettingsModels.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/settings/model/RuntimeSettingsModels.kt
@@ -96,6 +96,9 @@ enum class RuntimeExecutionRuleEnabledMode {
     ALWAYS,
     LOCKED_ONLY,
     DISABLED,
+
+    /** 命中后挂起等待用户确认；无确认渠道（宿主路径）时拒绝。 */
+    CONFIRM,
 }
 
 data class RuntimeExecutionRule(

--- a/agent-runtime/src/main/java/com/niki914/zafiro/util/ToolOutputTruncator.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/util/ToolOutputTruncator.kt
@@ -1,0 +1,83 @@
+package com.niki914.zafiro.util
+
+/**
+ * 工具输出统一截断器，对齐 pi 的 truncateHead / truncateTail 语义：
+ * - 行数 / 字节双限制（2000 行 / 50KB）先到先生效；
+ * - head 永不截断完整行；tail 仅在首个输出行超字节限制时允许部分行；
+ * - 字节计数为 UTF-8，截断边界不回退到半个字符。
+ * 调用方负责在 [Truncation.truncated] 时附截断提示。
+ */
+object ToolOutputTruncator {
+
+    const val DEFAULT_MAX_LINES = 2000
+    const val DEFAULT_MAX_BYTES = 50 * 1024
+
+    data class Truncation(
+        val content: String,
+        val truncated: Boolean,
+        val totalLines: Int,
+        val totalBytes: Int,
+    )
+
+    /** 保留开头。适合文档 / 文件类内容（如 SKILL.md）。 */
+    fun truncateHead(
+        content: String,
+        maxLines: Int = DEFAULT_MAX_LINES,
+        maxBytes: Int = DEFAULT_MAX_BYTES,
+    ): Truncation {
+        val lines = content.split("\n")
+        val totalBytes = content.toByteArray(Charsets.UTF_8).size
+        if (lines.size <= maxLines && totalBytes <= maxBytes) {
+            return Truncation(content, truncated = false, lines.size, totalBytes)
+        }
+        val kept = mutableListOf<String>()
+        var keptBytes = 0
+        for ((index, line) in lines.withIndex()) {
+            if (kept.size >= maxLines) break
+            val lineBytes = line.toByteArray(Charsets.UTF_8).size + if (index > 0) 1 else 0
+            if (keptBytes + lineBytes > maxBytes) break
+            kept += line
+            keptBytes += lineBytes
+        }
+        return Truncation(kept.joinToString("\n"), truncated = true, lines.size, totalBytes)
+    }
+
+    /** 保留结尾。适合命令执行类内容（结果 / 报错在末尾）。 */
+    fun truncateTail(
+        content: String,
+        maxLines: Int = DEFAULT_MAX_LINES,
+        maxBytes: Int = DEFAULT_MAX_BYTES,
+    ): Truncation {
+        val lines = content.split("\n")
+        val totalBytes = content.toByteArray(Charsets.UTF_8).size
+        if (lines.size <= maxLines && totalBytes <= maxBytes) {
+            return Truncation(content, truncated = false, lines.size, totalBytes)
+        }
+        val kept = ArrayDeque<String>()
+        var keptBytes = 0
+        for (index in lines.indices.reversed()) {
+            if (kept.size >= maxLines) break
+            val lineBytes = lines[index].toByteArray(Charsets.UTF_8).size + if (kept.isNotEmpty()) 1 else 0
+            if (keptBytes + lineBytes > maxBytes) {
+                // 一个行都放不下时取该行尾部（UTF-8 安全，允许部分行）
+                if (kept.isEmpty()) {
+                    val partial = takeLastUtf8(lines[index], maxBytes)
+                    kept.addFirst(partial)
+                    keptBytes = partial.toByteArray(Charsets.UTF_8).size
+                }
+                break
+            }
+            kept.addFirst(lines[index])
+            keptBytes += lineBytes
+        }
+        return Truncation(kept.joinToString("\n"), truncated = true, lines.size, totalBytes)
+    }
+
+    private fun takeLastUtf8(text: String, maxBytes: Int): String {
+        val bytes = text.toByteArray(Charsets.UTF_8)
+        if (bytes.size <= maxBytes) return text
+        var start = bytes.size - maxBytes
+        while (start < bytes.size && (bytes[start].toInt() and 0xC0) == 0x80) start++
+        return String(bytes, start, bytes.size - start, Charsets.UTF_8)
+    }
+}

--- a/agent-runtime/src/main/python/runtime.py
+++ b/agent-runtime/src/main/python/runtime.py
@@ -58,10 +58,50 @@ class BoundedWriter:
         return val
 
 
+class _ThreadRouter:
+    """sys.stdout/stderr stand-in that routes writes per-thread.
+
+    exec_code never swaps the global stream (concurrent Binder threads
+    calling exec_code would otherwise overwrite each other's stdout and
+    cross-wire results). Each exec thread binds its own writer; any other
+    thread — including threads spawned by the exec'd code — falls back to
+    the original stream.
+    """
+
+    def __init__(self, fallback):
+        self._fallback = fallback
+        self._local = threading.local()
+
+    def bind(self, writer):
+        self._local.writer = writer
+
+    def unbind(self):
+        self._local.writer = None
+
+    def _writer(self):
+        return getattr(self._local, "writer", None) or self._fallback
+
+    def write(self, s: str) -> int:
+        return self._writer().write(s)
+
+    def flush(self):
+        self._writer().flush()
+
+    def isatty(self) -> bool:
+        return False
+
+
+_real_stdout = sys.stdout
+_real_stderr = sys.stderr
+sys.stdout = _ThreadRouter(_real_stdout)
+sys.stderr = _ThreadRouter(_real_stderr)
+
+
 def exec_code(code: str, timeout: float = 30.0) -> str:
     """Execute Python code in a daemon thread with a timeout.
 
-    Captures stdout and stderr with a shared 50 KB budget.
+    Captures stdout and stderr with a shared 50 KB budget. Safe under
+    concurrent invocations: output capture is thread-local.
     Raises *TimeoutError* if the thread is still alive after *timeout*
     seconds.
 
@@ -75,12 +115,10 @@ def exec_code(code: str, timeout: float = 30.0) -> str:
     budget = OutputBudget()
     out_buf = BoundedWriter(budget)
     err_buf = BoundedWriter(budget)
-    old_out = sys.stdout
-    old_err = sys.stderr
-    sys.stdout = out_buf
-    sys.stderr = err_buf
 
     def run():
+        sys.stdout.bind(out_buf)
+        sys.stderr.bind(err_buf)
         try:
             exec(code, {"__builtins__": __builtins__})
         except Exception as e:
@@ -90,9 +128,6 @@ def exec_code(code: str, timeout: float = 30.0) -> str:
     t.daemon = True
     t.start()
     t.join(timeout=timeout)
-
-    sys.stdout = old_out
-    sys.stderr = old_err
 
     output = out_buf.getvalue()
     err_text = err_buf.getvalue()

--- a/agent-runtime/src/test/java/com/niki914/zafiro/chat/LoadSkillBuiltinTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/zafiro/chat/LoadSkillBuiltinTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -34,6 +35,52 @@ class LoadSkillBuiltinTest {
 
         assertEquals(TextToolResult.Status.Success, result.status)
         assertEquals("Skill content A", result.payload)
+    }
+
+    @Test
+    fun invoke_overLineLimit_truncatesAndAppendsPath() = runTest {
+        installRuntimeSettingsGatewayForTest(
+            FakeRuntimeSettingsGateway(
+                loadedSkills = mapOf(
+                    "skill-a" to loadedSkill(
+                        "skill-a",
+                        content = (1..2500).joinToString("\n") { "line $it" },
+                    )
+                )
+            )
+        )
+
+        val result = invokeAndDecode("""{"id":"skill-a"}""")
+
+        assertEquals(TextToolResult.Status.Success, result.status)
+        assertTrue(result.payload.contains("/private/skill-a/SKILL.md"))
+        assertTrue(result.payload.contains("[Content truncated:"))
+        assertTrue(result.payload.contains("line 1"))
+        assertTrue(result.payload.contains("line 2000"))
+        assertFalse(result.payload.contains("line 2001"))
+    }
+
+    @Test
+    fun invoke_overByteLimit_truncatesAndAppendsPath() = runTest {
+        installRuntimeSettingsGatewayForTest(
+            FakeRuntimeSettingsGateway(
+                loadedSkills = mapOf(
+                    "skill-a" to loadedSkill(
+                        "skill-a",
+                        // 总字节 > 50KB（每行 300 字节 × 200 行），行数未超限
+                        content = (1..200).joinToString("\n") { "line $it " + "x".repeat(290) },
+                    )
+                )
+            )
+        )
+
+        val result = invokeAndDecode("""{"id":"skill-a"}""")
+
+        assertEquals(TextToolResult.Status.Success, result.status)
+        assertTrue(result.payload.contains("/private/skill-a/SKILL.md"))
+        assertTrue(result.payload.contains("[Content truncated:"))
+        assertTrue(result.payload.contains("line 1"))
+        assertFalse(result.payload.contains("line 200"))
     }
 
     @Test
@@ -120,6 +167,7 @@ class LoadSkillBuiltinTest {
     private fun loadedSkill(
         id: String,
         enabled: Boolean = true,
+        content: String = "Skill content A",
     ): RuntimeLoadedSkill {
         return RuntimeLoadedSkill(
             id = id,
@@ -128,7 +176,7 @@ class LoadSkillBuiltinTest {
             relativePath = "$id/SKILL.md",
             absolutePath = "/private/$id/SKILL.md",
             absoluteDir = "/private/$id",
-            content = "Skill content A",
+            content = content,
             enabled = enabled,
         )
     }

--- a/agent-runtime/src/test/java/com/niki914/zafiro/chat/PromptComposerTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/zafiro/chat/PromptComposerTest.kt
@@ -92,6 +92,36 @@ class PromptComposerTest {
     // --- Tool context (stable tier) ---
 
     @Test
+    fun compose_injectsExecutionRulesGuidanceWhenToolsExist() {
+        val customPyTool = LocalTool.Py(
+            name = "py_launch_wechat",
+            description = "Launch WeChat",
+            code = "def main():\n    pass",
+            inputSchemaJson = null,
+        )
+        val result = PromptComposer().compose(
+            PromptComposerInput(
+                additionalInstructions = "",
+                tools = ResolvedTools(customPyTools = listOf(customPyTool)),
+            )
+        )
+
+        assertTrue(result.finalSystemPrompt.contains(PromptComposer.EXECUTION_RULES_GUIDANCE))
+    }
+
+    @Test
+    fun compose_omitsExecutionRulesGuidanceWhenNoTools() {
+        val result = PromptComposer().compose(
+            PromptComposerInput(
+                additionalInstructions = "base",
+                tools = ResolvedTools(),
+            )
+        )
+
+        assertFalse(result.finalSystemPrompt.contains(PromptComposer.EXECUTION_RULES_GUIDANCE))
+    }
+
+    @Test
     fun compose_omitsToolContextWhenNoToolsOrMcpServers() {
         val result = PromptComposer().compose(
             PromptComposerInput(

--- a/agent-runtime/src/test/java/com/niki914/zafiro/chat/ShellCommandSafetyPolicyTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/zafiro/chat/ShellCommandSafetyPolicyTest.kt
@@ -2,7 +2,11 @@ package com.niki914.zafiro.chat
 
 import com.niki914.zafiro.chat.agentic.shell.ShellCommandSafetyPolicy
 import com.niki914.zafiro.settings.RuntimeEnvironment
+import com.niki914.zafiro.chat.agentic.shell.ToolPermissionCoordinator
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -23,7 +27,7 @@ class ShellCommandSafetyPolicyTest {
             FakeRuntimeSettingsGateway(executionRules = listOf(dangerousRule()))
         )
 
-        assertTrue(ShellCommandSafetyPolicy().evaluate("getprop ro.product.model").allowed)
+        assertTrue(ShellCommandSafetyPolicy().evaluate(command = "getprop ro.product.model", toolName = "terminal").allowed)
     }
 
     @Test
@@ -32,7 +36,7 @@ class ShellCommandSafetyPolicyTest {
             FakeRuntimeSettingsGateway(executionRules = listOf(dangerousRule()))
         )
 
-        val decision = ShellCommandSafetyPolicy().evaluate("rm -rf /data/local/tmp/cache")
+        val decision = ShellCommandSafetyPolicy().evaluate(command = "rm -rf /data/local/tmp/cache", toolName = "terminal")
 
         assertFalse(decision.allowed)
         assertEquals("RULE_BLOCKED", decision.code)
@@ -55,7 +59,7 @@ class ShellCommandSafetyPolicyTest {
             "rm -r --force /data/local/tmp/cache",
             "rm --recursive -f /data/local/tmp/cache",
         ).forEach { command ->
-            val decision = ShellCommandSafetyPolicy().evaluate(command)
+            val decision = ShellCommandSafetyPolicy().evaluate(command = command, toolName = "terminal")
 
             assertFalse(decision.allowed)
             assertEquals("RULE_BLOCKED", decision.code)
@@ -70,10 +74,10 @@ class ShellCommandSafetyPolicyTest {
         )
 
         assertFalse(
-            ShellCommandSafetyPolicy().evaluate("sh -c 'pm uninstall com.example.app'").allowed
+            ShellCommandSafetyPolicy().evaluate(command = "sh -c 'pm uninstall com.example.app'", toolName = "terminal").allowed
         )
         assertFalse(
-            ShellCommandSafetyPolicy().evaluate("eval 'cmd package uninstall com.example.app'").allowed
+            ShellCommandSafetyPolicy().evaluate(command = "eval 'cmd package uninstall com.example.app'", toolName = "terminal").allowed
         )
     }
 
@@ -89,12 +93,12 @@ class ShellCommandSafetyPolicyTest {
 
         assertTrue(
             ShellCommandSafetyPolicy(isUnlocked = { true })
-                .evaluate("rm -rf /data/local/tmp/cache")
+                .evaluate("rm -rf /data/local/tmp/cache", toolName = "terminal")
                 .allowed
         )
         assertFalse(
             ShellCommandSafetyPolicy(isUnlocked = { false })
-                .evaluate("rm -rf /data/local/tmp/cache")
+                .evaluate("rm -rf /data/local/tmp/cache", toolName = "terminal")
                 .allowed
         )
     }
@@ -114,7 +118,87 @@ class ShellCommandSafetyPolicyTest {
             )
         )
 
-        assertFalse(ShellCommandSafetyPolicy().evaluate("echo [broken").allowed)
+        assertFalse(ShellCommandSafetyPolicy().evaluate(command = "echo [broken", toolName = "terminal").allowed)
+    }
+
+    @Test
+    fun evaluate_confirmRuleDeniedWithoutUiChannel() = runTest {
+        installRuntimeSettingsGatewayForTest(
+            FakeRuntimeSettingsGateway(
+                executionRules = listOf(dangerousRule(enabledMode = ExecutionRuleEnabledMode.CONFIRM))
+            )
+        )
+        ToolPermissionCoordinator.canRequestUserConfirmation = false
+
+        val decision = ShellCommandSafetyPolicy()
+            .evaluate("rm -rf /data/local/tmp/cache", toolName = "terminal")
+
+        assertFalse(decision.allowed)
+        assertEquals("CONFIRM_UNAVAILABLE", decision.code)
+        assertTrue(decision.reason.contains("cannot request permission"))
+    }
+
+    @Test
+    fun evaluate_confirmRuleDeniedByUser() = runTest {
+        installRuntimeSettingsGatewayForTest(
+            FakeRuntimeSettingsGateway(
+                executionRules = listOf(dangerousRule(enabledMode = ExecutionRuleEnabledMode.CONFIRM))
+            )
+        )
+        ToolPermissionCoordinator.canRequestUserConfirmation = true
+
+        val evaluation = async {
+            ShellCommandSafetyPolicy().evaluate("rm -rf /data/local/tmp/cache", toolName = "terminal")
+        }
+        withTimeout(5_000) {
+            ToolPermissionCoordinator.pendingConfirmation.first { it != null }
+        }
+        ToolPermissionCoordinator.respond(
+            ToolPermissionCoordinator.pendingConfirmation.value?.id.orEmpty(),
+            allowed = false,
+        )
+
+        val decision = evaluation.await()
+        assertFalse(decision.allowed)
+        assertEquals("CONFIRM_DENIED", decision.code)
+        assertEquals("危险删改", decision.matchedRuleName)
+    }
+
+    @Test
+    fun evaluate_confirmRuleAllowedStillBlockedByLaterRule() = runTest {
+        installRuntimeSettingsGatewayForTest(
+            FakeRuntimeSettingsGateway(
+                executionRules = listOf(
+                    dangerousRule(enabledMode = ExecutionRuleEnabledMode.CONFIRM),
+                    uninstallRule(),
+                )
+            )
+        )
+        ToolPermissionCoordinator.canRequestUserConfirmation = true
+
+        val evaluation = async {
+            ShellCommandSafetyPolicy().evaluate(
+                command = "rm -rf /data/local/tmp/cache; pm uninstall com.example.app",
+                toolName = "terminal",
+            )
+        }
+        withTimeout(5_000) {
+            ToolPermissionCoordinator.pendingConfirmation.first { it != null }
+        }
+        ToolPermissionCoordinator.respond(
+            ToolPermissionCoordinator.pendingConfirmation.value?.id.orEmpty(),
+            allowed = true,
+        )
+
+        val decision = evaluation.await()
+        assertFalse(decision.allowed)
+        assertEquals("RULE_BLOCKED", decision.code)
+        assertEquals("uninstall", decision.matchedRuleId)
+    }
+
+    @After
+    fun resetToolPermissionCoordinator() {
+        ToolPermissionCoordinator.canRequestUserConfirmation = false
     }
 
     private fun dangerousRule(

--- a/agent-runtime/src/test/java/com/niki914/zafiro/util/ToolOutputTruncatorTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/zafiro/util/ToolOutputTruncatorTest.kt
@@ -1,0 +1,88 @@
+package com.niki914.zafiro.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ToolOutputTruncatorTest {
+
+    @Test
+    fun head_withinLimits_returnsUntouched() {
+        val result = ToolOutputTruncator.truncateHead("a\nb\nc")
+        assertFalse(result.truncated)
+        assertEquals("a\nb\nc", result.content)
+    }
+
+    @Test
+    fun head_overLineLimit_keepsFirstLines() {
+        val content = (1..2500).joinToString("\n") { "line $it" }
+        val result = ToolOutputTruncator.truncateHead(content, maxLines = 10)
+
+        assertTrue(result.truncated)
+        assertEquals(2500, result.totalLines)
+        assertEquals("line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9\nline 10", result.content)
+    }
+
+    @Test
+    fun head_overByteLimit_stopsAtCompleteLines() {
+        val content = "aa\nbb\ncc\ndd"
+        val result = ToolOutputTruncator.truncateHead(content, maxLines = 100, maxBytes = 7)
+
+        assertTrue(result.truncated)
+        // aa(2) + \n(1) + bb(2) = 5 字节；加 cc(2)+\n(1) 到 8 字节超限 → 停在 bb
+        assertEquals("aa\nbb", result.content)
+    }
+
+    @Test
+    fun head_keepsMultibyteLinesByBytes() {
+        // 多字节行按 UTF-8 字节计数，边界落在整行之间，不切半个字符
+        val content = "a\n中文\nb" // 1 + 1 + 6 + 1 + 1 = 10 字节
+        val result = ToolOutputTruncator.truncateHead(content, maxLines = 100, maxBytes = 9)
+
+        assertTrue(result.truncated)
+        // a(1) + 中文(6+1) = 8 字节 ≤ 9；再加 b(1+1) 到 10 超限 → 停在中文行
+        assertEquals("a\n中文", result.content)
+    }
+
+    @Test
+    fun tail_overLineLimit_keepsLastLines() {
+        val content = (1..2500).joinToString("\n") { "line $it" }
+        val result = ToolOutputTruncator.truncateTail(content, maxLines = 10)
+
+        assertTrue(result.truncated)
+        assertEquals(2500, result.totalLines)
+        assertEquals(
+            (2491..2500).joinToString("\n") { "line $it" },
+            result.content,
+        )
+    }
+
+    @Test
+    fun tail_overByteLimit_keepsTailCompleteLines() {
+        val content = "aa\nbb\ncc\ndd"
+        val result = ToolOutputTruncator.truncateTail(content, maxLines = 100, maxBytes = 7)
+
+        assertTrue(result.truncated)
+        assertEquals("cc\ndd", result.content)
+    }
+
+    @Test
+    fun tail_singleHugeLine_takesPartialEnd() {
+        val content = "x".repeat(100)
+        val result = ToolOutputTruncator.truncateTail(content, maxLines = 100, maxBytes = 10)
+
+        assertTrue(result.truncated)
+        assertEquals("x".repeat(10), result.content)
+    }
+
+    @Test
+    fun tail_neverCutsMultibyteChar() {
+        val content = "第一行\n第二行"
+        val result = ToolOutputTruncator.truncateTail(content, maxLines = 100, maxBytes = 10)
+
+        assertTrue(result.truncated)
+        // 尾部 10 字节 = 第二行（3字×3字节+换行1字节=10字节），边界不切半个字符
+        assertEquals("第二行", result.content)
+    }
+}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,6 +15,10 @@ android {
     namespace = "com.niki914.zafiro.app"
     compileSdk = 37
 
+    testOptions {
+        unitTests.isIncludeAndroidResources = true
+    }
+
     defaultConfig {
         applicationId = "com.niki914.zafiro"
         minSdk = 26

--- a/app/src/main/java/com/niki914/zafiro/app/MainActivity.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/MainActivity.kt
@@ -51,4 +51,21 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        isResumed = true
+    }
+
+    override fun onPause() {
+        super.onPause()
+        isResumed = false
+    }
+
+    companion object {
+
+        /** 前后台标记：确认请求在后台时改为发通知（纯通知，无决策入口）。 */
+        @Volatile
+        var isResumed: Boolean = false
+            private set
+    }
 }

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/ExecutionRuleDetailContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/ExecutionRuleDetailContent.kt
@@ -16,7 +16,7 @@ import com.niki914.uikit.infra.ConfirmationLiquidDialog
 import com.niki914.uikit.infra.ProvideLiquidScreenContentForPreview
 import com.niki914.uikit.infra.component.SettingsGroupCard
 import com.niki914.uikit.infra.component.SettingsItemDivider
-import com.niki914.uikit.infra.component.SettingsSegmentedSelector
+import com.niki914.uikit.infra.component.SettingsListItem
 import com.niki914.uikit.infra.nav.pageViewModel
 import com.niki914.zafiro.app.ui.model.ExecutionRuleDeleteConfirmationState
 import com.niki914.zafiro.app.ui.model.ExecutionRuleFormState
@@ -132,6 +132,8 @@ private fun ExecutionRuleDetailContentBody(
     onPatternsInputChange: (String) -> Unit,
     onSave: () -> Unit,
 ) {
+    var showEnabledModeDialog by rememberSaveable { mutableStateOf(false) }
+
     EditableSettingsDetailFormScaffold(
         actionText = stringResource(R.string.execution_rules_save_action),
         requestedFocusField = requestedFocusField,
@@ -155,12 +157,12 @@ private fun ExecutionRuleDetailContentBody(
                 maxLines = 1,
             )
             SettingsItemDivider()
-            ExecutionRuleEnabledModeSection(
+            ExecutionRuleEnabledModeRow(
                 selectedMode = uiState.formState.enabledMode,
                 enabled = !uiState.isSaving,
-                onModeSelected = {
+                onClick = {
                     fieldController.clearActiveField()
-                    onEnabledModeChange(it)
+                    showEnabledModeDialog = true
                 },
             )
         }
@@ -181,21 +183,45 @@ private fun ExecutionRuleDetailContentBody(
             )
         }
     }
+
+    // 生效时机：单选弹窗（SplitButton 四选项文本放不下，回归 PRD §3）
+    val modeOptions = RuntimeExecutionRuleEnabledMode.entries.map { mode ->
+        ExecutionRuleModeOption(mode, stringResource(mode.labelRes()))
+    }
+    SingleChoiceLiquidDialog(
+        visible = showEnabledModeDialog,
+        onDismissRequest = { showEnabledModeDialog = false },
+        title = stringResource(R.string.execution_rules_field_enabled_mode),
+        options = modeOptions,
+        selectedId = uiState.formState.enabledMode.name,
+        optionId = ExecutionRuleModeOption::id,
+        optionLabel = ExecutionRuleModeOption::label,
+        onSelect = { option ->
+            showEnabledModeDialog = false
+            onEnabledModeChange(option.mode)
+        },
+    )
+}
+
+private data class ExecutionRuleModeOption(
+    val mode: RuntimeExecutionRuleEnabledMode,
+    val label: String,
+) {
+    val id: String get() = mode.name
 }
 
 @Composable
-private fun ExecutionRuleEnabledModeSection(
+private fun ExecutionRuleEnabledModeRow(
     selectedMode: RuntimeExecutionRuleEnabledMode,
-    onModeSelected: (RuntimeExecutionRuleEnabledMode) -> Unit,
+    onClick: () -> Unit,
     enabled: Boolean = true,
 ) {
-    SettingsSegmentedSelector(
+    SettingsListItem(
         title = stringResource(R.string.execution_rules_field_enabled_mode),
-        options = RuntimeExecutionRuleEnabledMode.entries,
-        selected = selectedMode,
-        label = { option -> stringResource(option.labelRes()) },
-        onSelected = onModeSelected,
+        currentState = stringResource(selectedMode.labelRes()),
+        showChevron = true,
         enabled = enabled,
+        onClick = onClick,
     )
 }
 
@@ -224,6 +250,7 @@ private fun RuntimeExecutionRuleEnabledMode.labelRes(): Int {
         RuntimeExecutionRuleEnabledMode.ALWAYS -> R.string.execution_rules_enabled_mode_enabled
         RuntimeExecutionRuleEnabledMode.LOCKED_ONLY -> R.string.execution_rules_enabled_mode_locked_only
         RuntimeExecutionRuleEnabledMode.DISABLED -> R.string.execution_rules_enabled_mode_disabled
+        RuntimeExecutionRuleEnabledMode.CONFIRM -> R.string.execution_rules_enabled_mode_confirm
     }
 }
 

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
@@ -4,6 +4,7 @@ import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsDraggedAsState
@@ -44,6 +45,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
@@ -55,11 +57,16 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.niki914.zafiro.app.MainActivity
 import com.niki914.zafiro.app.R
 import com.niki914.uikit.infra.ConfirmationLiquidDialog
+import com.niki914.uikit.infra.LiquidDialog
+import com.niki914.uikit.infra.component.MaterialTintLiquidButton
 import com.niki914.uikit.infra.LocalLiquidViewportAvoidanceController
 import com.niki914.uikit.infra.ProvideLiquidScreenContentForPreview
 import com.niki914.uikit.infra.liquidScreenTopPadding
@@ -78,7 +85,9 @@ import com.niki914.zafiro.app.ui.model.HomeToolStatus
 import com.niki914.zafiro.app.ui.model.ToolPresentation
 import com.niki914.zafiro.app.ui.nav.TextTitle
 import com.niki914.zafiro.app.ui.nav.TopBarActionSpec
+import com.niki914.zafiro.chat.agentic.shell.ToolPermissionCoordinator
 import com.niki914.zafiro.repo.UpdateCheckHolder
+import com.niki914.store.XIpcBridge
 import com.niki914.uikit.base.BaseTheme
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
@@ -308,6 +317,90 @@ fun HomePageContent(
         },
         onNegativeClick = { UpdateCheckHolder.dismiss() },
         dismissOnBackgroundTap = false,
+    )
+
+    ToolPermissionDialog()
+}
+
+/**
+ * CONFIRM 型执行规则的用户确认对话框（永不超时，PRD §3）。
+ * 后台时改为发一条纯通知（无决策入口），点通知回主 App 决策。
+ */
+@Composable
+private fun ToolPermissionDialog() {
+    val context = LocalContext.current
+    val pending by ToolPermissionCoordinator.pendingConfirmation.collectAsState()
+
+    // 纯通知：仅告知有请求在等待，决策必须在应用内完成
+    LaunchedEffect(pending?.id) {
+        val request = pending ?: return@LaunchedEffect
+        if (MainActivity.isResumed) return@LaunchedEffect
+        val command = request.command.let { if (it.length > 80) it.take(80) + "…" else it }
+        XIpcBridge.postNotification(
+            context = context,
+            title = context.getString(R.string.tool_permission_notification_title),
+            content = context.getString(R.string.tool_permission_notification_content, command),
+            uri = null,
+            client = null,
+        )
+    }
+
+    val request = pending ?: return
+    LiquidDialog(
+        visible = true,
+        onDismissRequest = { ToolPermissionCoordinator.respond(request.id, allowed = false) },
+        dismissOnBackgroundTap = false,
+        title = {
+            Text(
+                text = stringResource(R.string.tool_permission_dialog_title),
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Text(
+                    text = stringResource(R.string.tool_permission_request_intro, request.toolName),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = request.command,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 10,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(MaterialTheme.shapes.medium)
+                        .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                        .padding(10.dp),
+                )
+                Text(
+                    text = stringResource(R.string.tool_permission_matched_rule, request.matchedRuleName),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        },
+        actions = {
+            MaterialTintLiquidButton(
+                text = stringResource(R.string.tool_permission_deny),
+                onClick = { ToolPermissionCoordinator.respond(request.id, allowed = false) },
+                modifier = Modifier.weight(1f),
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                contentColor = MaterialTheme.colorScheme.onSurface,
+            )
+            MaterialTintLiquidButton(
+                text = stringResource(R.string.tool_permission_allow),
+                onClick = { ToolPermissionCoordinator.respond(request.id, allowed = true) },
+                modifier = Modifier.weight(1f),
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+            )
+        },
     )
 }
 

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/ToolChain.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/ToolChain.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -94,6 +95,8 @@ private val BlockFlingScrollPropagation: NestedScrollConnection = object : Neste
 /** 命令型工具（精确匹配）：结果体为「命令单行 + 输出」上下分段样式。 */
 private val CommandToolNames = setOf("terminal", "execute_python")
 
+/** 结果文本型工具（精确匹配）：结果体为等宽结果文本（可选中、无复制按钮）。 */
+private val ResultTextToolNames = setOf("load_skill")
 /**
  * Stateless tool call list. Single-tool: renders one [CollapsibleBlock] directly.
  * Multi-tool: renders a header [CollapsibleBlock] (title = count) whose expansion
@@ -185,9 +188,10 @@ private fun SingleToolRow(
                     output = displayOutput(status).trim(),
                     isError = status.state == HomeToolState.Failed,
                 )
+            } else if (status.name in ResultTextToolNames && status.state != HomeToolState.Failed) {
+                ResultTextBody(text = displayOutput(status).trim())
             } else {
                 // 兕底：正文只显示本地化「成功 / 失败」，失败红色。
-                // load_skill 成功要展示文件路径，但路径未随结果链路传到 UI（待定），暂同兕底。
                 FallbackResultBody(isFailed = status.state == HomeToolState.Failed)
             }
         }
@@ -323,6 +327,31 @@ private fun FallbackResultBody(isFailed: Boolean) {
             MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = BlockBodyAlpha)
         },
     )
+}
+
+/**
+ * 结果文本体：面板底色 + 等宽结果文本（如 load_skill 返回的 SKILL.md 内容，
+ * 超限截断时尾部含绝对路径提示）。复用 ToolResultText（已包 SelectionContainer，
+ * 文本可选中）；不带复制按钮。
+ */
+@Composable
+private fun ResultTextBody(text: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                RoundedCornerShape(16.dp),
+            )
+            .padding(horizontal = CommandPanelPadX)
+            .padding(vertical = OutputPadY),
+    ) {
+        ToolResultText(
+            text = text,
+            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
 }
 
 /**

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/HomeChatState.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/HomeChatState.kt
@@ -170,7 +170,11 @@ internal interface HomeChatRuntime {
 
 private object LlmHomeChatRuntime : HomeChatRuntime {
     override fun stream(query: String): Flow<LlmStreamEvent> =
-        LLMController.stream(query, runBlocking { ContextProvider.await() })
+        LLMController.stream(
+            query = query,
+            context = runBlocking { ContextProvider.await() },
+            fromUserInterface = true,
+        )
 
     override suspend fun resetConversation() = LLMController.resetConversation()
     override suspend fun stopCurrentRound() =

--- a/app/src/main/java/com/niki914/zafiro/repo/LocalSettingsDefaults.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/LocalSettingsDefaults.kt
@@ -1,18 +1,19 @@
 package com.niki914.zafiro.repo
 
-import com.niki914.zafiro.mod.LocalSettings
+import android.content.Context
+import com.niki914.zafiro.app.R
 import com.niki914.zafiro.settings.model.RuntimeExecutionRule
 import com.niki914.zafiro.settings.model.RuntimeExecutionRuleEnabledMode
 
 internal object LocalSettingsDefaults {
     const val DEFAULT_SYSTEM_PROMPT = ""
 
-    val defaultMemories = listOf(
-        "Zafiro 的 settings 根目录是 /data/user/0/com.niki914.zafiro/files/settings/。",
-        "Zafiro 自己的包名是 com.niki914.zafiro。GitHub 仓库地址是 https://github.com/niki914/zafiro 。",
-        "如果用户需要备份设置，可以导出 files/settings/ 目录下的 JSON 文件，并在恢复时覆盖对应文件。",
-        "不要随意修改 settings 内容；如果没有明确需要，不要读取或改写这些 JSON 文件。",
-    )
+    // Seed memories live in res/raw/seed_memories.txt，一行一条（与 seed_py_*.py 同一模式）。
+    fun defaultMemories(context: Context): List<String> {
+        val text = context.resources.openRawResource(R.raw.seed_memories)
+            .bufferedReader().use { it.readText() }
+        return text.lines().map(String::trim).filter(String::isNotEmpty)
+    }
 
     val defaultExecutionRules = listOf(
         RuntimeExecutionRule(
@@ -41,17 +42,4 @@ internal object LocalSettingsDefaults {
             patterns = listOf("\\bsu\\b", "\\bsetprop\\b", "\\bdd\\b", "\\breboot\\b"),
         ),
     )
-
-    fun applyTo(settings: LocalSettings): LocalSettings {
-        return LocalSettingsCodec.withExecutionRules(
-            settings = LocalSettingsCodec.withMemories(
-                settings = LocalSettingsCodec.withPrompt(
-                    settings = settings,
-                    prompt = DEFAULT_SYSTEM_PROMPT.trimIndent(),
-                ),
-                memories = defaultMemories,
-            ),
-            rules = defaultExecutionRules,
-        )
-    }
 }

--- a/app/src/main/java/com/niki914/zafiro/repo/LocalSettingsDefaults.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/LocalSettingsDefaults.kt
@@ -17,29 +17,26 @@ internal object LocalSettingsDefaults {
 
     val defaultExecutionRules = listOf(
         RuntimeExecutionRule(
-            id = "builtin-dangerous-delete",
-            name = "危险删改",
-            enabledMode = RuntimeExecutionRuleEnabledMode.LOCKED_ONLY,
+            id = "builtin-dangerous",
+            name = "高危操作",
+            enabledMode = RuntimeExecutionRuleEnabledMode.CONFIRM,
             patterns = listOf(
+                // 危险删改
                 "\\brm\\s+-rf\\b",
                 "\\brm\\s+-(?=[^\\s]*r)(?=[^\\s]*f)[^\\s]*\\b",
                 "\\brm\\s+-r\\s+-f\\b",
                 "\\brm\\s+(?=[^\\n]*--recursive\\b)(?=[^\\n]*--force\\b)[^\\n]*",
                 "\\brm\\s+(?=[^\\n]*-(?:[^\\s-]*r[^\\s-]*|-[^-\\s]*recursive)\\b)(?=[^\\n]*-(?:[^\\s-]*f[^\\s-]*|-[^-\\s]*force)\\b)[^\\n]*",
                 "\\bmkfs\\b",
+                // 卸载相关
+                "\\bpm\\s+uninstall\\b",
+                "\\bcmd\\s+package\\s+uninstall\\b",
+                // 高危提权
+                "\\bsu\\b",
+                "\\bsetprop\\b",
+                "\\bdd\\b",
+                "\\breboot\\b",
             ),
-        ),
-        RuntimeExecutionRule(
-            id = "builtin-uninstall",
-            name = "卸载相关",
-            enabledMode = RuntimeExecutionRuleEnabledMode.ALWAYS,
-            patterns = listOf("\\bpm\\s+uninstall\\b", "\\bcmd\\s+package\\s+uninstall\\b"),
-        ),
-        RuntimeExecutionRule(
-            id = "builtin-privileged",
-            name = "高危提权",
-            enabledMode = RuntimeExecutionRuleEnabledMode.ALWAYS,
-            patterns = listOf("\\bsu\\b", "\\bsetprop\\b", "\\bdd\\b", "\\breboot\\b"),
         ),
     )
 }

--- a/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
@@ -175,7 +175,7 @@ object XRepo {
                 context,
                 StoreDescriptorRegistry.AGENT_MAIN_MEMORY_ID,
                 MemorySettingsCodec.encodeMemories(
-                    LocalSettingsDefaults.defaultMemories,
+                    LocalSettingsDefaults.defaultMemories(context),
                     System.currentTimeMillis()
                 ),
             )

--- a/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
@@ -987,7 +987,7 @@ class CustomPyToolApi internal constructor(
         if (normalized.timeoutMs !in 1_000L..CustomPyTool.MAX_CUSTOM_PY_TOOL_TIMEOUT_MS) {
             return ToolValidation("timeout_ms", "Must be between 1000 and 120000.")
         }
-        val decision = safetyPolicy.evaluate(normalized.code)
+        val decision = safetyPolicy.evaluate(normalized.code, toolName = normalized.name)
         if (!decision.allowed) {
             return ToolValidation("code", decision.reason)
         }

--- a/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
@@ -1,6 +1,7 @@
 package com.niki914.zafiro.repo
 
 import android.content.Context
+import com.niki914.zafiro.app.R
 import com.niki914.logging.Logger
 import com.niki914.zafiro.chat.agentic.buildin.BuiltinToolRegistry
 import com.niki914.zafiro.chat.agentic.python.PyRuntime
@@ -187,7 +188,10 @@ object XRepo {
                 context,
                 StoreDescriptorRegistry.TOOLS_PY_ID,
                 ToolSettingsCodec.encodeCustomPyTools(
-                    listOf(DEFAULT_WEB_SEARCH_TOOL, DEFAULT_LAUNCH_WECHAT_TOOL)
+                    listOf(
+                        seedWebSearchTool(context),
+                        seedLaunchWechatTool(context),
+                    )
                 ),
             )
             writeJsonLocked(
@@ -273,81 +277,27 @@ object XRepo {
         }
     }
 
-    // Seed custom py tool: web search via DuckDuckGo HTML endpoint. Code/schema are the
-    // reflection cache written by the same pipeline py_meta_tools write uses.
-    private val CODE_WEB_SEARCH = """
-        import json
-        import urllib.parse
-
-        import requests
-        from bs4 import BeautifulSoup
-
-
-        def main(query: str, max_results: int = 8):
-            '''Search the web with DuckDuckGo (HTML endpoint). Returns a list of {title, url, snippet}.'''
-            resp = requests.post(
-                "https://html.duckduckgo.com/html/",
-                data={"q": query},
-                headers={"User-Agent": "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36"},
-                timeout=15,
-            )
-            resp.raise_for_status()
-            soup = BeautifulSoup(resp.text, "html.parser")
-            results = []
-            for item in soup.select("div.result.results_links")[: max_results]:
-                link = item.select_one("a.result__a")
-                if link is None:
-                    continue
-                title = link.get_text(strip=True)
-                url = _clean_url(link.get("href", ""))
-                snippet_el = item.select_one("td.result__snippet") or item.select_one(".result__snippet")
-                snippet = snippet_el.get_text(strip=True) if snippet_el else ""
-                if title and url:
-                    results.append({"title": title, "url": url, "snippet": snippet})
-            print(json.dumps(results, ensure_ascii=False))
-
-
-        def _clean_url(href: str) -> str:
-            if href.startswith("//duckduckgo.com/l/") or href.startswith("https://duckduckgo.com/l/"):
-                parsed = urllib.parse.urlparse(href if href.startswith("http") else "https:" + href)
-                target = urllib.parse.parse_qs(parsed.query).get("uddg", [""])[0]
-                return urllib.parse.unquote(target)
-            return href
-        """.trimIndent()
-
     private val SCHEMA_WEB_SEARCH =
-        """{"type":"object","properties":{"query":{"type":"string"},"max_results":{"type":"integer","description":"default: 8"}},"required":["query"]}"""
+        """{"type":"object","properties":{"query":{"type":"string"},"engine":{"type":"string","enum":["all","baidu","sogou","ddg"],"description":"search engine; \"all\" (default) merges Baidu + Sogou + DuckDuckGo"},"max_results":{"type":"integer","description":"default: 8"}},"required":["query"]}"""
 
-    private val DEFAULT_WEB_SEARCH_TOOL = CustomPyTool(
+    // Seed custom py tools: code lives in res/raw，此处只负责组装。
+    private fun seedWebSearchTool(context: Context) = CustomPyTool(
         name = "py_web_search",
-        description = "Search the web with DuckDuckGo. Returns a list of {title, url, snippet}.",
+        description = "Search the web (default: multi-engine merge of Baidu + Sogou + DuckDuckGo; or engine=baidu/sogou/ddg). Returns a list of {title, url, snippet}.",
         schemaJson = SCHEMA_WEB_SEARCH,
-        code = CODE_WEB_SEARCH,
+        code = readRawResource(context, R.raw.seed_py_web_search),
     )
 
-    // 复活自旧 CustomTool launch_wechat（am start -n com.tencent.mm/...）
-    private val CODE_LAUNCH_WECHAT = """
-        import subprocess
-
-
-        def main():
-            '''启动微信 (Launch WeChat).'''
-            result = subprocess.run(
-                ["am", "start", "-n", "com.tencent.mm/com.tencent.mm.ui.LauncherUI"],
-                capture_output=True, text=True, timeout=10,
-            )
-            if result.returncode != 0:
-                print(result.stderr.strip())
-                raise SystemExit(1)
-            print("WeChat launched.")
-        """.trimIndent()
-
-    private val DEFAULT_LAUNCH_WECHAT_TOOL = CustomPyTool(
+    private fun seedLaunchWechatTool(context: Context) = CustomPyTool(
         name = "py_launch_wechat",
         description = "启动微信 (Launch WeChat).",
         schemaJson = """{"type":"object","properties":{},"required":[]}""",
-        code = CODE_LAUNCH_WECHAT,
+        code = readRawResource(context, R.raw.seed_py_launch_wechat),
     )
+
+    private fun readRawResource(context: Context, rawId: Int): String {
+        return context.resources.openRawResource(rawId).bufferedReader().use { it.readText() }
+    }
 
     private fun defaultMainAgentProfile(nowMillis: Long): AgentProfile {
         return AgentProfile(

--- a/app/src/main/res/raw/seed_memories.txt
+++ b/app/src/main/res/raw/seed_memories.txt
@@ -1,0 +1,3 @@
+Zafiro's settings root is /data/user/0/com.niki914.zafiro/files/settings/.
+Zafiro's package name is com.niki914.zafiro; GitHub repo: https://github.com/niki914/zafiro.
+Custom Python tools are programmable and self-repairable: a broken tool (e.g. a web-search parser after an engine redesign) can be diagnosed with py_meta_tools read, fixed via test, and replaced via write; tools may call external HTTP APIs with requests.

--- a/app/src/main/res/raw/seed_py_launch_wechat.py
+++ b/app/src/main/res/raw/seed_py_launch_wechat.py
@@ -1,0 +1,13 @@
+import subprocess
+
+
+def main():
+    '''启动微信 (Launch WeChat).'''
+    result = subprocess.run(
+        ["am", "start", "-n", "com.tencent.mm/com.tencent.mm.ui.LauncherUI"],
+        capture_output=True, text=True, timeout=10,
+    )
+    if result.returncode != 0:
+        print(result.stderr.strip())
+        raise SystemExit(1)
+    print("WeChat launched.")

--- a/app/src/main/res/raw/seed_py_web_search.py
+++ b/app/src/main/res/raw/seed_py_web_search.py
@@ -1,0 +1,140 @@
+# Seed tool: multi-engine web search (all / baidu / sogou / ddg).
+# ponytail: baidu/sogou 返回跳转链接不展开；解析选择器随站点改版会失效，Agent 可自更新本脚本。
+import json
+import urllib.parse
+from concurrent.futures import ThreadPoolExecutor
+
+import requests
+from bs4 import BeautifulSoup
+
+_UA_ANDROID = "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36"
+_UA_DESKTOP = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+
+
+def main(query: str, engine: str = "all", max_results: int = 8):
+    '''Search the web. engine: "all" (default, merges Baidu + Sogou + DuckDuckGo), "baidu", "sogou" or "ddg". Returns a list of {title, url, snippet}.'''
+    engines = ("baidu", "sogou", "ddg") if engine == "all" else (engine,)
+    with ThreadPoolExecutor(max_workers=len(engines)) as pool:
+        futures = [pool.submit(_search, e, query, max_results) for e in engines]
+        # ddg 在无代理网络会超时，给短 timeout 快速失败，不拖慢整体
+        fetched = []
+        for e, fut in zip(engines, futures):
+            try:
+                fetched.append(fut.result(timeout=20))
+            except Exception:
+                fetched.append([])
+    print(json.dumps(_merge(fetched, max_results), ensure_ascii=False))
+
+
+def _search(engine: str, query: str, max_results: int):
+    if engine == "baidu":
+        # baidu 桌面 UA 会触发验证码，必须移动 UA
+        resp = requests.get(
+            "https://www.baidu.com/s",
+            params={"wd": query},
+            headers={"User-Agent": _UA_ANDROID},
+            timeout=15,
+        )
+        parser = _parse_baidu
+    elif engine == "sogou":
+        resp = requests.get(
+            "https://www.sogou.com/web",
+            params={"query": query},
+            headers={"User-Agent": _UA_DESKTOP},
+            timeout=15,
+        )
+        parser = _parse_sogou
+    else:
+        resp = requests.post(
+            "https://html.duckduckgo.com/html/",
+            data={"q": query},
+            headers={"User-Agent": _UA_ANDROID},
+            timeout=8,
+        )
+        parser = _parse_ddg
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+    return parser(soup, max_results)
+
+
+def _merge(lists, max_results):
+    seen = set()
+    merged = []
+    for group in lists:
+        for item in group:
+            url = item.get("url", "")
+            if url in seen:
+                continue
+            seen.add(url)
+            merged.append(item)
+            if len(merged) >= max_results:
+                return merged
+    return merged
+
+
+def _parse_ddg(soup, max_results):
+    results = []
+    for item in soup.select("div.result.results_links")[: max_results]:
+        link = item.select_one("a.result__a")
+        if link is None:
+            continue
+        snippet_el = item.select_one("td.result__snippet") or item.select_one(".result__snippet")
+        _append(results, link.get_text(strip=True), _clean_ddg_url(link.get("href", "")), snippet_el)
+        if len(results) >= max_results:
+            break
+    return results
+
+
+def _parse_baidu(soup, max_results):
+    results = []
+    for item in soup.select("div.c-result"):
+        if len(results) >= max_results:
+            break
+        title_el = item.select_one("h3")
+        if title_el is None:
+            continue
+        try:
+            url = json.loads(item.get("data-log", "{}")).get("mu", "")
+        except ValueError:
+            url = ""
+        snippet_el = None
+        for sel in ("[class*=content-right]", "[class*=abstract]", "[class*=clamp]", "[class*=desc]"):
+            candidate = item.select_one(sel)
+            if candidate is not None:
+                snippet_el = candidate
+                break
+        _append(results, title_el.get_text(strip=True), url, snippet_el)
+    return results
+
+
+def _parse_sogou(soup, max_results):
+    results = []
+    for item in soup.select("div.vrwrap, div.rb"):
+        if len(results) >= max_results:
+            break
+        link = item.select_one("h3 a")
+        if link is None:
+            continue
+        snippet_el = item.select_one(".str-text-info") or item.select_one(".str_info") or item.select_one(".space-txt")
+        _append(results, link.get_text(strip=True), _clean_sogou_url(link.get("href", "")), snippet_el)
+    return results
+
+
+def _append(results, title, url, snippet_el):
+    snippet = snippet_el.get_text(strip=True) if snippet_el else ""
+    if title and url:
+        results.append({"title": title, "url": url, "snippet": snippet})
+
+
+def _clean_ddg_url(href: str) -> str:
+    if href.startswith("//duckduckgo.com/l/") or href.startswith("https://duckduckgo.com/l/"):
+        parsed = urllib.parse.urlparse(href if href.startswith("http") else "https:" + href)
+        target = urllib.parse.parse_qs(parsed.query).get("uddg", [""])[0]
+        return urllib.parse.unquote(target)
+    return href
+
+
+def _clean_sogou_url(href: str) -> str:
+    if href.startswith("/link"):
+        return "https://www.sogou.com" + href
+    return href

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -188,6 +188,14 @@
     <string name="execution_rules_enabled_mode_enabled">任何時候</string>
     <string name="execution_rules_enabled_mode_locked_only">鎖定畫面時</string>
     <string name="execution_rules_enabled_mode_disabled">停用</string>
+    <string name="execution_rules_enabled_mode_confirm">詢問我</string>
+    <string name="tool_permission_dialog_title">AI 請求執行操作</string>
+    <string name="tool_permission_request_intro">工具「%1$s」請求執行以下命令：</string>
+    <string name="tool_permission_matched_rule">命中規則「%1$s」</string>
+    <string name="tool_permission_allow">允許本次</string>
+    <string name="tool_permission_deny">拒絕</string>
+    <string name="tool_permission_notification_title">Zafiro 正在等待你的確認</string>
+    <string name="tool_permission_notification_content">AI 請求執行被攔截的命令：%1$s。開啟應用程式以允許或拒絕。</string>
     <string name="execution_rules_field_patterns">比對規則</string>
     <string name="execution_rules_field_patterns_hint">例如：\brm\s+-rf\b</string>
     <string name="execution_rules_field_patterns_description">每行輸入一個關鍵字或正則表達式，只要符合其中一項，便會攔截該指令。</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -189,6 +189,14 @@
     <string name="execution_rules_enabled_mode_enabled">Always</string>
     <string name="execution_rules_enabled_mode_locked_only">When screen is locked</string>
     <string name="execution_rules_enabled_mode_disabled">Disabled</string>
+    <string name="execution_rules_enabled_mode_confirm">Ask me</string>
+    <string name="tool_permission_dialog_title">AI requests to run an operation</string>
+    <string name="tool_permission_request_intro">Tool "%1$s" wants to run the following command:</string>
+    <string name="tool_permission_matched_rule">Matched rule "%1$s"</string>
+    <string name="tool_permission_allow">Allow once</string>
+    <string name="tool_permission_deny">Deny</string>
+    <string name="tool_permission_notification_title">Zafiro is waiting for your confirmation</string>
+    <string name="tool_permission_notification_content">AI wants to run a blocked command: %1$s. Open the app to allow or deny.</string>
     <string name="execution_rules_field_patterns">Patterns</string>
     <string name="execution_rules_field_patterns_hint">For example: \brm\s+-rf\b</string>
     <string name="execution_rules_field_patterns_description">Enter one keyword or regular expression per line. The command is blocked as soon as any rule matches.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -189,6 +189,14 @@
     <string name="execution_rules_enabled_mode_enabled">Siempre</string>
     <string name="execution_rules_enabled_mode_locked_only">Solo con pantalla bloqueada</string>
     <string name="execution_rules_enabled_mode_disabled">Desactivado</string>
+    <string name="execution_rules_enabled_mode_confirm">Preguntarme</string>
+    <string name="tool_permission_dialog_title">La IA solicita ejecutar una operación</string>
+    <string name="tool_permission_request_intro">La herramienta "%1$s" solicita ejecutar el siguiente comando:</string>
+    <string name="tool_permission_matched_rule">Regla alcanzada: "%1$s"</string>
+    <string name="tool_permission_allow">Permitir una vez</string>
+    <string name="tool_permission_deny">Denegar</string>
+    <string name="tool_permission_notification_title">Zafiro espera tu confirmación</string>
+    <string name="tool_permission_notification_content">La IA solicita ejecutar un comando bloqueado: %1$s. Abre la aplicación para permitirlo o denegarlo.</string>
     <string name="execution_rules_field_patterns">Reglas</string>
     <string name="execution_rules_field_patterns_hint">Ejemplo: \brm\s+-rf\b</string>
     <string name="execution_rules_field_patterns_description">Introduzca una palabra clave o expresión regular por línea. El comando se interceptará si coincide con cualquiera de ellas.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -188,6 +188,14 @@
     <string name="execution_rules_enabled_mode_enabled">常時</string>
     <string name="execution_rules_enabled_mode_locked_only">画面ロック時のみ</string>
     <string name="execution_rules_enabled_mode_disabled">無効</string>
+    <string name="execution_rules_enabled_mode_confirm">確認を求める</string>
+    <string name="tool_permission_dialog_title">AI が操作の実行を要求しています</string>
+    <string name="tool_permission_request_intro">ツール「%1$s」が次のコマンドの実行を要求しています：</string>
+    <string name="tool_permission_matched_rule">一致したルール「%1$s」</string>
+    <string name="tool_permission_allow">今回のみ許可</string>
+    <string name="tool_permission_deny">拒否</string>
+    <string name="tool_permission_notification_title">Zafiro が確認を待っています</string>
+    <string name="tool_permission_notification_content">AI がブロックされたコマンドの実行を要求しています：%1$s。アプリを開いて許可または拒否してください。</string>
     <string name="execution_rules_field_patterns">ルール</string>
     <string name="execution_rules_field_patterns_hint">例：\brm\s+-rf\b</string>
     <string name="execution_rules_field_patterns_description">1行につき1つのキーワードまたは正規表現を入力します。いずれかにマッチした場合、そのコマンドをブロックします。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -188,6 +188,14 @@
     <string name="execution_rules_enabled_mode_enabled">总是</string>
     <string name="execution_rules_enabled_mode_locked_only">锁屏时</string>
     <string name="execution_rules_enabled_mode_disabled">不生效</string>
+    <string name="execution_rules_enabled_mode_confirm">询问我</string>
+    <string name="tool_permission_dialog_title">AI 请求执行操作</string>
+    <string name="tool_permission_request_intro">工具「%1$s」请求执行以下命令：</string>
+    <string name="tool_permission_matched_rule">命中规则「%1$s」</string>
+    <string name="tool_permission_allow">允许本次</string>
+    <string name="tool_permission_deny">拒绝</string>
+    <string name="tool_permission_notification_title">Zafiro 正在等待你的确认</string>
+    <string name="tool_permission_notification_content">AI 请求执行被拦截的命令：%1$s。打开应用以允许或拒绝。</string>
     <string name="execution_rules_field_patterns">规则</string>
     <string name="execution_rules_field_patterns_hint">例如：\brm\s+-rf\b</string>
     <string name="execution_rules_field_patterns_description">每行输入一个关键字或正则表达式，命中任意一条时，拦截该命令。</string>

--- a/app/src/test/java/com/niki914/zafiro/repo/XRepoTest.kt
+++ b/app/src/test/java/com/niki914/zafiro/repo/XRepoTest.kt
@@ -58,7 +58,7 @@ class XRepoTest {
             LlmConfigsSettingsCodec.parse(store.jsonFor(StoreDescriptorRegistry.LLM_CONFIGS_ID)),
         )
         assertEquals(
-            LocalSettingsDefaults.defaultMemories,
+            LocalSettingsDefaults.defaultMemories(context),
             MemorySettingsCodec.parseMemories(store.jsonFor(StoreDescriptorRegistry.AGENT_MAIN_MEMORY_ID)),
         )
         assertEquals(

--- a/app/src/test/java/com/niki914/zafiro/repo/XRepoTest.kt
+++ b/app/src/test/java/com/niki914/zafiro/repo/XRepoTest.kt
@@ -1,7 +1,8 @@
 package com.niki914.zafiro.repo
 
+import android.app.Application
 import android.content.Context
-import android.content.ContextWrapper
+import androidx.test.core.app.ApplicationProvider
 import com.niki914.zafiro.app.util.SilentLoggerRule
 import com.niki914.store.StoreDescriptorRegistry
 import kotlinx.coroutines.test.runTest
@@ -13,19 +14,22 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import com.niki914.zafiro.settings.MemoryMutationResult
 import com.niki914.zafiro.settings.model.RuntimeCustomPyTool as CustomPyTool
 import com.niki914.zafiro.settings.model.RuntimeExecutionRule as ExecutionRule
 import com.niki914.zafiro.settings.model.RuntimeExecutionRuleEnabledMode as ExecutionRuleEnabledMode
 import com.niki914.zafiro.settings.model.RuntimeMcpServer as McpServer
 
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
 class XRepoTest {
     @get:Rule
     val silentLoggerRule = SilentLoggerRule()
 
-    private val context: Context = object : ContextWrapper(null) {
-        override fun getApplicationContext(): Context = this
-    }
+    private val context: Context = ApplicationProvider.getApplicationContext()
 
     @After
     fun tearDown() {


### PR DESCRIPTION
## 概述

分支 `wip/tool-memory-permission`，五个功能提交，覆盖工具上下文 / 记忆内容 / 默认工具 / 权限管理四条线。

## 变更

### 1. 多引擎 Web Search（b543858e）
- `py_web_search` 支持 `engine` 枚举参数：`ddg`（默认）/ `baidu` / `sogou`
- 单工具 + 枚举，输出统一 `{title, url, snippet}`；线程安全 stdout 读取

### 2. 默认记忆种子文件（c3f5c86f）
- 默认记忆移到 res/raw seed 文件（英文），含自修复条目
- 告知 Agent `py_web_search` 脚本会随搜索引擎改版失效，可用写工具自更新

### 3. CONFIRM 执行规则模式（b5a1a229）
- 执行规则命中支持「确认」行为：挂起等待用户对话框允许/拒绝（allow once / deny）
- 主 App 内权限确认对话框

### 4. 执行规则 App 级教学（9019361a）
- 提示模型执行规则是 App 级、用户可配置的

### 5. 工具输出截断统一（5e2deb93）
- 新增共享 `ToolOutputTruncator`（对齐 pi：2000 行 / 50KB 双限制、UTF-8 安全、head 永不切行）
- load_skill：head 截断，超限时尾部附 SKILL.md 绝对路径提示
- execute_python：head→tail，修 UTF-8 截断缺陷 + 补行数限制 + 截断提示
- terminal：补缺失的截断提示（原静默截断）
- UI：load_skill 结果展开显示等宽文本（可选中，无复制按钮）

## 验证

- `:agent-runtime` 全量单元测试通过（48 tests）
- `:app` 编译通过