### PR TITLE
Batch: title bar padding, collapse state, cold-start focus, py_install_apk tool, prerelease update check

### DIFF
--- a/app/src/main/java/com/niki914/zafiro/app/App.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/App.kt
@@ -51,6 +51,9 @@ class App : Application() {
             XRepo.skills.seedDefaults()
         }
         applicationScope.launch {
+            XRepo.seedPyTools()
+        }
+        applicationScope.launch {
             PyRuntime.warmUp()
         }
     }

--- a/app/src/main/java/com/niki914/zafiro/app/ui/ZafiroApp.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/ZafiroApp.kt
@@ -245,6 +245,9 @@ fun ZafiroApp(
         ) {
             LiquidScreen(
                 state = screenState,
+                // 折叠状态拉取自当前导航条目：页面经 ReportTitleBarCollapsed 写入，
+                // 条目存活期保留，导航切页同帧生效，返回时首帧恢复离开前状态。
+                collapsed = currentEntry.titleCollapsed,
                 actionsEnabled = !isPageTransitioning,
                 leftButton = currentLeftAction?.let { action ->
                     {

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
@@ -70,7 +70,7 @@ import com.niki914.uikit.infra.ConfirmationLiquidDialog
 import com.niki914.uikit.infra.LiquidDialog
 import com.niki914.uikit.infra.component.MaterialTintLiquidButton
 import com.niki914.uikit.infra.LocalLiquidViewportAvoidanceController
-import com.niki914.uikit.infra.LocalTitleBarCollapseState
+import com.niki914.uikit.infra.ReportTitleBarCollapsed
 import com.niki914.uikit.infra.ProvideLiquidScreenContentForPreview
 import com.niki914.uikit.infra.liquidScreenTopPadding
 import com.niki914.uikit.infra.nav.pageViewModel
@@ -130,16 +130,10 @@ fun HomePageContent(
     val keyboardController = LocalSoftwareKeyboardController.current
     val listState = rememberLazyListState()
 
-    // Home Chat 是可 saveable 恢复滚动位置的 Pinned 页：自报滚动状态给顶栏，
-    // 使返回时（scroll 恢复但不产生滚动事件）背景板能立即回到实色。
-    val titleBarCollapseState = LocalTitleBarCollapseState.current
-    LaunchedEffect(titleBarCollapseState, listState) {
-        snapshotFlow {
-            listState.firstVisibleItemIndex > 0 || listState.firstVisibleItemScrollOffset > 0
-        }.collect { scrolled ->
-            titleBarCollapseState.hasReporter = true
-            titleBarCollapseState.isCollapsed = scrolled
-        }
+    // Home Chat 是可 saveable 恢复滚动位置的 Pinned 页：折叠状态写入当前条目，
+    // 返回时（scroll 恢复但不产生滚动事件）背景板由条目保留的状态立即动画恢复。
+    ReportTitleBarCollapsed {
+        listState.firstVisibleItemIndex > 0 || listState.firstVisibleItemScrollOffset > 0
     }
     val imeBottom = with(density) { WindowInsets.ime.getBottom(this).toDp() }
     val navigationBottom = with(density) { WindowInsets.navigationBars.getBottom(this).toDp() }

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
@@ -238,8 +238,9 @@ fun HomePageContent(
     RegisterPageChrome(pageChromeContribution)
 
     // 冷启动键盘焦点：仅进程内首次进入 Home、无草稿输入且不在加载中时抢焦点。
-    // 标志在成功/耗尽后才置位：若 effect 在重试期间被组合销毁取消，
-    // 下次进入 Home 会重新尝试（否则会像日志里那样 begin 后无 attempt 直接丢失）。
+    // 标志在首次 effect 执行后即置位：无论聚焦成功、attempts 耗尽还是条件不满足
+    // （有草稿/正在生成），都不再重试 —— 否则回答完成时 isGenerating 翻转会重启
+    // 本 effect，导致"回答完成后自动弹键盘"（冷启动时未成功聚焦过的场景）。
     if (!composerAutoFocusDone && !uiState.isLoadingConversation) {
         LaunchedEffect(uiState.input.isBlank(), uiState.isGenerating) {
             if (uiState.input.isBlank() && !uiState.isGenerating) {
@@ -252,8 +253,8 @@ fun HomePageContent(
                         return@LaunchedEffect
                     }
                 }
-                composerAutoFocusDone = true
             }
+            composerAutoFocusDone = true
         }
     }
 

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/SavedConfigDesignPreview.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/SavedConfigDesignPreview.kt
@@ -353,7 +353,7 @@ private fun SingleChoiceDialogPreview() {
             showBlurLayer = false,
         )
         var selectedProtocol by remember { mutableStateOf("openai-responses") }
-        LiquidScreen(state = screenState) {
+        LiquidScreen(state = screenState, collapsed = false) {
             Box(
                 modifier = Modifier
                     .fillMaxSize()

--- a/app/src/main/java/com/niki914/zafiro/repo/UpdateCheckApi.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/UpdateCheckApi.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.jsonPrimitive
@@ -48,6 +49,8 @@ private object UpdateCheckApi {
 
     private const val GITHUB_API_LATEST =
         "https://api.github.com/repos/niki914/zafiro/releases/latest"
+    private const val GITHUB_API_LATEST_ANY =
+        "https://api.github.com/repos/niki914/zafiro/releases?per_page=1"
 
     private val semverRe = Regex("""(\d+\.\d+\.\d+)""")
 
@@ -58,16 +61,33 @@ private object UpdateCheckApi {
     }
 
     private fun resolveUpdateOrNull(currentVersion: String): UpdateCheckResult {
-        val body = fetchLatestRelease() ?: return noUpdate()
-        val obj = json.parseToJsonElement(body) as? JsonObject ?: return noUpdate()
+        // 先看最新 stable release；无更新时兜底看最新 release（含 prerelease，
+        // preview 分发线靠它才能被检测到）
+        return checkRelease(fetchLatestRelease(), currentVersion, includePrerelease = false)
+            ?: checkRelease(fetchLatestReleaseAny(), currentVersion, includePrerelease = true)
+            ?: noUpdate()
+    }
 
-        if (obj["draft"]?.jsonPrimitive?.booleanOrNull == true) return noUpdate()
-        if (obj["prerelease"]?.jsonPrimitive?.booleanOrNull == true) return noUpdate()
+    private fun checkRelease(
+        body: String?,
+        currentVersion: String,
+        includePrerelease: Boolean,
+    ): UpdateCheckResult? {
+        if (body == null) return null
+        val element = json.parseToJsonElement(body)
+        val obj = when (element) {
+            is JsonObject -> element
+            is JsonArray -> element.firstOrNull() as? JsonObject
+            else -> null
+        } ?: return null
 
-        val tagName = obj["tag_name"]?.jsonPrimitive?.content ?: return noUpdate()
-        val remoteVersion = semverRe.find(tagName)?.groupValues?.get(1) ?: return noUpdate()
+        if (obj["draft"]?.jsonPrimitive?.booleanOrNull == true) return null
+        if (!includePrerelease && obj["prerelease"]?.jsonPrimitive?.booleanOrNull == true) return null
 
-        if (!isNewer(remoteVersion, currentVersion)) return noUpdate()
+        val tagName = obj["tag_name"]?.jsonPrimitive?.content ?: return null
+        val remoteVersion = semverRe.find(tagName)?.groupValues?.get(1) ?: return null
+
+        if (!isNewer(remoteVersion, currentVersion)) return null
 
         val releaseUrl = obj["html_url"]?.jsonPrimitive?.content.orEmpty()
         return UpdateCheckResult(
@@ -77,8 +97,12 @@ private object UpdateCheckApi {
         )
     }
 
-    private fun fetchLatestRelease(): String? {
-        val request = Request.Builder().url(GITHUB_API_LATEST).build()
+    private fun fetchLatestRelease(): String? = fetch(GITHUB_API_LATEST)
+
+    private fun fetchLatestReleaseAny(): String? = fetch(GITHUB_API_LATEST_ANY)
+
+    private fun fetch(url: String): String? {
+        val request = Request.Builder().url(url).build()
         return xTry {
             client.newCall(request).execute().use { response ->
                 if (response.isSuccessful && response.body != null) {

--- a/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
@@ -187,12 +187,7 @@ object XRepo {
             writeJsonLocked(
                 context,
                 StoreDescriptorRegistry.TOOLS_PY_ID,
-                ToolSettingsCodec.encodeCustomPyTools(
-                    listOf(
-                        seedWebSearchTool(context),
-                        seedLaunchWechatTool(context),
-                    )
-                ),
+                ToolSettingsCodec.encodeCustomPyTools(seedPyToolDefaults(context)),
             )
             writeJsonLocked(
                 context,
@@ -208,6 +203,26 @@ object XRepo {
                 "elapsedMs=${System.currentTimeMillis() - startedAtMs}"
         )
         return result
+    }
+
+    /**
+     * 启动时补齐缺失的 seed py tools（按 name 判缺）。
+     *
+     * 只追加用户列表里没有的工具，不覆盖用户对同名工具的修改；
+     * 用户已删除的 seed 会被复活（tools 无删除墓碑，无法区分"未装过"与"删过"）。
+     */
+    suspend fun seedPyTools() {
+        val context = context()
+        updateJsonOrFalse(StoreDescriptorRegistry.TOOLS_PY_ID) { json ->
+            val existing = ToolSettingsCodec.parseCustomPyTools(json)
+            val existingNames = existing.map { it.name }.toSet()
+            val missing = seedPyToolDefaults(context).filter { it.name !in existingNames }
+            if (missing.isEmpty()) {
+                null
+            } else {
+                ToolSettingsCodec.encodeCustomPyTools(existing + missing)
+            }
+        }
     }
 
     suspend fun onboardingCompleted(): Boolean {
@@ -303,6 +318,15 @@ object XRepo {
     private val SCHEMA_WEB_SEARCH =
         """{"type":"object","properties":{"query":{"type":"string"},"engine":{"type":"string","enum":["all","baidu","sogou","ddg"],"description":"search engine; \"all\" (default) merges Baidu + Sogou + DuckDuckGo"},"max_results":{"type":"integer","description":"default: 8"}},"required":["query"]}"""
 
+    // Seed custom py tools 全量列表：新增 seed 时在此追加，
+    // seedPyTools() 每次启动补齐缺失，老用户升级后自动获得新工具。
+    internal fun seedPyToolDefaults(context: Context): List<CustomPyTool> =
+        listOf(
+            seedWebSearchTool(context),
+            seedLaunchWechatTool(context),
+            seedInstallApkTool(context),
+        )
+
     // Seed custom py tools: code lives in res/raw，此处只负责组装。
     private fun seedWebSearchTool(context: Context) = CustomPyTool(
         name = "py_web_search",
@@ -316,6 +340,18 @@ object XRepo {
         description = "启动微信 (Launch WeChat).",
         schemaJson = """{"type":"object","properties":{},"required":[]}""",
         code = readRawResource(context, R.raw.seed_py_launch_wechat),
+    )
+
+    private val SCHEMA_INSTALL_APK =
+        """{"type":"object","properties":{"url":{"type":"string","description":"APK 直链 URL"},"force":{"type":"boolean","description":"覆盖安装；默认已安装则跳过"}},"required":["url"]}"""
+
+    // 下载+安装大 APK 可能超过默认 30s，直接设到上限 120s。
+    private fun seedInstallApkTool(context: Context) = CustomPyTool(
+        name = "py_install_apk",
+        description = "Download an APK from a URL and install it via su. Non-force by default: skips if the app is already installed; set force=true to overwrite.",
+        schemaJson = SCHEMA_INSTALL_APK,
+        code = readRawResource(context, R.raw.seed_py_install_apk),
+        timeoutMs = CustomPyTool.MAX_CUSTOM_PY_TOOL_TIMEOUT_MS,
     )
 
     private fun readRawResource(context: Context, rawId: Int): String {

--- a/app/src/main/res/raw/seed_py_install_apk.py
+++ b/app/src/main/res/raw/seed_py_install_apk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""直装工具：给定 APK 直链 URL，用 su 下载并安装到本机 Android。
+
+默认非强制：目标应用已安装时跳过安装。不额外写包名判断 —— 依赖
+`pm install` 不带 -r 的既有语义：包已存在时报 INSTALL_FAILED_ALREADY_EXISTS，
+此时视为"已安装，跳过"。--force 时加 -r 覆盖安装。
+
+用法（Termux 或任意可调 su 的环境）：
+    python3 install_apk.py https://example.com/app.apk
+    python3 install_apk.py --force https://example.com/app.apk
+
+退出码：0 已安装；1 安装失败；2 su 不可用/未授权；3 已安装，跳过。
+
+也可注册为 Zafiro python tool：main(url, force=False)。
+"""
+import argparse
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.request
+
+INSTALL_TIMEOUT = 300
+UA = "Mozilla/5.0 (Linux; Android 14)"
+
+
+def su_run(args, timeout=INSTALL_TIMEOUT):
+    """在 root 下执行命令；找不到 su 时抛 FileNotFoundError。"""
+    cmd = ["su", "-c", " ".join(shlex.quote(a) for a in args)]
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
+
+def download(url, dest):
+    print(f"[1/2] downloading {url}")
+    req = urllib.request.Request(url, headers={"User-Agent": UA})
+    with urllib.request.urlopen(req, timeout=120) as resp, open(dest, "wb") as f:
+        shutil.copyfileobj(resp, f)
+    print(f"      saved {dest} ({os.path.getsize(dest)} bytes)")
+
+
+def install(apk_path, force):
+    cmd = ["pm", "install"]
+    if force:
+        cmd.append("-r")
+    cmd.append(apk_path)
+    return su_run(cmd)
+
+
+def main(url, force=False):
+    try:
+        probe = su_run(["id"], timeout=10)
+    except FileNotFoundError:
+        print("未找到 su：需要 root（Magisk / KernelSU 授权后重试）", file=sys.stderr)
+        sys.exit(2)
+    if probe.returncode != 0:
+        print("su 未授权或不可用", file=sys.stderr)
+        sys.exit(2)
+
+    fd, apk_path = tempfile.mkstemp(suffix=".apk")
+    os.close(fd)
+    try:
+        download(url, apk_path)
+        print(f"[2/2] installing via su ({'force' if force else 'non-force'})")
+        r = install(apk_path, force)
+        out = (r.stdout + r.stderr).strip()
+        if r.returncode != 0:
+            if "INSTALL_FAILED_ALREADY_EXISTS" in out:
+                print("已安装，跳过（加 --force 可覆盖安装）")
+                sys.exit(3)
+            print(f"install failed: {out or 'unknown error'}", file=sys.stderr)
+            sys.exit(1)
+        print("installed")
+    finally:
+        try:
+            os.unlink(apk_path)
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("url", help="APK 直链 URL")
+    ap.add_argument("--force", action="store_true", help="覆盖安装（默认已安装则跳过）")
+    args = ap.parse_args()
+    main(args.url, force=args.force)

--- a/app/src/test/java/com/niki914/zafiro/repo/XRepoTest.kt
+++ b/app/src/test/java/com/niki914/zafiro/repo/XRepoTest.kt
@@ -15,6 +15,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.json.JSONObject
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import com.niki914.zafiro.settings.MemoryMutationResult
@@ -62,7 +63,7 @@ class XRepoTest {
             MemorySettingsCodec.parseMemories(store.jsonFor(StoreDescriptorRegistry.AGENT_MAIN_MEMORY_ID)),
         )
         assertEquals(
-            listOf("py_web_search", "py_launch_wechat"),
+            XRepo.seedPyToolDefaults(context).map { it.name },
             ToolSettingsCodec.parseCustomPyTools(store.jsonFor(StoreDescriptorRegistry.TOOLS_PY_ID))
                 .map { it.name },
         )
@@ -86,6 +87,69 @@ class XRepoTest {
 
         assertFalse(updated)
         assertEquals(0, store.writeCount)
+    }
+
+    @Test
+    fun seedPyTools_addsMissingSeedToolsAndIsIdempotent() = runTest {
+        val store = installStore(FakeDomainSettingsStore())
+
+        XRepo.seedPyTools()
+        assertEquals(
+            XRepo.seedPyToolDefaults(context).map { it.name },
+            ToolSettingsCodec.parseCustomPyTools(store.jsonFor(StoreDescriptorRegistry.TOOLS_PY_ID))
+                .map { it.name },
+        )
+
+        // 幂等：已补齐后不再写
+        val writesAfterFirst = store.writeCount
+        XRepo.seedPyTools()
+        assertEquals(writesAfterFirst, store.writeCount)
+    }
+
+    @Test
+    fun seedPyTools_keepsUserToolsAndDoesNotOverwriteUserEdits() = runTest {
+        val seedNames = XRepo.seedPyToolDefaults(context).map { it.name }
+        val userEditedSeed = seedNames.first()
+        val store = installStore(
+            FakeDomainSettingsStore(
+                StoreDescriptorRegistry.TOOLS_PY_ID to ToolSettingsCodec.encodeCustomPyTools(
+                    listOf(
+                        CustomPyTool(name = userEditedSeed, code = "user-modified"),
+                        CustomPyTool(name = "py_custom_user", code = "print(1)"),
+                    )
+                ),
+            )
+        )
+
+        XRepo.seedPyTools()
+
+        val tools = ToolSettingsCodec.parseCustomPyTools(store.jsonFor(StoreDescriptorRegistry.TOOLS_PY_ID))
+        // 用户改过的同名 seed 不被覆盖
+        assertEquals("user-modified", tools.first { it.name == userEditedSeed }.code)
+        // 用户自定义工具保留，缺失 seed 全部补上
+        assertEquals(seedNames.toSet() + setOf("py_custom_user"), tools.map { it.name }.toSet())
+    }
+
+    @Test
+    fun allSeedTools_areValid() = runTest {
+        val seeds = XRepo.seedPyToolDefaults(context)
+        val namePattern = Regex("^py_[a-z][a-z0-9_]{0,63}$")
+        assertTrue(seeds.isNotEmpty())
+        for (seed in seeds) {
+            assertTrue("bad name: ${seed.name}", namePattern.matches(seed.name))
+            assertTrue("empty code: ${seed.name}", seed.code.isNotBlank())
+            assertTrue("missing main entry: ${seed.name}", "def main(" in seed.code)
+            assertTrue(
+                "invalid schema: ${seed.name}",
+                runCatching { JSONObject(seed.schemaJson) }.isSuccess,
+            )
+            assertTrue(
+                "timeout out of range: ${seed.name}",
+                seed.timeoutMs in 1_000L..CustomPyTool.MAX_CUSTOM_PY_TOOL_TIMEOUT_MS,
+            )
+        }
+        // 名字唯一
+        assertEquals(seeds.size, seeds.map { it.name }.toSet().size)
     }
 
     @Test

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreen.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreen.kt
@@ -73,6 +73,9 @@ fun LiquidScreen(
     val isDarkTheme = LocalAppDarkTheme.current
     val density = LocalDensity.current
     val chromeBackdrop = rememberLayerBackdrop()
+    // 标题两侧预留 = ActionBarButton 占宽（12dp 内边距 ×2 + 48sp 按钮）。
+    // 随系统字体缩放同步放大，防止长标题压到左右按钮下方。
+    val titleHorizontalPadding = with(density) { 12.dp * 2 + 48.sp.toDp() }
     val dialogHostState = remember { LiquidDialogHostState() }
     val topInset = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
     val titleBarHeight = 56.dp
@@ -219,7 +222,7 @@ fun LiquidScreen(
                     .fillMaxWidth()
                     .padding(top = topInset)
                     .fillMaxHeight()
-                    .padding(horizontal = 48.dp),
+                    .padding(horizontal = titleHorizontalPadding),
                 transitionSpec = {
                     val titleEasing = FastOutSlowInEasing
                     val enterForward = slideInHorizontally(

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreen.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreen.kt
@@ -45,10 +45,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
@@ -66,6 +63,7 @@ import kotlinx.coroutines.delay
 @Composable
 fun LiquidScreen(
     state: LiquidScreenState,
+    collapsed: Boolean,
     modifier: Modifier = Modifier,
     actionsEnabled: Boolean = true,
     leftButton: (@Composable () -> Unit)? = null,
@@ -86,56 +84,17 @@ fun LiquidScreen(
     val navigationBottomPx = WindowInsets.navigationBars.getBottom(density)
     var screenHeightPx by remember { mutableStateOf(0) }
 
-    // 内容滚动观测：被动判定内容是否离开顶部。
-    // 用于顶栏背景色/小标题的布尔动画：离开顶部 → 渐显，回到顶部 → 渐隐。
-    // 不可滚动页面不会产生任何滚动事件，恒为 false（顶栏全透明）。
-    var isContentScrolled by remember { mutableStateOf(false) }
-    val scrollConnection = remember {
-        object : NestedScrollConnection {
-            override fun onPostScroll(
-                consumed: Offset,
-                available: Offset,
-                source: NestedScrollSource,
-            ): Offset {
-                if (available.y > 0f) {
-                    // 内容已在顶部仍继续下拉（顶部过滚动）：已回到顶部。
-                    isContentScrolled = false
-                } else if (consumed.y < 0f) {
-                    // finger 上滑、内容向下滚：已离开顶部。
-                    isContentScrolled = true
-                }
-                return Offset.Zero
-            }
-        }
-    }
-    val titleCollapseState = remember { TitleBarCollapseState() }
-    // 导航时重置事件通道与自报标记。Pinned 页若不自报（非 Saveable 滚动状态），
-    // 重建后必在顶部，重置后恒 false 即正确；可 saveable 恢复滚动位置的页（如 Home Chat）
-    // 应写入 collapse state 自报（hasReporter=true），返回时首帧立即纠正，不受重置影响。
-    LaunchedEffect(state.title, state.titleDirection) {
-        when (state.titleDirection) {
-            TitleDirection.Forward, TitleDirection.Back -> {
-                isContentScrolled = false
-                titleCollapseState.hasReporter = false
-            }
-            TitleDirection.None -> {}
-        }
-    }
+    // 背景板/小标题折叠状态唯一来源：当前导航条目的 titleCollapsed
+    // （页面经 ReportTitleBarCollapsed 写入）。bar 拉取，无导航清零、
+    // 无共享状态、无退场页竞争；条目存活期状态保留，返回时首帧恢复。
+
     // 动画时长与 action bar 左右按钮显隐动画一致，页面切换时两页滚动状态
     // 不同也不会闪变：alpha 总是从当前值动画到目标值。
     val collapseAnimSpec = tween<Float>(durationMillis = 280, easing = LinearOutSlowInEasing)
-    // 背景与小标题共用同一信号源，保证两者同步动画：
-    // Collapsible 页由页面自报（与大标题同一阈值）；Pinned 页由嵌套滚动观测驱动。
-    val barTarget = if (state.isTitleCollapsible || titleCollapseState.hasReporter) {
-        titleCollapseState.isCollapsed
-    } else {
-        isContentScrolled
-    }
-    val titleTarget = if (state.isTitleCollapsible) {
-        titleCollapseState.isCollapsed
-    } else {
-        true
-    }
+    // 背景与小标题共用同一信号源，保证两者同步动画；
+    // 小标题仅在 Collapsible 页随折叠浮现，Pinned 页常驻。
+    val barTarget = collapsed
+    val titleTarget = if (state.isTitleCollapsible) collapsed else true
     val barAlpha by animateFloatAsState(
         targetValue = if (barTarget) 1f else 0f,
         animationSpec = collapseAnimSpec,
@@ -177,14 +136,12 @@ fun LiquidScreen(
             LocalLiquidScreenContentContext provides LiquidScreenContentContext(
                 topPadding = actionBarHeight,
             ),
-            LocalTitleBarCollapseState provides titleCollapseState,
             LocalLiquidViewportAvoidanceController provides state.viewportAvoidanceController,
             LocalLiquidDialogHostState provides dialogHostState,
         ) {
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .nestedScroll(scrollConnection)
                     .graphicsLayer {
                         translationY = avoidanceOffsetPx
                     },

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreenContentContext.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/LiquidScreenContentContext.kt
@@ -2,16 +2,16 @@ package com.niki914.uikit.infra
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.compositionLocalOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.Modifier
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.niki914.uikit.infra.nav.LocalNavigationEntry
+import com.niki914.uikit.infra.nav.NavigationEntry
+import com.niki914.uikit.infra.nav.Page
 
 @Stable
 class LiquidScreenContentContext internal constructor(
@@ -24,6 +24,26 @@ class LiquidScreenContentContext internal constructor(
  * 业务页面应由 `LiquidScreen` 承载；Preview 或独立样例请使用
  * `ProvideLiquidScreenContentForPreview` 包裹。
  */
+/**
+ * 把页面自身的「内容是否已滚离顶部」写入当前导航条目（`LocalNavigationEntry`）。
+ *
+ * 折叠状态归属条目（`NavigationEntry.titleCollapsed`）：action bar 只拉取
+ * 当前条目的状态，因此过渡期退场页的写入不会干扰新页；条目在栈内存活期间
+ * 状态保留，返回本页时 bar 首帧即恢复离开前的状态（配合 alpha 动画平滑过渡）。
+ *
+ * 不可滚动的页面无需调用（条目默认 false = 背景板透明）。
+ */
+@Composable
+fun ReportTitleBarCollapsed(isCollapsed: () -> Boolean) {
+    val entry = LocalNavigationEntry.current
+    LaunchedEffect(entry) {
+        snapshotFlow(isCollapsed).collect { entry.titleCollapsed = it }
+    }
+}
+
+// ponytail: 折叠信号唯一来源是条目上的 titleCollapsed（bar 拉、页面推自己槽）；
+// 若再出现第二个信号通道，应先删掉旧的再考虑新的。
+
 val LocalLiquidScreenContentContext: ProvidableCompositionLocal<LiquidScreenContentContext> =
     compositionLocalOf {
         error(
@@ -32,30 +52,13 @@ val LocalLiquidScreenContentContext: ProvidableCompositionLocal<LiquidScreenCont
         )
     }
 
-/**
- * Collapsible 页（`ZafiroPage.titleMode == Collapsible`）向 `LiquidScreen` 回报
- * 「内容是否已滚离顶部」的通道：true = 大标题已滚走（小标题浮现、背景实色）。
- * 默认 false = 假定在顶部（大标题展示中）。Pinned 页不写此状态。
- */
-@Stable
-class TitleBarCollapseState {
-    /** true = 内容已滚过大标题（小标题应浮现）；非滚动页恒为 false（顶栏全透明）。 */
-    var isCollapsed: Boolean by mutableStateOf(false)
-
-    /** 是否有页面在本帧接管了回报。导航时由 LiquidScreen 清零，
-     * 防止上一页的 isCollapsed 残值泄漏给不自报的页面。 */
-    var hasReporter: Boolean by mutableStateOf(false)
-}
-
-// ponytail: 折叠信号有 Pinned（根部嵌套滚动观测）与 Collapsible（页面自报）两条通道；
-// 再出现第三个 Collapsible 容器时，应把大标题收敛进 LiquidScreen 统一渲染，删除双通道。
-
-val LocalTitleBarCollapseState: ProvidableCompositionLocal<TitleBarCollapseState> =
-    staticCompositionLocalOf { TitleBarCollapseState() }
-
 @Composable
 fun liquidScreenTopPadding(extra: Dp = 0.dp): Dp {
     return LocalLiquidScreenContentContext.current.topPadding + extra
+}
+
+private object PreviewPage : Page {
+    override val routeKey: String = "preview"
 }
 
 @Composable
@@ -67,7 +70,7 @@ fun ProvideLiquidScreenContentForPreview(
         LocalLiquidScreenContentContext provides LiquidScreenContentContext(
             topPadding = topPadding,
         ),
-        LocalTitleBarCollapseState provides TitleBarCollapseState(),
+        LocalNavigationEntry provides NavigationEntry(id = "preview", page = PreviewPage),
         content = content,
     )
 }

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsListPageContent.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingsListPageContent.kt
@@ -11,12 +11,10 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
@@ -24,15 +22,15 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.foundation.ScrollState
+import com.niki914.uikit.infra.ReportTitleBarCollapsed
 import com.niki914.uikit.infra.nav.LocalPageTitle
-import com.niki914.uikit.infra.LocalTitleBarCollapseState
 import com.niki914.uikit.infra.liquidScreenTopPadding
 
 /**
  * 设置列表页容器，必须运行在 `LiquidScreen` 内容树内。
  *
  * 内容顶部渲染页面大标题（`LocalPageTitle`，由页面宿主按 entry 提供），
- * 随滚动淡出并把折叠比例写回 `LocalTitleBarCollapseState`，
+ * 随滚动淡出并经 `ReportTitleBarCollapsed` 把折叠状态写入当前导航条目，
  * 由 `LiquidScreen` 驱动顶栏小标题浮现与背景色渐显。
  *
  * Preview 或独立样例请用 `ProvideLiquidScreenContentForPreview` 提供壳层上下文。
@@ -48,13 +46,8 @@ fun SettingsListPageContent(
     // 大标题完全滚离的布尔判定；derivedStateOf 避免逐帧重组。
     val isCollapsed by remember { derivedStateOf { scrollState.value > collapseRangePx } }
 
-    val titleCollapseState = LocalTitleBarCollapseState.current
-    // 用 snapshotFlow 订阅 derivedState：composition 不读它，不能用 SideEffect（不会重组重跑）。
-    // snapshotFlow 启动时先发射当前值：返回本页时立即纠正共享状态，
-    // 因此不需要 onDispose 重置（转场期间退场页写入后不会再次发射，不会覆盖新页的正确值）。
-    LaunchedEffect(titleCollapseState) {
-        snapshotFlow { isCollapsed }.collect { titleCollapseState.isCollapsed = it }
-    }
+    // 折叠状态写入当前导航条目，action bar 拉取；返回本页时立即恢复离开前状态。
+    ReportTitleBarCollapsed { isCollapsed }
 
     Column(
         modifier = modifier

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/nav/NavigationController.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/nav/NavigationController.kt
@@ -19,7 +19,13 @@ data class NavigationEntry<P : Page>(
     val id: String,
     val page: P,
     override val viewModelStore: ViewModelStore = ViewModelStore(),
-) : ViewModelStoreOwner
+) : ViewModelStoreOwner {
+    /** 本页内容是否已滚离顶部（驱动 action bar 背景板渐显与小标题浮现）。
+     * 由页面自己写入（ReportTitleBarCollapsed）；状态归属条目：
+     * 条目在栈内存活期间保留，返回本页时 bar 首帧即取到离开前的状态，
+     * 过渡期退场页写的是自己的槽，bar 只读当前条目，无共享竞争。 */
+    var titleCollapsed: Boolean by mutableStateOf(false)
+}
 
 @Stable
 class NavigationController<P : Page>(

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/preview/ConfirmationLiquidDialogPreview.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/preview/ConfirmationLiquidDialogPreview.kt
@@ -24,7 +24,7 @@ private fun ConfirmationLiquidDialogPreviewContent() {
         showBlurLayer = false,
     )
 
-    LiquidScreen(state = screenState) {
+    LiquidScreen(state = screenState, collapsed = false) {
         Box(
             modifier = Modifier
                 .fillMaxSize()

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/preview/LiquidDialogPreview.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/preview/LiquidDialogPreview.kt
@@ -42,7 +42,7 @@ private fun LiquidDialogPreviewContent() {
         }
     }
 
-    LiquidScreen(state = screenState) {
+    LiquidScreen(state = screenState, collapsed = false) {
         Box(
             modifier = Modifier
                 .fillMaxSize()


### PR DESCRIPTION
## Summary
- fix: derive title bar side padding from action button footprint so long titles no longer slide under the buttons
- fix: own action bar collapse state per navigation entry
- fix: auto-focus composer keyboard only on cold start, not after replies
- feat: seed py_install_apk tool and backfill missing seed tools on startup
- fix: update check also compares latest prerelease release

## Testing
- ./gradlew :ui-kit:compileDebugKotlin