### PR TITLE
feat: streaming typewriter reveal and scroll-to-bottom affordance

### DIFF
--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/HomeChatComponents.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/HomeChatComponents.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -36,16 +37,26 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextMotion
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.mikepenz.markdown.annotator.annotatorSettings
+import com.mikepenz.markdown.annotator.buildMarkdownAnnotatedString
+import com.mikepenz.markdown.compose.components.MarkdownComponentModel
+import com.mikepenz.markdown.compose.components.markdownComponents
+import com.mikepenz.markdown.compose.elements.MarkdownText
 import com.mikepenz.markdown.m3.Markdown
 import com.mikepenz.markdown.m3.markdownTypography
+import com.mikepenz.markdown.model.MarkdownTypography
 import com.mikepenz.markdown.model.rememberMarkdownState
+import com.niki914.zafiro.app.ui.content.reveal.RevealTimeline
+import com.niki914.zafiro.app.ui.content.reveal.rememberStreamReveal
 import com.niki914.zafiro.app.R
 import com.niki914.uikit.infra.ActionBarButton
 import com.niki914.uikit.infra.component.LiquidTextField
@@ -138,44 +149,38 @@ println(answer)
 fun AssistantOutputText(
     text: String,
     modifier: Modifier = Modifier,
+    reveal: RevealTimeline? = null,
 ) {
+    val markdownState = rememberMarkdownState(
+        content = text,
+        immediate = true,
+    )
+    val revealComponents = remember(reveal) { reveal?.let(::revealMarkdownComponents) }
+    val typography = assistantMarkdownTypography()
+
+    SelectionContainer(modifier = modifier.fillMaxWidth()) {
+        if (revealComponents == null) {
+            Markdown(
+                markdownState = markdownState,
+                modifier = Modifier.fillMaxWidth(),
+                typography = typography,
+            )
+        } else {
+            Markdown(
+                markdownState = markdownState,
+                modifier = Modifier.fillMaxWidth(),
+                typography = typography,
+                components = revealComponents,
+            )
+        }
+    }
+}
+
+@Composable
+private fun assistantMarkdownTypography(): MarkdownTypography {
     val bodyStyle = MaterialTheme.typography.bodyLarge.copy(
         fontSize = (MaterialTheme.typography.bodyLarge.fontSize.value + 1f).sp,
         lineHeight = (MaterialTheme.typography.bodyLarge.lineHeight.value + 2f).sp,
-    )
-    val h1Style = bodyStyle.copy(
-        fontSize = 18.sp,
-        lineHeight = 22.sp,
-        fontWeight = FontWeight.SemiBold,
-    )
-    val h2Style = bodyStyle.copy(
-        fontSize = 15.sp,
-        lineHeight = 20.sp,
-        fontWeight = FontWeight.SemiBold,
-    )
-    val h3Style = bodyStyle.copy(
-        fontSize = 14.sp,
-        lineHeight = 19.sp,
-        fontWeight = FontWeight.SemiBold,
-    )
-    val h4Style = bodyStyle.copy(
-        fontSize = 13.sp,
-        lineHeight = 18.sp,
-        fontWeight = FontWeight.Medium,
-    )
-    val h5Style = bodyStyle.copy(
-        fontSize = 12.sp,
-        lineHeight = 17.sp,
-        fontWeight = FontWeight.Medium,
-    )
-    val h6Style = bodyStyle.copy(
-        fontSize = 11.sp,
-        lineHeight = 16.sp,
-        fontWeight = FontWeight.Medium,
-    )
-    val tableStyle = bodyStyle.copy(
-        fontSize = 16.sp,
-        lineHeight = 22.sp,
     )
     val codeStyle = bodyStyle.copy(
         fontSize = 15.sp,
@@ -188,34 +193,64 @@ fun AssistantOutputText(
         fontStyle = FontStyle.Italic,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
     )
-    val markdownState = rememberMarkdownState(
-        content = text,
-        immediate = true,
+    return markdownTypography(
+        h1 = bodyStyle.copy(fontSize = 18.sp, lineHeight = 22.sp, fontWeight = FontWeight.SemiBold),
+        h2 = bodyStyle.copy(fontSize = 15.sp, lineHeight = 20.sp, fontWeight = FontWeight.SemiBold),
+        h3 = bodyStyle.copy(fontSize = 14.sp, lineHeight = 19.sp, fontWeight = FontWeight.SemiBold),
+        h4 = bodyStyle.copy(fontSize = 13.sp, lineHeight = 18.sp, fontWeight = FontWeight.Medium),
+        h5 = bodyStyle.copy(fontSize = 12.sp, lineHeight = 17.sp, fontWeight = FontWeight.Medium),
+        h6 = bodyStyle.copy(fontSize = 11.sp, lineHeight = 16.sp, fontWeight = FontWeight.Medium),
+        text = bodyStyle,
+        code = codeStyle,
+        inlineCode = codeStyle,
+        quote = quoteStyle,
+        paragraph = bodyStyle,
+        ordered = bodyStyle,
+        bullet = bodyStyle,
+        list = bodyStyle,
+        table = bodyStyle.copy(fontSize = 16.sp, lineHeight = 22.sp),
     )
+}
 
-    SelectionContainer(modifier = modifier.fillMaxWidth()) {
-        Markdown(
-            markdownState = markdownState,
-            modifier = Modifier.fillMaxWidth(),
-            typography = markdownTypography(
-                h1 = h1Style,
-                h2 = h2Style,
-                h3 = h3Style,
-                h4 = h4Style,
-                h5 = h5Style,
-                h6 = h6Style,
-                text = bodyStyle,
-                code = codeStyle,
-                inlineCode = codeStyle,
-                quote = quoteStyle,
-                paragraph = bodyStyle,
-                ordered = bodyStyle,
-                bullet = bodyStyle,
-                list = bodyStyle,
-                table = tableStyle,
-            ),
+/**
+ * 打字机显现的自定义块组件：段落/标题替换为带 reveal 修饰符的渲染，其余块走默认。
+ * 各块用自身源文偏移与时间轴对齐，块间显现顺序天然正确。
+ */
+private fun revealMarkdownComponents(timeline: RevealTimeline) = markdownComponents(
+    text = { RevealedBlockText(it, timeline, it.typography.text) },
+    paragraph = { RevealedBlockText(it, timeline, it.typography.paragraph) },
+    heading1 = { RevealedBlockText(it, timeline, it.typography.h1) },
+    heading2 = { RevealedBlockText(it, timeline, it.typography.h2) },
+    heading3 = { RevealedBlockText(it, timeline, it.typography.h3) },
+    heading4 = { RevealedBlockText(it, timeline, it.typography.h4) },
+    heading5 = { RevealedBlockText(it, timeline, it.typography.h5) },
+    heading6 = { RevealedBlockText(it, timeline, it.typography.h6) },
+    setextHeading1 = { RevealedBlockText(it, timeline, it.typography.h1) },
+    setextHeading2 = { RevealedBlockText(it, timeline, it.typography.h2) },
+)
+
+@Composable
+private fun RevealedBlockText(
+    model: MarkdownComponentModel,
+    timeline: RevealTimeline,
+    style: TextStyle,
+) {
+    val reveal = rememberStreamReveal(timeline = timeline, sourceStart = model.node.startOffset)
+    val annotator = annotatorSettings()
+    val annotated = remember(model.content, model.node, style, annotator) {
+        model.content.buildMarkdownAnnotatedString(
+            textNode = model.node,
+            style = style,
+            annotatorSettings = annotator,
         )
     }
+    reveal.sync(sourceEnd = model.node.endOffset, renderedText = annotated.text)
+    MarkdownText(
+        content = annotated,
+        modifier = reveal.modifier,
+        style = style.copy(textMotion = TextMotion.Animated),
+        onTextLayout = { layoutResult, _ -> reveal.onTextLayout(layoutResult) },
+    )
 }
 
 @Preview(

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
@@ -2,10 +2,15 @@ package com.niki914.zafiro.app.ui.content
 
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsDraggedAsState
@@ -29,6 +34,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -51,6 +57,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
@@ -58,6 +65,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
@@ -86,6 +94,7 @@ import com.niki914.zafiro.app.ui.model.HomeChatViewModel
 import com.niki914.zafiro.app.ui.model.HomeToolState
 import com.niki914.zafiro.app.ui.model.HomeToolStatus
 import com.niki914.zafiro.app.ui.model.ToolPresentation
+import com.niki914.zafiro.app.ui.content.reveal.RevealTimeline
 import com.niki914.zafiro.app.ui.nav.TextTitle
 import com.niki914.zafiro.app.ui.nav.TopBarActionSpec
 import com.niki914.zafiro.chat.agentic.shell.ToolPermissionCoordinator
@@ -139,20 +148,31 @@ fun HomePageContent(
     val navigationBottom = with(density) { WindowInsets.navigationBars.getBottom(this).toDp() }
     var isComposerFocused by remember { mutableStateOf(false) }
     val effectiveImeBottom = if (isComposerFocused) imeBottom else 0.dp
-    val composerBottomPadding = (effectiveImeBottom + 12.dp).coerceAtLeast(navigationBottom + 20.dp)
+    // 统一视觉底间距：键盘关闭时与 composer 底距一致，不随 ime 放大——键盘打开时
+    // 额外空间全部由 composerBottomPadding 提供，箭头/消息的呼吸空间保持固定
+    val composerGap = navigationBottom + 20.dp
+    val composerBottomPadding = (effectiveImeBottom + 12.dp).coerceAtLeast(composerGap)
+    // composer 实测高度（默认 68dp = LiquidChatComposer 的 minHeight），首帧布局后回填
+    val composerHeight = remember { mutableStateOf(68.dp) }
     val bottomThresholdPx = with(density) { 24.dp.roundToPx() }
     val lastTurn = uiState.turns.lastOrNull()
+    // 贴底由「滚动位置 + contentPadding」共同决定：composer 几何（ime 动画、多行输入
+    // 长高）变化时 padding 跟着变，也必须重新贴底，否则最后一条消息被 composer 遮住
     val bottomContentVersion = remember(
         uiState.turns.size,
         uiState.streamEventCount,
         lastTurn?.id,
         lastTurn?.blocks?.size,
+        composerBottomPadding,
+        composerHeight.value,
     ) {
         listOf(
             uiState.turns.size,
             uiState.streamEventCount,
             lastTurn?.id,
             lastTurn?.blocks?.size,
+            composerBottomPadding,
+            composerHeight.value,
         )
     }
     val isAtBottom by remember(listState, bottomThresholdPx) {
@@ -165,11 +185,12 @@ fun HomePageContent(
                     lastVisibleItem.offset + lastVisibleItem.size <= viewportEnd + bottomThresholdPx
         }
     }
-    var shouldFollowBottom by rememberScrollFollowState(
+    val shouldFollowBottomState = rememberScrollFollowState(
         interactionSource = listState.interactionSource,
         isScrollInProgress = { listState.isScrollInProgress },
         isAtEnd = { isAtBottom },
     )
+    var shouldFollowBottom by shouldFollowBottomState
     val dismissInputFocus = remember(focusManager, keyboardController) {
         {
             keyboardController?.hide()
@@ -256,7 +277,11 @@ fun HomePageContent(
         uiState = uiState,
         listState = listState,
         composerBottomPadding = composerBottomPadding,
+        composerGap = composerGap,
+        composerHeight = composerHeight,
         composerFocusRequester = composerFocusRequester,
+        followBottom = shouldFollowBottomState,
+        isAtBottom = isAtBottom,
         onContentTap = dismissInputFocus,
         onInputChange = { value ->
             viewModel.sendIntent(HomeChatIntent.InputChanged(value))
@@ -410,7 +435,11 @@ private fun HomePageContentBody(
     uiState: HomeChatUiState,
     listState: LazyListState,
     composerBottomPadding: Dp,
+    composerGap: Dp,
+    composerHeight: MutableState<Dp>,
     composerFocusRequester: FocusRequester,
+    followBottom: MutableState<Boolean>,
+    isAtBottom: Boolean,
     onContentTap: () -> Unit,
     onInputChange: (String) -> Unit,
     onSendClick: () -> Unit,
@@ -429,6 +458,23 @@ private fun HomePageContentBody(
     activeThinkingKey: String? = null,
     onToggleActionRow: (Long, ActionSource) -> Unit,
 ) {
+    // 流式打字机时钟：整个 Home 持有一个（同一时刻只有最后一条回答在流式），
+    // 进度提升到列表层，流式 item 滚出视口被销毁后滑回，打字进度不重播。
+    val revealTimeline = remember { RevealTimeline() }
+    val streamingReveal = if (uiState.isGenerating) revealTimeline else null
+    LaunchedEffect(revealTimeline) {
+        revealTimeline.run()
+    }
+    LaunchedEffect(uiState.isGenerating, uiState.turns.lastOrNull()?.id) {
+        if (uiState.isGenerating) revealTimeline.reset()
+    }
+
+    // 底部避让总高：composer 底距 + 实测高度 + 统一视觉间距。列表贴底留白与箭头
+    // 位置同源；键盘关闭时（composerBottomPadding == composerGap）即为
+    // composerBottomPadding*2 + composerHeight，composer 顶上方留一个视觉间距
+    val bottomClearance = composerBottomPadding + composerHeight.value + composerGap
+    val density = LocalDensity.current
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -446,7 +492,7 @@ private fun HomePageContentBody(
                 start = 20.dp,
                 top = liquidScreenTopPadding(24.dp),
                 end = 20.dp,
-                bottom = 128.dp,
+                bottom = bottomClearance,
             ),
         ) {
             itemsIndexed(
@@ -467,6 +513,7 @@ private fun HomePageContentBody(
                     turn = turn,
                     userBubblePosition = position,
                     isLastTurn = index == uiState.turns.lastIndex,
+                    streamingReveal = streamingReveal,
                     onContentTap = onContentTap,
                     onReGenerate = onReGenerate,
                     onFork = onFork,
@@ -511,8 +558,46 @@ private fun HomePageContentBody(
                         start = 20.dp,
                         end = 20.dp,
                         bottom = composerBottomPadding,
-                    ),
+                    )
+                    // 放在 padding 之后：只测 composer 本体高度，不含底边距
+                    .onSizeChanged { size ->
+                        composerHeight.value = with(density) { size.height.toDp() }
+                    },
             )
+        }
+
+        // 解除贴底锚定且不在底部时出现：点击恢复跟随并平滑滚回底部
+        val scrollToBottomScope = rememberCoroutineScope()
+        AnimatedVisibility(
+            visible = !followBottom.value && !isAtBottom,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = bottomClearance),
+            enter = fadeIn(tween(160)) + scaleIn(tween(180), initialScale = 0.82f),
+            exit = fadeOut(tween(100)) + scaleOut(tween(120), targetScale = 0.86f),
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                    .clickable {
+                        followBottom.value = true
+                        scrollToBottomScope.launch {
+                            listState.animateScrollToItem(uiState.turns.size)
+                        }
+                    },
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_arrow_down),
+                    contentDescription = stringResource(
+                        R.string.ui_home_scroll_to_bottom_content_description,
+                    ),
+                    tint = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
         }
 
         if (uiState.isLoadingConversation) {
@@ -558,6 +643,7 @@ private fun HomeChatTurnItem(
     turn: HomeChatTurn,
     userBubblePosition: UserBubblePosition,
     isLastTurn: Boolean,
+    streamingReveal: RevealTimeline?,
     onContentTap: () -> Unit,
     onReGenerate: (Long) -> Unit,
     onFork: (Long) -> Unit,
@@ -700,6 +786,7 @@ private fun HomeChatTurnItem(
                                     ) {
                                         AssistantOutputText(
                                             text = block.text,
+                                            reveal = if (isLastTurn) streamingReveal else null,
                                         )
                                     }
                                 }
@@ -861,6 +948,10 @@ private fun HomePageContentPreview() {
                 ),
                 listState = rememberLazyListState(),
                 composerBottomPadding = 20.dp,
+                composerGap = 20.dp,
+                composerHeight = remember { mutableStateOf(68.dp) },
+                followBottom = remember { mutableStateOf(true) },
+                isAtBottom = true,
                 onContentTap = {},
                 onInputChange = {},
                 onSendClick = {},

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/reveal/RevealModifier.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/reveal/RevealModifier.kt
@@ -1,0 +1,280 @@
+package com.niki914.zafiro.app.ui.content.reveal
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.LayoutModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.invalidateDraw
+import androidx.compose.ui.node.invalidateMeasurement
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.unit.Constraints
+import java.text.BreakIterator
+import java.util.Locale
+import kotlin.math.ceil
+import kotlin.math.floor
+
+/**
+ * 一个文本块的显现句柄：组合层持有它，向节点回传排版结果；节点反过来读它携带的
+ * 块信息（源文本起点、渲染文本）。句柄按块记忆（key = sourceStart），文本增长只是
+ * 更新 [text]，节点身份与路径缓存不重建。
+ */
+@Stable
+internal class RevealState internal constructor(
+    internal val timeline: RevealTimeline,
+    internal val sourceStart: Int,
+) {
+    internal var text: String = ""
+    internal var node: RevealNode? = null
+
+    val modifier: Modifier = Modifier.then(RevealElement(this))
+
+    /** 组合期同步：把块的源文本末偏移上报给时间轴（单调 max），并记录渲染文本。 */
+    fun sync(sourceEnd: Int, renderedText: String) {
+        text = renderedText
+        timeline.mergeTarget(sourceEnd)
+    }
+
+    fun onTextLayout(result: TextLayoutResult?) {
+        node?.onTextLayout(result)
+    }
+}
+
+@Composable
+internal fun rememberStreamReveal(
+    timeline: RevealTimeline,
+    sourceStart: Int,
+): RevealState = remember(timeline, sourceStart) {
+    RevealState(timeline, sourceStart)
+}
+
+private data class RevealElement(
+    val state: RevealState,
+) : ModifierNodeElement<RevealNode>() {
+    override fun create(): RevealNode = RevealNode(state)
+
+    override fun update(node: RevealNode) {
+        node.state = state
+        node.refresh()
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "streamReveal"
+    }
+}
+
+/**
+ * 按时间轴进度显现文本：进度内的字素正常绘制，下一个字素按剩余比例渐显；
+ * 高度跟随显现行增长，未显现部分不占高度，保证贴底滚动的目标稳定。
+ * 进度坐标见 [RevealTimeline]：本地进度 = 全局已显现偏移 - 块的源文本起点。
+ */
+internal class RevealNode(
+    internal var state: RevealState,
+) : Modifier.Node(), DrawModifierNode, LayoutModifierNode {
+
+    private val timeline get() = state.timeline
+    private val sourceStart get() = state.sourceStart
+    private val text get() = state.text
+
+    private val alphaPaint = Paint()
+    private var layoutResult: TextLayoutResult? = null
+
+    // 字素边界（每个字素的起始偏移，末位为 text.length）；块级文本很短，文本变化时整体重算
+    private var boundaries: IntArray = intArrayOf(0)
+    private var boundariesText: String = ""
+
+    // 路径缓存：同一排版下，已显现字素的合并路径与下一个字素路径
+    private var pathLayout: TextLayoutResult? = null
+    private var pathGraphemeIndex: Int = -1
+    private var fullPath: Path? = null
+    private var nextPath: Path? = null
+
+    private var measuredVisibleHeight: Int = -1
+
+    override fun onAttach() {
+        timeline.attach(this)
+    }
+
+    override fun onDetach() {
+        timeline.detach(this)
+        layoutResult = null
+        pathLayout = null
+        pathGraphemeIndex = -1
+        fullPath = null
+        nextPath = null
+    }
+
+    fun onTextLayout(result: TextLayoutResult?) {
+        if (layoutResult === result) return
+        layoutResult = result
+        pathLayout = null
+        pathGraphemeIndex = -1
+        fullPath = null
+        nextPath = null
+        refresh()
+    }
+
+    /** 帧时钟推进后回调：按需请求重测（跨行）并重绘。 */
+    fun onRevealChanged() {
+        refresh()
+    }
+
+    internal fun refresh() {
+        if (!isAttached) return
+        val layout = layoutResult ?: return
+        val wanted = visibleHeight(fullHeight = layout.size.height)
+        if (wanted != measuredVisibleHeight) {
+            measuredVisibleHeight = wanted
+            invalidateMeasurement()
+        }
+        invalidateDraw()
+    }
+
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints,
+    ): MeasureResult {
+        val placeable = measurable.measure(constraints)
+        val visible = visibleHeight(fullHeight = placeable.height)
+        measuredVisibleHeight = visible
+        val height = visible.coerceIn(constraints.minHeight, constraints.maxHeight)
+        return layout(placeable.width, height) {
+            placeable.place(0, 0)
+        }
+    }
+
+    override fun ContentDrawScope.draw() {
+        val contentScope = this
+        val local = timeline.revealedChars - sourceStart
+        if (local >= text.length) {
+            drawContent()
+            return
+        }
+        if (local <= 0f) return
+        val layout = layoutResult ?: run {
+            drawContent()
+            return
+        }
+        val bounds = ensureBoundaries()
+        val fullIndex = lastBoundaryIndexAtMost(bounds, floor(local).toInt())
+        ensurePaths(layout, bounds, fullIndex)
+
+        // 已显现字素：裁剪到前 fullIndex 个字素的合并路径
+        if (fullIndex > 0) {
+            fullPath?.let { path -> clipPath(path) { contentScope.drawContent() } }
+        }
+
+        // 下一个字素：按剩余比例渐显
+        val graphemeStart = bounds[fullIndex]
+        val graphemeEnd = bounds.getOrNull(fullIndex + 1) ?: return
+        if (graphemeEnd <= graphemeStart) return
+        val alpha = ((local - graphemeStart) / (graphemeEnd - graphemeStart)).coerceIn(0f, 1f)
+        if (alpha <= 0f) return
+        nextPath?.let { path ->
+            clipPath(path) {
+                alphaPaint.alpha = alpha
+                drawContext.canvas.saveLayer(Rect(Offset.Zero, size), alphaPaint)
+                try {
+                    contentScope.drawContent()
+                } finally {
+                    drawContext.canvas.restore()
+                }
+            }
+        }
+    }
+
+    /** 显现进度对应的高度：最后一行已显现字素的行底；未开始显现为 0。 */
+    private fun visibleHeight(fullHeight: Int): Int {
+        val local = timeline.revealedChars - sourceStart
+        if (local >= text.length) return fullHeight
+        if (local <= 0f) return 0
+        val layout = layoutResult ?: return fullHeight
+        val bounds = ensureBoundaries()
+        val index = lastBoundaryIndexAtMost(bounds, ceil(local).toInt())
+        val end = bounds[index]
+        if (end <= 0 || layout.lineCount == 0) return 0
+        val line = layout.getLineForOffset((end - 1).coerceAtMost(text.length - 1))
+        return ceil(layout.getLineBottom(line)).toInt().coerceAtMost(fullHeight)
+    }
+
+    private fun ensureBoundaries(): IntArray {
+        if (boundariesText != text) {
+            boundaries = graphemeStarts(text)
+            boundariesText = text
+        }
+        return boundaries
+    }
+
+    private fun ensurePaths(
+        layout: TextLayoutResult,
+        bounds: IntArray,
+        fullIndex: Int,
+    ) {
+        val sameLayout = pathLayout === layout
+        if (sameLayout && pathGraphemeIndex == fullIndex) return
+
+        fullPath = if (fullIndex <= 0) {
+            null
+        } else if (sameLayout &&
+            fullIndex == pathGraphemeIndex + 1 &&
+            bounds[fullIndex] == bounds[pathGraphemeIndex] + 1
+        ) {
+            // 相邻单字素推进：把上一帧的「下一个字素」并入已显现路径，只重算下一个
+            val accumulated = fullPath ?: Path()
+            nextPath?.let(accumulated::addPath)
+            accumulated
+        } else {
+            layout.getPathForRange(0, bounds[fullIndex])
+        }
+        pathLayout = layout
+        pathGraphemeIndex = fullIndex
+        nextPath = nextGraphemePath(layout, bounds, fullIndex)
+    }
+
+    private fun nextGraphemePath(
+        layout: TextLayoutResult,
+        bounds: IntArray,
+        fullIndex: Int,
+    ): Path? {
+        val start = bounds[fullIndex]
+        val end = bounds.getOrNull(fullIndex + 1) ?: return null
+        return if (end > start && end <= text.length) {
+            layout.getPathForRange(start, end)
+        } else {
+            null
+        }
+    }
+
+    /** 最后一个 <= value 的边界下标；value 小于首边界时返回 0。 */
+    private fun lastBoundaryIndexAtMost(bounds: IntArray, value: Int): Int {
+        val found = bounds.binarySearch(value)
+        return if (found >= 0) found else -found - 2
+    }
+}
+
+/** 每个字素的起始偏移数组，形如 [0, s1, s2, ..., length]。 */
+private fun graphemeStarts(text: String): IntArray {
+    if (text.isEmpty()) return intArrayOf(0)
+    val iterator = BreakIterator.getCharacterInstance(Locale.ROOT)
+    iterator.setText(text)
+    val result = ArrayList<Int>(text.length + 1)
+    var boundary = iterator.first()
+    while (boundary != BreakIterator.DONE) {
+        result += boundary
+        boundary = iterator.next()
+    }
+    if (result.lastOrNull() != text.length) result += text.length
+    return result.toIntArray()
+}

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/reveal/RevealTimeline.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/reveal/RevealTimeline.kt
@@ -1,0 +1,132 @@
+package com.niki914.zafiro.app.ui.content.reveal
+
+import androidx.compose.runtime.withFrameNanos
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
+
+/**
+ * 流式回答的打字进度时钟。
+ *
+ * 进度只有一个坐标：整条回答源文本的字符偏移（[revealedChars]）。每个参与显现的
+ * 文本块用自己的源文本 startOffset 换算本地进度，块与块之间天然按源文本顺序衔接，
+ * 不需要排队协议；块增删、重挂载都只是重新读一次进度。
+ *
+ * 进度是普通字段，帧间推进不写 Compose State，不触发重组与重排版；仅通过
+ * [RevealNode.onRevealChanged] 让挂载中的节点重绘，显现跨行时由节点自行请求重测。
+ */
+class RevealTimeline {
+    /** 当前源文本已确定的最大末偏移；各文本块按自身区间单调合并。 */
+    @Volatile
+    var targetChars: Int = 0
+        private set
+
+    /** 已显现到的源文本偏移。仅帧循环写入。 */
+    @Volatile
+    var revealedChars: Float = 0f
+        private set
+
+    val hasBacklog: Boolean
+        get() = revealedChars < targetChars
+
+    private val wakeups = Channel<Unit>(Channel.CONFLATED)
+    private val nodes = mutableListOf<RevealNode>()
+
+    /**
+     * 合并一个文本块的源文本末偏移（startOffset + 块长）。
+     * 取单调 max：多块回合（前置文本 + 工具 + 后续文本）里各块分别上报，
+     * target 不会回缩——回缩会让已打出的字消失重打。
+     */
+    fun mergeTarget(sourceEnd: Int) {
+        if (sourceEnd > targetChars) {
+            targetChars = sourceEnd
+            wake()
+        }
+    }
+
+    /** 新回合 / 重新生成时归零，回答从头开始打字。 */
+    fun reset() {
+        revealedChars = 0f
+        targetChars = 0
+        wake()
+    }
+
+    internal fun attach(node: RevealNode) {
+        nodes += node
+        wake()
+    }
+
+    internal fun detach(node: RevealNode) {
+        nodes.remove(node)
+    }
+
+    /**
+     * 帧循环。有积压时按自适应速度推进；无积压时挂起等待唤醒
+     * （文本增长或新节点挂载都会唤醒）。
+     *
+     * 页面退到后台时帧钟停摆；恢复后若与上一帧间隔超过 [STALL_SNAP_SECONDS]，
+     * 直接追平目标不补播——后台期间 Runtime 继续追加的内容没有观看价值。
+     */
+    suspend fun run() {
+        var previousFrameNanos = 0L
+        while (currentCoroutineContext().isActive) {
+            if (!hasBacklog) {
+                previousFrameNanos = 0L
+                wakeups.receive()
+                continue
+            }
+            val frameNanos = withFrameNanos { it }
+            val elapsedSeconds = if (previousFrameNanos == 0L) {
+                0f
+            } else {
+                (frameNanos - previousFrameNanos) / NANOS_PER_SECOND
+            }
+            previousFrameNanos = frameNanos
+            if (!hasBacklog) continue
+
+            revealedChars = if (elapsedSeconds > STALL_SNAP_SECONDS) {
+                targetChars.toFloat()
+            } else {
+                advance(
+                    current = revealedChars,
+                    target = targetChars.toFloat(),
+                    elapsedSeconds = elapsedSeconds,
+                )
+            }
+            val snapshot = nodes.toList()
+            for (node in snapshot) node.onRevealChanged()
+        }
+    }
+
+    private fun wake() {
+        wakeups.trySend(Unit)
+    }
+
+    companion object {
+        /**
+         * 单帧步长：基速 [BASE_CHARS_PER_SECOND]，积压时按 [CATCH_UP_SECONDS] 追平
+         * 加速，上限 [MAX_CHARS_PER_SECOND]。模型快它就快，永不滞后。
+         */
+        internal fun advance(
+            current: Float,
+            target: Float,
+            elapsedSeconds: Float,
+        ): Float {
+            if (current >= target) return target
+            val backlog = target - current
+            val speed = maxOf(
+                BASE_CHARS_PER_SECOND,
+                backlog / CATCH_UP_SECONDS,
+            ).coerceAtMost(MAX_CHARS_PER_SECOND)
+            val step = speed * elapsedSeconds.coerceIn(0f, MAX_FRAME_SECONDS)
+            return (current + step).coerceAtMost(target)
+        }
+
+        internal const val BASE_CHARS_PER_SECOND = 36f
+        internal const val MAX_CHARS_PER_SECOND = 240f
+        internal const val CATCH_UP_SECONDS = 0.20f
+        internal const val MAX_FRAME_SECONDS = 0.05f
+        internal const val STALL_SNAP_SECONDS = 0.25f
+        private const val NANOS_PER_SECOND = 1_000_000_000f
+    }
+}

--- a/app/src/main/res/drawable/ic_arrow_down.xml
+++ b/app/src/main/res/drawable/ic_arrow_down.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M12,7L12,17M12,17L7,12M12,17L17,12"
+        android:strokeWidth="2"
+        android:strokeColor="#FFFFFF"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+</vector>

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -54,6 +54,7 @@
         <item quantity="other">%d 個工具</item>
     </plurals>
     <string name="ui_home_send_content_description">傳送訊息</string>
+    <string name="ui_home_scroll_to_bottom_content_description">滾動到底部</string>
     <string name="ui_home_stop_content_description">停止生成</string>
     <string name="ui_home_action_copy_content_description">複製</string>
     <string name="ui_home_action_regenerate_content_description">重新生成</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -55,6 +55,7 @@
         <item quantity="other">%d tools</item>
     </plurals>
     <string name="ui_home_send_content_description">Send message</string>
+    <string name="ui_home_scroll_to_bottom_content_description">Scroll to bottom</string>
     <string name="ui_home_stop_content_description">Stop generating</string>
     <string name="ui_home_action_copy_content_description">Copy</string>
     <string name="ui_home_action_regenerate_content_description">Regenerate</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -55,6 +55,7 @@
         <item quantity="other">%d herramientas</item>
     </plurals>
     <string name="ui_home_send_content_description">Enviar mensaje</string>
+    <string name="ui_home_scroll_to_bottom_content_description">Ir al final</string>
     <string name="ui_home_stop_content_description">Detener generación</string>
     <string name="ui_home_action_copy_content_description">Copiar</string>
     <string name="ui_home_action_regenerate_content_description">Regenerar</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -54,6 +54,7 @@
     <item quantity="other">%d 個のツール</item>
     </plurals>
     <string name="ui_home_send_content_description">メッセージを送信</string>
+    <string name="ui_home_scroll_to_bottom_content_description">一番下へスクロール</string>
     <string name="ui_home_stop_content_description">生成を停止</string>
     <string name="ui_home_action_copy_content_description">コピー</string>
     <string name="ui_home_action_regenerate_content_description">再生成</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
         <item quantity="other">%d 个工具</item>
     </plurals>
     <string name="ui_home_send_content_description">发送消息</string>
+    <string name="ui_home_scroll_to_bottom_content_description">滚动到底部</string>
     <string name="ui_home_stop_content_description">停止生成</string>
     <string name="ui_home_action_copy_content_description">复制</string>
     <string name="ui_home_action_regenerate_content_description">重新生成</string>

--- a/app/src/test/java/com/niki914/zafiro/app/ui/content/reveal/RevealTimelineTest.kt
+++ b/app/src/test/java/com/niki914/zafiro/app/ui/content/reveal/RevealTimelineTest.kt
@@ -1,0 +1,54 @@
+package com.niki914.zafiro.app.ui.content.reveal
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RevealTimelineTest {
+
+    @Test
+    fun `uses base speed floor for tiny backlog`() {
+        // 积压 7 字素时追赶曲线低于基速，走基速：36 * 0.05s = 1.8
+        val advanced = RevealTimeline.advance(current = 0f, target = 7f, elapsedSeconds = 0.05f)
+        assertEquals(RevealTimeline.BASE_CHARS_PER_SECOND * RevealTimeline.MAX_FRAME_SECONDS, advanced, 0.01f)
+    }
+
+    @Test
+    fun `catches up when backlog builds and stays under cap`() {
+        // 积压 2000 字素：追赶速度远超上限，单帧步长 = 240 * 0.05s = 12
+        val advanced = RevealTimeline.advance(current = 0f, target = 2000f, elapsedSeconds = 0.05f)
+        assertEquals(RevealTimeline.MAX_CHARS_PER_SECOND * RevealTimeline.MAX_FRAME_SECONDS, advanced, 0.01f)
+    }
+
+    @Test
+    fun `never overshoots target`() {
+        val advanced = RevealTimeline.advance(current = 99.9f, target = 100f, elapsedSeconds = 1f)
+        assertEquals(100f, advanced, 0.001f)
+    }
+
+    @Test
+    fun `long gap advances at most one capped frame`() {
+        val advanced = RevealTimeline.advance(current = 0f, target = 2000f, elapsedSeconds = 10f)
+        assertEquals(
+            RevealTimeline.MAX_CHARS_PER_SECOND * RevealTimeline.MAX_FRAME_SECONDS,
+            advanced,
+            0.01f,
+        )
+    }
+
+    @Test
+    fun `no progress when complete`() {
+        val advanced = RevealTimeline.advance(current = 100f, target = 100f, elapsedSeconds = 1f)
+        assertEquals(100f, advanced, 0.001f)
+    }
+
+    @Test
+    fun `target merges monotonically across blocks`() {
+        val timeline = RevealTimeline()
+        timeline.mergeTarget(100) // 第一段文本块
+        timeline.mergeTarget(40)  // 后续块出现时不可回缩，否则已打出的字会被吞掉
+        assertEquals(100, timeline.targetChars)
+        timeline.mergeTarget(260) // 更大的块继续推进
+        assertEquals(260, timeline.targetChars)
+    }
+}


### PR DESCRIPTION
## Summary

- Streaming answers now reveal with a typewriter effect: single frame-clock (`RevealTimeline`) shared at the Home level, per-grapheme reveal with a fade-in on the leading grapheme. Zero recomposition/relayout during typing (draw-only invalidation); progress lives above the list so items scrolled out of the viewport never replay their typing.
- Added a scroll-to-bottom button that appears when follow-bottom is disengaged, styled as a 40dp circle with scale/fade transitions.
- List bottom clearance and arrow position are derived from the composer's real footprint (bottom padding + measured height + fixed visual gap) instead of hardcoded 84dp/128dp, so the arrow never gets covered by a multiline composer and the last message stays clear of the composer/IME.

## Details

- `RevealTimeline`: monotonic char-offset progress, adaptive speed (base 36 cps, catch-up accel, 240 cps cap), snap-to-target after background stalls. Plain `@Volatile` fields — no Compose state writes per frame.
- `RevealModifier`: draw-time clip against grapheme boundaries (`BreakIterator`), incremental path merging for adjacent single-grapheme advances, height grows line-by-line with revealed content.
- Markdown text/paragraph/heading components are swapped only while streaming; completed answers render through the default components (identical output).
- Follow-bottom re-anchors on composer geometry changes (IME animation, multiline growth), fixing the last message being covered when the keyboard opens.

## Test plan

- [x] `:app:compileDebugKotlin` clean
- [x] `RevealTimelineTest` unit tests pass (advance curve, caps, stall, monotonic merge)
- [x] Manual: typewriter pacing, multi-turn reset, regenerate restart, scroll-away no-replay
- [x] Manual: arrow position with multiline composer, IME open/close re-anchor
