### PR TITLE
M3E collapsible blocks, py_web_read seed, streaming tool placeholder

### DIFF
--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/LlmStreamEvent.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/LlmStreamEvent.kt
@@ -26,6 +26,12 @@ sealed interface LlmStreamEvent {
         val call: ToolCallStatus,
     ) : LlmStreamEvent
 
+    /** 工具调用参数流式构建中：仅名字已知、参数未完整。UI 以 Running 占位（转圈、不可展开），
+     *  后续 [ToolRunning] 按 callId 原地更新为完整信息。 */
+    data class ToolPending(
+        val call: ToolCallStatus,
+    ) : LlmStreamEvent
+
     data class ToolSucceeded(
         val call: ToolCallStatus,
         val outputText: String? = null,

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/stream/LlmStreamEventMapper.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/stream/LlmStreamEventMapper.kt
@@ -143,7 +143,17 @@ object LlmStreamEventMapper {
                 null
             }
 
-            is TurnEvent.ToolCallStarted, is TurnEvent.ToolCallDelta, is TurnEvent.ToolCallReady,
+            // 工具意图阶段：名字已知、参数在途——透传为 ToolPending，UI 以 Running 占位（转圈、不可展开）。
+            // 身份取自事件字段：发起中的调用未进 partial.content，从 partial 里取不到。
+            // Delta 不透传（无需参数实时预览）；Ready 与 Running 几乎同时，走 Running 即可。
+            is TurnEvent.ToolCallStarted -> LlmStreamEvent.ToolPending(
+                ToolCallStatus(
+                    callId = event.callId.ifEmpty { null },
+                    name = event.toolName,
+                )
+            )
+
+            is TurnEvent.ToolCallDelta, is TurnEvent.ToolCallReady,
             is TurnEvent.RetryScheduled -> null
 
             // 用户停止：不映射为错误事件（停止由消费端 cancel 表达）；

--- a/agent-runtime/src/test/java/com/niki914/zafiro/chat/agentic/stream/LlmStreamEventMapperTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/zafiro/chat/agentic/stream/LlmStreamEventMapperTest.kt
@@ -194,19 +194,28 @@ class LlmStreamEventMapperTest {
         assertEquals("failed", (result as LlmStreamEvent.ToolFailed).message)
     }
 
-    // ── 工具意图阶段不发射（无 UI 消费端） ────────────────────────────────────
+    // ── 工具意图阶段：Started 透传占位，Delta/Ready/Retry 丢弃 ────────────────
 
     @Test
-    fun `ToolCall intent and Retry events are dropped`() {
+    fun `ToolCallStarted maps to ToolPending and other intent events are dropped`() {
         val partial = AssistantMessage(emptyList())
         val call = ContentBlock.ToolCall("c", "t", "{}")
-        val events = listOf(
-            TurnEvent.ToolCallStarted(0, partial),
+
+        val started = LlmStreamEventMapper.map(
+            TurnEvent.ToolCallStarted(0, partial, callId = "c1", toolName = "terminal"),
+            0L,
+            "default error",
+        )
+        val pending = started as LlmStreamEvent.ToolPending
+        assertEquals("c1", pending.call.callId)
+        assertEquals("terminal", pending.call.name)
+
+        val dropped = listOf(
             TurnEvent.ToolCallDelta(0, "{}", partial),
             TurnEvent.ToolCallReady(0, call, partial),
             TurnEvent.RetryScheduled(1, 3, 100L, "rate limit"),
         )
-        events.forEach {
+        dropped.forEach {
             assertNull(LlmStreamEventMapper.map(it, 0L, "default error"))
         }
     }

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/CollapsibleBlock.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/CollapsibleBlock.kt
@@ -1,15 +1,20 @@
 package com.niki914.zafiro.app.ui.content
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
-import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
@@ -18,10 +23,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -32,7 +39,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import com.niki914.uikit.infra.shape.G2FieldShape
 
 // ── 块 UI 密度参数表（折叠块 + 命令型工具正文 + turn 分隔共用）────────────────
 // 调视觉密度只改这一处；使用处按名引用或组合计算（如 TurnSeparator - BlockSpacing），
@@ -41,12 +50,20 @@ internal val TurnSeparator = 42.dp    // turn 分隔总间距：UserMsg→agent 
 internal val BlockSpacing = 12.dp      // 统一块间距：turn 内块间、头部↔展开内容、多工具链行间、命令↔输出缝隙
 internal val UserBubbleGap = 3.dp      // 连续 User 气泡组内间隙（纯 User turn 间 LazyColumn item 顶距）
 // ======
-internal val BlockRowInset = 6.dp     // 折叠行左右内收
-internal val BlockContentInset = 12.dp // 展开内容左右内收（比头部宽，展示更多）
-internal val BlockRowGap = 8.dp       // 折叠行 icon↔标题、标题↔箭头
-internal val BlockRowIcon = 13.dp     // 折叠行图标
-internal val BlockRowChevron = 14.dp  // 折叠行箭头
-internal val BlockSpinnerSize = 11.dp // 运行中 spinner
+internal val BlockHeaderInsetCollapsed = 16.dp // 呼吸：收起态 header 水平内收（收得深）
+internal val BlockHeaderInsetExpanded = 12.dp  // 呼吸：展开态 header 水平放开；header 左右 padding 下限 12dp
+internal val BlockContainerPadY = 12.dp   // 容器纵向内收（折叠行上下呼吸；卡片底部对称基准）
+internal val BlockIconDot = 24.dp        // 图标 tonal 底 / 尾部槽位
+internal val BlockRowGap = 8.dp          // 图标↔标题、标题↔尾部
+internal val BlockRowIcon = 13.dp        // 折叠行图标
+internal val BlockRowChevron = 18.dp     // 折叠行箭头（与 loader / 左图标视觉相近）
+internal val BlockLoaderSize = 20.dp     // 运行中 M3E LoadingIndicator（装在尾部圆底内）
+
+// 展开内容左右内收 = 展开态左右圆底中线（headerInset + 圆底半径），由常量推导、不另设魔法数字。
+// 收起态圆底中线 = BlockHeaderInsetCollapsed + BlockIconDot / 2，随呼吸动画移动，不用于对齐。
+internal val BlockContentInset = BlockHeaderInsetExpanded + BlockIconDot / 2
+internal val BlockContentTopGap = BlockContainerPadY // 标题底部→内容顶部 = 标题顶部→卡缘，纵向节奏均一（12-12-12）
+internal val BlockContentBottomGap = BlockContainerPadY // 展开内容离容器下缘 = header 上方内收，上下对称
 internal val CommandPanelPadX = 12.dp // 命令面板左右内收
 internal val CopyBtnGap = 6.dp        // 面板内容 / 文本 ↔ 复制按钮 的邻近间隙
 internal val CommandRowPadY = 4.dp    // 命令行纵向
@@ -56,21 +73,38 @@ internal val CopyBtnSize = 26.dp      // 复制按钮
 internal val CopyIconSize = 14.dp     // 复制图标
 internal val ResultScrollMaxHeight = 102.dp // 工具结果/思考正文滚动高度上限
 
-/** 展开正文颜色
- * （thinking/skill 兜底共用：onSurfaceVariant.copy(alpha = 这里)）；
- * 取值需浅于折叠行（0.7）。调色只改这一处。
- */
-internal val BlockBodyAlpha = 0.6f
+// 块正文统一色规则：onSurfaceVariant 满值（不叠 alpha）。
+// 层级三档：收起行 variant×0.7 < 块内正文 variant < 助手回答 onSurface。
+// 输出/思考的区分由等宽字体承担，亮度不参与表意。
+
+// ── 容器 shape morph 圆角 ───────────────────────────────────────────────────
+
+/** 折叠常态圆角（偏胶囊的对话气泡感）。 */
+private val BlockRadiusCollapsed = 24.dp
+
+/** 按压圆角：向胶囊进一步形变，反馈「可按」。 */
+private val BlockRadiusPressed = 30.dp
+
+/** 展开圆角：容器变大后取更平的圆角，呈现「内容住进容器」。 */
+private val BlockRadiusExpanded = 18.dp
+
+private val BlockExpandSpring = spring<IntSize>(dampingRatio = 0.9f, stiffness = Spring.StiffnessMediumLow)
 
 /**
- * THINKING / TOOLING 共用折叠块：左图标 + 标题（过长右侧省略），点击展开；头部相对正文内收 6dp。
- * 展开内容左缘对齐 icon 中线、右缘对齐箭头中线（比头部更宽，展示更多内容）。
- * [isRunning] 为 true 时右上角显示 spinner（工具执行中），否则显示箭头。
- * 显隐动画：纯匀速展开/收缩（无 fade、无弹性），短时长。
- *
- * 折叠行变浅方案：不换色 token，前景统一 onSurfaceVariant.copy(alpha=0.7f)（淡文本色降透明度），
- * 字号 labelLarge；展开内容相应收敛（padding 12dp），保持"内容比行大"的层级。
+ * THINKING / TOOLING 共用折叠块（M3 Expressive）：
+ * - Shape morphing：按压圆角 24→30dp（向胶囊形变）+ 0.97 缩放；展开后容器驻留
+ *   （surfaceContainerLow）、圆角收敛 18dp；圆角全程 spring。
+ * - State layer：按压时容器浮现（alpha 驱动）替代 ripple（indication = null）。
+ * - 展开/收起为 spring（expandVertically + fade），与 chevron、多工具链 stagger 同语言。
+ * - [isRunning] 时尾部为 M3E LoadingIndicator（与 composer 发送按钮一致），与 chevron 共用圆底槽位。
+ * - 呼吸：header 水平内收收起 16dp ↔ 展开 12dp（spring，与圆角 morph 同步）。
+ *   展开内容左右 = BlockContentInset = 展开态左右圆底中线（由常量推导，恢复中线对齐）。
+ * - 折叠行上下 BlockContainerPadY（12dp）；标题下方 BlockContentTopGap 与内容下缘
+ *   BlockContentBottomGap 同取 PadY：标题上方 / 标题下方 / 内容下缘三段等距。
+ * - 首尾槽位同为 24dp tonal 圆底，左右对称。
+ * 块正文统一色：收起行 variant×0.7，块内正文 variant 满值，回答 onSurface。
  */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun CollapsibleBlock(
     icon: ImageVector,
@@ -81,69 +115,138 @@ fun CollapsibleBlock(
     isRunning: Boolean = false,
     content: @Composable ColumnScope.() -> Unit = {},
 ) {
-    // 折叠行前景：淡文本色降透明度（用户选定：只调 alpha 变浅，不换 token）
-    val contentColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
-    val chevron by animateFloatAsState(
+    val interaction = remember { MutableInteractionSource() }
+    val pressed by interaction.collectIsPressedAsState()
+
+    val radiusDp by animateDpAsState(
+        targetValue = when {
+            pressed -> BlockRadiusPressed
+            isExpanded -> BlockRadiusExpanded
+            else -> BlockRadiusCollapsed
+        },
+        animationSpec = spring(dampingRatio = 0.75f, stiffness = Spring.StiffnessMediumLow),
+        label = "blockRadius",
+    )
+    val scale by animateFloatAsState(
+        targetValue = if (pressed) 0.97f else 1f,
+        animationSpec = spring(dampingRatio = 0.6f, stiffness = Spring.StiffnessMedium),
+        label = "blockScale",
+    )
+    val surfaceAlpha by animateFloatAsState(
+        targetValue = when {
+            isExpanded -> 1f
+            pressed -> 0.65f
+            else -> 0f
+        },
+        animationSpec = spring(dampingRatio = 1f, stiffness = Spring.StiffnessMedium),
+        label = "blockSurface",
+    )
+    val titleColor by animateColorAsState(
+        targetValue = if (isExpanded) {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        } else {
+            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+        },
+        animationSpec = spring(dampingRatio = 1f, stiffness = Spring.StiffnessMedium),
+        label = "blockTitle",
+    )
+    val chevronRotation by animateFloatAsState(
         targetValue = if (isExpanded) 90f else 0f,
         animationSpec = spring(dampingRatio = 0.8f, stiffness = Spring.StiffnessMedium),
         label = "chevron",
     )
+    // 呼吸：header 水平内收随展开放开（收 14dp ↔ 放 8dp），与圆角 morph 同一动作
+    val headerInset by animateDpAsState(
+        targetValue = if (isExpanded) BlockHeaderInsetExpanded else BlockHeaderInsetCollapsed,
+        animationSpec = spring(dampingRatio = 0.75f, stiffness = Spring.StiffnessMediumLow),
+        label = "headerInset",
+    )
+
+    val shape = remember(radiusDp) { G2FieldShape(radiusDp) }
+    val surface = MaterialTheme.colorScheme.surfaceContainerLow
 
     Column(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+            }
+            .background(surface.copy(alpha = surfaceAlpha), shape)
+            .clickable(
+                interactionSource = interaction,
+                indication = null,
+                onClick = onToggle,
+            )
+            .padding(vertical = BlockContainerPadY),
     ) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                    onClick = onToggle,
-                )
-                .padding(horizontal = BlockRowInset),
             verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = headerInset),
         ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                modifier = Modifier.size(BlockRowIcon),
-                tint = contentColor,
-            )
+            Box(
+                modifier = Modifier
+                    .size(BlockIconDot)
+                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f), CircleShape),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(BlockRowIcon),
+                    tint = titleColor,
+                )
+            }
             Spacer(modifier = Modifier.width(BlockRowGap))
             Text(
                 text = title,
                 style = MaterialTheme.typography.labelLarge,
-                color = contentColor,
+                color = titleColor,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f),
             )
             Spacer(modifier = Modifier.width(BlockRowGap))
-            if (isRunning) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(BlockSpinnerSize),
-                    strokeWidth = 1.5.dp,
-                    color = contentColor.copy(alpha = 0.6f),
-                )
-            } else {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                    contentDescription = null,
-                    tint = contentColor.copy(alpha = 0.6f),
-                    modifier = Modifier
-                        .size(BlockRowChevron)
-                        .graphicsLayer { rotationZ = chevron },
-                )
+            // 尾部槽位：tonal 圆底与左图标对称，内容在 chevron（完成）↔ loader（运行中）间切换
+            Box(
+                modifier = Modifier
+                    .size(BlockIconDot)
+                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f), CircleShape),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (isRunning) {
+                    LoadingIndicator(
+                        modifier = Modifier.size(BlockLoaderSize),
+                        color = titleColor,
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        contentDescription = null,
+                        tint = titleColor.copy(alpha = 0.6f),
+                        modifier = Modifier
+                            .size(BlockRowChevron)
+                            .graphicsLayer { rotationZ = chevronRotation },
+                    )
+                }
             }
         }
         AnimatedVisibility(
             visible = isExpanded,
-            enter = expandVertically(animationSpec = tween(160, easing = LinearEasing)),
-            exit = shrinkVertically(animationSpec = tween(160, easing = LinearEasing)),
+            enter = expandVertically(BlockExpandSpring) +
+                fadeIn(spring(dampingRatio = 1f, stiffness = Spring.StiffnessMediumLow)),
+            exit = shrinkVertically(BlockExpandSpring) +
+                fadeOut(spring(dampingRatio = 1f, stiffness = Spring.StiffnessMedium)),
         ) {
-            // 展开内容：左缘对齐 icon 中线（6 + 13/2 ≈ 12.5）、右缘对齐箭头中线（6 + 14/2 = 13）
-            // 统一 12dp；top = BlockSpacing：头部与内容间间距与块间/行间一致（padding 放在收起态高度为 0 的内容内，折叠时不产生幻影空隙）
-            Column(modifier = Modifier.padding(start = BlockContentInset, end = BlockContentInset, top = BlockSpacing)) {
+            Column(
+                modifier = Modifier
+                    .padding(
+                        start = BlockContentInset,
+                        end = BlockContentInset,
+                        top = BlockContentTopGap,
+                        bottom = BlockContentBottomGap,
+                    ),
+            ) {
                 content()
             }
         }

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
@@ -828,7 +828,7 @@ private fun HomeChatTurnItem(
                                         ToolResultText(
                                             text = block.text,
                                             style = MaterialTheme.typography.bodySmall,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = BlockBodyAlpha),
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                                             // active 思考块展开时滚到底跟随；用户可手动滚动不锁
                                             autoScrollToEnd = isThinkingExpanded && thinkingKey == activeThinkingKey,
                                         )

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/ToolChain.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/ToolChain.kt
@@ -234,7 +234,7 @@ private fun CodeToolBody(
             Text(
                 text = command,
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f),
@@ -267,7 +267,8 @@ private fun CodeToolBody(
                 color = if (isError) {
                     MaterialTheme.colorScheme.error
                 } else {
-                    MaterialTheme.colorScheme.onSurface
+                    // 块正文统一 onSurfaceVariant 满值（见 CollapsibleBlock.kt 色彩规则）
+                    MaterialTheme.colorScheme.onSurfaceVariant
                 },
                 maxLines = 6,
                 overflow = TextOverflow.Ellipsis,
@@ -322,8 +323,7 @@ private fun FallbackResultBody(isFailed: Boolean) {
         color = if (isFailed) {
             MaterialTheme.colorScheme.error
         } else {
-            // 与 Thinking 正文同款淡文本色（onSurface → onSurfaceVariant 降 alpha）
-            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = BlockBodyAlpha)
+            MaterialTheme.colorScheme.onSurfaceVariant
         },
     )
 }
@@ -348,7 +348,7 @@ private fun ResultTextBody(text: String) {
         ToolResultText(
             text = text,
             style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
-            color = MaterialTheme.colorScheme.onSurface,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
 }

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/HomeChatState.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/HomeChatState.kt
@@ -447,8 +447,14 @@ class HomeChatViewModel internal constructor(
                 updateState { copy(activeThinkingKey = null) }
             }
 
+            is LlmStreamEvent.ToolPending -> updateTurn(turnId) {
+                // 占位行：仅名字已知，Running 态转圈、不可展开；后续 ToolRunning 按 callId 原地更新
+                it.updateTool(event.call, HomeToolState.Running)
+            }
+
             is LlmStreamEvent.ToolRunning -> updateTurn(turnId) {
-                it.appendTool(event.call, HomeToolState.Running)
+                // updateTool 而非 appendTool：参数构建期可能已插入占位行，按 callId 原地更新
+                it.updateTool(event.call, HomeToolState.Running)
             }
 
             is LlmStreamEvent.ToolSucceeded -> updateTurn(turnId) {
@@ -847,12 +853,13 @@ class HomeChatViewModel internal constructor(
     }
 
     private fun HomeChatTurn.findToolBlockIndex(callId: String?, label: String): Int {
+        // 有 id 的调用只按 id 精确匹配：miss 即新调用（同名工具并发时不可互相覆盖），不落入无名兕底
         if (callId != null) {
-            val exactMatch = blocks.indexOfLast { block ->
+            return blocks.indexOfLast { block ->
                 block is HomeChatBlock.Tool && block.status.callId == callId
             }
-            if (exactMatch != -1) return exactMatch
         }
+        // 无 id 的调用才按「无名块 + 同名」匹配（不提供 callId 的接入路径）
         return blocks.indexOfLast { block ->
             block is HomeChatBlock.Tool && block.status.callId == null && block.status.name == label
         }
@@ -876,6 +883,7 @@ class HomeChatViewModel internal constructor(
         is LlmStreamEvent.ThinkingStarted -> "ThinkingStarted"
         is LlmStreamEvent.ThinkingEnded -> "ThinkingEnded"
         is LlmStreamEvent.ToolRunning -> "ToolRunning"
+        is LlmStreamEvent.ToolPending -> "ToolPending"
         is LlmStreamEvent.ToolSucceeded -> "ToolSucceeded"
         is LlmStreamEvent.ToolFailed -> "ToolFailed"
         is LlmStreamEvent.Error -> "Error"

--- a/app/src/main/java/com/niki914/zafiro/chat/LlmStreamCollectors.kt
+++ b/app/src/main/java/com/niki914/zafiro/chat/LlmStreamCollectors.kt
@@ -121,6 +121,8 @@ private class FullTextProjector(
                 listOf(LlmTextFrame(renderSegments(), isFirst = false, isFinal = false))
             }
 
+            is LlmStreamEvent.ToolPending -> listOf()
+
             is LlmStreamEvent.ToolRunning -> {
                 upsertTool(event.call, labels.called)
                 val calledFrame = LlmTextFrame(renderSegments(), isFirst = false, isFinal = false)
@@ -223,6 +225,8 @@ private class ChunkTextProjector(
                 }
                 listOf(LlmTextFrame(fullText.toString(), isFirst = false, isFinal = false))
             }
+
+            is LlmStreamEvent.ToolPending -> listOf()
 
             is LlmStreamEvent.ToolRunning -> {
                 appendToolLine(event.call, labels.called)

--- a/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
@@ -323,6 +323,7 @@ object XRepo {
     internal fun seedPyToolDefaults(context: Context): List<CustomPyTool> =
         listOf(
             seedWebSearchTool(context),
+            seedWebReadTool(context),
             seedLaunchWechatTool(context),
             seedInstallApkTool(context),
         )
@@ -333,6 +334,17 @@ object XRepo {
         description = "Search the web (default: multi-engine merge of Baidu + Sogou + DuckDuckGo; or engine=baidu/sogou/ddg). Returns a list of {title, url, snippet}.",
         schemaJson = SCHEMA_WEB_SEARCH,
         code = readRawResource(context, R.raw.seed_py_web_search),
+    )
+
+    private val SCHEMA_WEB_READ =
+        """{"type":"object","properties":{"url":{"type":"string","description":"Page URL"},"keyword":{"type":"string","description":"Return only the section around this keyword"},"max_chars":{"type":"integer","description":"Max characters to return (default 6000)"},"timeout":{"type":"integer","description":"HTTP timeout seconds (default 25)"}},"required":["url"]}"""
+
+    // 抓取网页正文：与 py_web_search 配套，搜索只给摘要时读全文。
+    private fun seedWebReadTool(context: Context) = CustomPyTool(
+        name = "py_web_read",
+        description = "Fetch a URL and extract readable article text. Optional keyword returns only the section around it. Companion to py_web_search when snippets are not enough.",
+        schemaJson = SCHEMA_WEB_READ,
+        code = readRawResource(context, R.raw.seed_py_web_read),
     )
 
     private fun seedLaunchWechatTool(context: Context) = CustomPyTool(

--- a/app/src/main/res/raw/seed_py_web_read.py
+++ b/app/src/main/res/raw/seed_py_web_read.py
@@ -1,0 +1,110 @@
+# Seed tool: fetch a URL and extract readable article text (companion to py_web_search,
+# use when search only gives snippets and the full page is needed).
+# ponytail: article-container selectors break on site redesigns; Agent can self-update this script.
+import re
+import html
+import requests
+
+
+def _clean(s: str) -> str:
+    s = re.sub(r'[ \t\u00a0\u3000]+', ' ', s)
+    s = re.sub(r'\n\s*\n+', '\n', s)
+    return '\n'.join(line.strip() for line in s.split('\n') if line.strip())
+
+
+def _extract_article(raw: str) -> str:
+    # 1) <article> block
+    m = re.search(r'<article\b[\s\S]*?</article>', raw, re.I)
+    if m:
+        return m.group(0)
+
+    # 2) common article container div, depth-aware closing match
+    m = re.search(
+        r'<div\b[^>]*(?:art_content|artibody|article-content|article_content|article|content)[^>]*>',
+        raw, re.I,
+    )
+    if m:
+        start = m.start()
+        depth = 0
+        i = start
+        while i < len(raw):
+            op = re.match(r'<div\b[^>]*>', raw[i:], re.I)
+            cl = re.match(r'</div\s*>', raw[i:], re.I)
+            if cl:
+                depth -= 1
+                if depth <= 0:
+                    return raw[start:i + cl.end()]
+                i += cl.end()
+                continue
+            if op:
+                tag = op.group(0)
+                if not tag.rstrip().endswith('/>'):
+                    depth += 1
+                i += op.end()
+                continue
+            i += 1
+        return raw[start:]
+
+    # 3) <body> fallback
+    m = re.search(r'<body\b[\s\S]*?</body>', raw, re.I)
+    if m:
+        return m.group(0)
+
+    return raw
+
+
+def _decoded_text(r) -> str:
+    enc = None
+    m = re.search(r'charset=["\']?([\w-]+)', r.headers.get('Content-Type', ''), re.I)
+    if m:
+        enc = m.group(1)
+    if not enc:
+        m = re.search(r'<meta[^>]+charset=["\']?([\w-]+)', r.text[:2000], re.I)
+        if m:
+            enc = m.group(1)
+    candidates = [enc, 'utf-8', 'gb18030']
+    for c in candidates:
+        if not c:
+            continue
+        try:
+            r.encoding = c
+            return r.text
+        except Exception:
+            continue
+    return r.text
+
+
+def main(url: str, keyword: str = "", max_chars: int = 6000, timeout: int = 25):
+    """抓取网页并提取可读正文。可选 keyword：只返回关键词附近的一整段文本（定位到后前后各取一半 max_chars）。
+    当 py_web_search 只给摘要、需要读全文时使用。"""
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Linux; Android 12; Pixel 6) AppleWebKit/537.36 '
+                      '(KHTML, like Gecko) Chrome/120.0 Mobile Safari/537.36',
+        'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
+    }
+    r = requests.get(url, headers=headers, timeout=timeout)
+    r.raise_for_status()
+    raw = _decoded_text(r)
+
+    # strip noisy blocks
+    raw = re.sub(r'<(script|style|noscript|iframe|svg)[\s\S]*?</\1>', ' ', raw, flags=re.I)
+    raw = re.sub(r'<head[\s\S]*?</head>', ' ', raw, flags=re.I)
+
+    body = _extract_article(raw)
+    body = re.sub(r'<(script|style|noscript)[\s\S]*?</\1>', ' ', body, flags=re.I)
+
+    text = re.sub(r'<[^>]+>', '\n', body)
+    text = html.unescape(text)
+    text = _clean(text)
+
+    if keyword:
+        idx = text.lower().find(keyword.lower())
+        if idx >= 0:
+            start = max(0, idx - max_chars // 2)
+            text = text[start:start + max_chars]
+        else:
+            text = text[:max_chars]
+    else:
+        text = text[:max_chars]
+
+    print(text)

--- a/app/src/test/java/com/niki914/zafiro/app/ui/model/HomeChatControllerTest.kt
+++ b/app/src/test/java/com/niki914/zafiro/app/ui/model/HomeChatControllerTest.kt
@@ -495,6 +495,48 @@ class HomeChatViewModelTest {
     }
 
     @Test
+    fun toolPending_insertsPlaceholderAndToolRunningUpdatesInPlace() = runTest {
+        val conversations = FakeHomeConversationStore()
+        val viewModel = HomeChatViewModel(
+            conversations = conversations,
+            runtime = FakeHomeChatRuntime(stream = {
+                flowOf(
+                    LlmStreamEvent.RoundStarted,
+                    LlmStreamEvent.ToolPending(
+                        ToolCallStatus(callId = "c1", name = "terminal", label = "terminal")
+                    ),
+                    LlmStreamEvent.ToolRunning(
+                        ToolCallStatus(
+                            callId = "c1",
+                            name = "terminal",
+                            label = "terminal",
+                            argumentsJson = """{"command":"ls"}""",
+                        )
+                    ),
+                    LlmStreamEvent.Completed,
+                )
+            }),
+        )
+
+        viewModel.sendIntent(HomeChatIntent.InputChanged("hello"))
+        runCurrent()
+        viewModel.sendIntent(HomeChatIntent.Send)
+        advanceUntilIdle()
+
+        // 占位行被 ToolRunning 原地更新，不产生重复块
+        val toolBlocks =
+            viewModel.uiStateFlow.value.turns.single().blocks.filterIsInstance<HomeChatBlock.Tool>()
+        assertEquals(1, toolBlocks.size)
+        assertEquals("c1", toolBlocks.single().status.callId)
+        assertEquals(HomeToolState.Running, toolBlocks.single().status.state)
+        // inputText 经 ToolPresentation.inputOf 提取：terminal 取 command 字段
+        assertEquals("ls", toolBlocks.single().status.inputText)
+
+        viewModel.sendIntent(HomeChatIntent.NewConversation)
+        advanceUntilIdle()
+    }
+
+    @Test
     fun completed_keepsConversationAndLastOpenedId() = runTest {
         val conversations = FakeHomeConversationStore()
         val viewModel = HomeChatViewModel(

--- a/libs/okia/src/main/java/com/niki914/okia/event/TurnEvent.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/event/TurnEvent.kt
@@ -40,8 +40,14 @@ sealed interface TurnEvent {
     /** contentIndex 处思考块完成。 */
     data class ThinkingEnded(val index: Int, val content: String, val partial: AssistantMessage) : TurnEvent
 
-    /** contentIndex 处工具调用块开始。 */
-    data class ToolCallStarted(val index: Int, val partial: AssistantMessage) : TurnEvent
+    /** contentIndex 处工具调用块开始。携带发起中的调用身份（参数在途，可能为空）。
+     *  注意：此时调用尚未进入 partial.content（仍为 pendingToolCalls），身份只能从事件字段取。 */
+    data class ToolCallStarted(
+        val index: Int,
+        val partial: AssistantMessage,
+        val callId: String = "",
+        val toolName: String = "",
+    ) : TurnEvent
 
     /** contentIndex 处工具调用参数 delta。 */
     data class ToolCallDelta(val index: Int, val delta: String, val partial: AssistantMessage) : TurnEvent

--- a/libs/okia/src/main/java/com/niki914/okia/loop/RealAgentLoop.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/loop/RealAgentLoop.kt
@@ -454,7 +454,9 @@ internal class RealAgentLoop : AgentLoop {
                 onEvent(
                     TurnEvent.ToolCallStarted(
                         toolCallIndex(state, state.pendingToolCalls.lastIndex),
-                        state.partialMessage()
+                        state.partialMessage(),
+                        callId = event.callId,
+                        toolName = event.toolName,
                     )
                 )
             }


### PR DESCRIPTION
## Summary

- **M3 Expressive collapsible blocks**: G2 container with spring shape morphing (press 24→30dp, expand 24→18dp), press state layer, breathing header inset (16↔12dp), symmetric vertical rhythm derived from `BlockContainerPadY`, content aligned to icon-dot midlines, M3E `LoadingIndicator` for running tools, unified block body color to `onSurfaceVariant`
- **py_web_read seed tool**: fetch a URL and extract readable article text; optional keyword returns the surrounding section. Companion to `py_web_search` when snippets are not enough
- **Streaming tool placeholder**: `TurnEvent.ToolCallStarted` now carries `callId`/`toolName` (identity was dropped at the loop layer), so the mapper can emit `ToolPending` the moment the model starts building a call — the home UI shows a running placeholder row updated in place when execution starts, instead of a blank screen during large-argument generation

## Test plan

- [x] `:app`, `:libs:okia`, `:agent-runtime` unit tests pass
- [x] New tests: pending→running in-place upsert, mapper ToolPending mapping, tool block exact-id matching
- [x] Manual on-device check: placeholder spinner appears during argument generation