### PR TITLE
fix: app name matching across locales and app-launch tooling

### DIFF
--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/BuiltinToolRegistry.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/BuiltinToolRegistry.kt
@@ -1,6 +1,7 @@
 package com.niki914.zafiro.chat.agentic.buildin
 
 import com.niki914.zafiro.chat.agentic.buildin.impl.ExecutePythonBuiltin
+import com.niki914.zafiro.chat.agentic.buildin.impl.FindInstalledAppsBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.LaunchAppBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.LoadSkillBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.PyMetaToolsBuiltin
@@ -9,7 +10,6 @@ import com.niki914.zafiro.chat.agentic.buildin.impl.NotifyBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.OpenUriBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.ScreenOperationAccessibilityBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.ScreenOperationShellBuiltin
-import com.niki914.zafiro.chat.agentic.buildin.impl.SearchAppsBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.TerminalBuiltin
 
 class BuiltinToolRegistry(
@@ -32,7 +32,7 @@ class BuiltinToolRegistry(
                 OpenUriBuiltin(),
                 LoadSkillBuiltin(),
                 TerminalBuiltin(),
-                SearchAppsBuiltin(),
+                FindInstalledAppsBuiltin(),
                 ScreenOperationAccessibilityBuiltin(),
                 ScreenOperationShellBuiltin(),
             )

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/FindInstalledAppsBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/FindInstalledAppsBuiltin.kt
@@ -16,15 +16,15 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
 
-class SearchAppsBuiltin : BuiltinTool() {
-    override val name: String = "search_apps"
+class FindInstalledAppsBuiltin : BuiltinTool() {
+    override val name: String = "find_installed_apps"
 
     override val description: String =
-        "Search installed Android apps by app name or package name. Use this before launch_app when the requested app name may be ambiguous."
+        "Find installed apps on this device by app name or package name. Serves opening apps only: use it to resolve which app to open. Not a general search tool."
 
     override val defaultEnabled: Boolean = true
 
-    override val inputSchemaJson: String? get() = SEARCH_APPS_SCHEMA
+    override val inputSchemaJson: String? get() = FIND_INSTALLED_APPS_SCHEMA
 
     override suspend fun invoke(request: BuiltinToolRequest): BuiltinToolResult {
         val args = try {
@@ -35,7 +35,7 @@ class SearchAppsBuiltin : BuiltinTool() {
             }
             return BuiltinToolResult.failure(
                 code = "INVALID_ARGUMENTS_JSON",
-                message = "search_apps arguments must be a JSON object with a query field.",
+                message = "find_installed_apps arguments must be a JSON object with a query field.",
                 hint = """Example: {"query":"微信","include_system":false,"limit":10}""",
                 fieldErrors = mapOf(
                     "argumentsJson" to (throwable.message ?: "Invalid JSON object.")
@@ -46,7 +46,7 @@ class SearchAppsBuiltin : BuiltinTool() {
         if (args.query.isBlank()) {
             return BuiltinToolResult.failure(
                 code = "MISSING_REQUIRED_FIELD",
-                message = "search_apps requires a non-blank query.",
+                message = "find_installed_apps requires a non-blank query.",
                 fieldErrors = mapOf("query" to "Field 'query' must not be blank."),
             )
         }
@@ -68,7 +68,7 @@ class SearchAppsBuiltin : BuiltinTool() {
         )
     }
 
-    private fun parseArguments(argumentsJson: String): SearchAppsArguments {
+    private fun parseArguments(argumentsJson: String): FindInstalledAppsArguments {
         val element = try {
             Json.parseToJsonElement(argumentsJson)
         } catch (throwable: SerializationException) {
@@ -78,7 +78,7 @@ class SearchAppsBuiltin : BuiltinTool() {
         }
         val obj = element as? JsonObject
             ?: throw IllegalArgumentException("argumentsJson must be a JSON object.")
-        return SearchAppsArguments(
+        return FindInstalledAppsArguments(
             query = obj.string("query").trim(),
             includeSystem = obj["include_system"]?.jsonPrimitive?.booleanOrNull ?: false,
             limit = obj["limit"]?.jsonPrimitive?.intOrNull ?: DEFAULT_LIMIT,
@@ -103,7 +103,7 @@ class SearchAppsBuiltin : BuiltinTool() {
         return this[key]?.jsonPrimitive?.contentOrNull.orEmpty()
     }
 
-    private data class SearchAppsArguments(
+    private data class FindInstalledAppsArguments(
         val query: String,
         val includeSystem: Boolean,
         val limit: Int,
@@ -111,13 +111,13 @@ class SearchAppsBuiltin : BuiltinTool() {
 
     companion object {
         private const val DEFAULT_LIMIT = 10
-        private const val SEARCH_APPS_SCHEMA = """
+        private const val FIND_INSTALLED_APPS_SCHEMA = """
             {
               "type": "object",
               "properties": {
                 "query": {
                   "type": "string",
-                  "description": "App name or package name fragment to search."
+                  "description": "App name or package name fragment to resolve."
                 },
                 "include_system": {
                   "type": "boolean",

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/LaunchAppBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/LaunchAppBuiltin.kt
@@ -81,7 +81,7 @@ class LaunchAppBuiltin : BuiltinTool() {
             AppMatchResult.NotFound -> BuiltinToolResult.failure(
                 code = "APP_NOT_FOUND",
                 message = "No installed app matches '$appName'.",
-                hint = "Try search_apps with a broader query.",
+                hint = "The app may be installed under a different name. Retry with an alternative name, or ask the user which app to open.",
                 data = JsonObject(mapOf("app_name" to JsonPrimitive(appName))),
             )
         }

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/device/AppInfoCache.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/device/AppInfoCache.kt
@@ -5,17 +5,25 @@ import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
+import android.content.res.Configuration
 import android.os.Build
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 
 data class AppInfo(
     val packageName: String,
     val appName: String,
     val isSystemApp: Boolean,
+
+    /**
+     * 多语言标签全集（系统默认 + zh-CN/zh-TW/en/ja/es），匹配层用；
+     * appName 仍是系统语言标签，用于展示与排序。
+     */
+    val labels: Set<String> = setOf(appName),
 )
 
 sealed interface AppMatchResult {
@@ -34,7 +42,7 @@ object AppInfoMatcher {
             return AppMatchResult.NotFound
         }
 
-        val exactMatches = apps.filter { it.appName.lowercase() == query }
+        val exactMatches = apps.filter { it.matches { label -> label == query } }
         if (exactMatches.isNotEmpty()) {
             return when (exactMatches.size) {
                 1 -> AppMatchResult.Found(exactMatches.first())
@@ -42,12 +50,24 @@ object AppInfoMatcher {
             }
         }
 
-        val candidates = apps.filter { it.appName.lowercase().contains(query) }
+        val prefixMatches = apps.filter { it.matches { label -> label.startsWith(query) } }
+        if (prefixMatches.isNotEmpty()) {
+            return when (prefixMatches.size) {
+                1 -> AppMatchResult.Found(prefixMatches.first())
+                else -> AppMatchResult.Candidates(prefixMatches)
+            }
+        }
+
+        // 仅包含命中属于弱匹配：即使唯一也返回候选，由模型裁决，避免“微信”误启动“微信输入法”类产品族子串。
+        val candidates = apps.filter { it.matches { label -> label.contains(query) } }
         return when (candidates.size) {
             0 -> AppMatchResult.NotFound
-            1 -> AppMatchResult.Found(candidates.first())
             else -> AppMatchResult.Candidates(candidates)
         }
+    }
+
+    private fun AppInfo.matches(predicate: (String) -> Boolean): Boolean {
+        return labels.any { predicate(it.lowercase()) }
     }
 }
 
@@ -85,7 +105,7 @@ class AppInfoCache(
             .asSequence()
             .filter { includeSystem || !it.isSystemApp }
             .filter {
-                it.appName.lowercase().contains(normalizedQuery) ||
+                it.labels.any { label -> label.lowercase().contains(normalizedQuery) } ||
                         it.packageName.lowercase().contains(normalizedQuery)
             }
             .sortedWith(compareBy<AppInfo> { it.isSystemApp }.thenBy { it.appName.lowercase() })
@@ -143,13 +163,47 @@ class AppInfoCache(
                 packageName = appInfo.packageName,
                 appName = loadLabel(packageManager).toString(),
                 isSystemApp = (appInfo.flags and ApplicationInfo.FLAG_SYSTEM) != 0,
+                labels = loadLabels(appInfo),
             )
         } catch (_: Throwable) {
             null
         }
     }
 
+    /** 按固定语言槽位加载标签；无对应语言资源时回退该应用默认语言的字符串，去重后入集。 */
+    private fun loadLabels(appInfo: ApplicationInfo): Set<String> {
+        val labels = LinkedHashSet<String>()
+        appInfo.nonLocalizedLabel?.let { labels += it.toString() }
+        if (appInfo.labelRes == 0) {
+            return labels
+        }
+        val pkgContext = try {
+            appContext.createPackageContext(appInfo.packageName, Context.CONTEXT_IGNORE_SECURITY)
+        } catch (_: Throwable) {
+            return labels
+        }
+        LABEL_LOCALES.distinctBy { it.toLanguageTag() }.forEach { locale ->
+            try {
+                val config = Configuration().apply { setLocale(locale) }
+                labels += pkgContext.createConfigurationContext(config).getString(appInfo.labelRes)
+            } catch (_: Throwable) {
+                // 单个语言资源异常不影响其余槽位
+            }
+        }
+        return labels
+    }
+
     companion object {
         private const val MAX_SEARCH_LIMIT = 20
+
+        // 中文（简/繁）、英文、日语、西语覆盖主流应用命名语言；系统默认语言始终参与。
+        private val LABEL_LOCALES = listOf(
+            Locale.getDefault(),
+            Locale.SIMPLIFIED_CHINESE,
+            Locale.TRADITIONAL_CHINESE,
+            Locale.ENGLISH,
+            Locale.JAPAN,
+            Locale("es"),
+        )
     }
 }

--- a/agent-runtime/src/test/java/com/niki914/zafiro/chat/AppInfoMatcherTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/zafiro/chat/AppInfoMatcherTest.kt
@@ -24,20 +24,64 @@ class AppInfoMatcherTest {
     }
 
     @Test
-    fun matchByName_returnsFoundForSingleFuzzyMatch() {
-        val result = AppInfoMatcher.matchByName(apps, "设置")
+    fun matchByName_returnsFoundForExactNameInAnyLocale() {
+        // 英文系统场景：appName 是英文标签，中文查询经多语言标签精确命中
+        val wechat = AppInfo(
+            packageName = "com.tencent.mm",
+            appName = "WeChat",
+            isSystemApp = false,
+            labels = setOf("WeChat", "微信"),
+        )
+        val wetype = AppInfo(
+            packageName = "com.tencent.wetype",
+            appName = "微信输入法",
+            isSystemApp = false,
+            labels = setOf("微信输入法"),
+        )
 
-        assertEquals(AppMatchResult.Found(apps[2]), result)
+        val result = AppInfoMatcher.matchByName(listOf(wechat, wetype), "微信")
+
+        assertEquals(AppMatchResult.Found(wechat), result)
     }
 
     @Test
-    fun matchByName_returnsCandidatesWhenFuzzyMatchIsAmbiguous() {
-        val result = AppInfoMatcher.matchByName(apps, "音乐")
+    fun matchByName_returnsFoundForSinglePrefixMatch() {
+        val result = AppInfoMatcher.matchByName(apps, "音乐播")
+
+        assertEquals(AppMatchResult.Found(apps[3]), result)
+    }
+
+    @Test
+    fun matchByName_returnsCandidatesWhenPrefixMatchIsAmbiguous() {
+        val music = AppInfo(packageName = "com.example.music", appName = "音乐播放器", isSystemApp = false)
+        val musicPro = AppInfo(packageName = "com.example.music.pro", appName = "音乐专业版", isSystemApp = false)
+
+        val result = AppInfoMatcher.matchByName(listOf(music, musicPro), "音乐")
 
         assertTrue(result is AppMatchResult.Candidates)
-        assertEquals(
-            listOf(apps[3], apps[4]),
-            (result as AppMatchResult.Candidates).apps,
-        )
+    }
+
+    @Test
+    fun matchByName_returnsCandidatesForSingleContainsOnlyMatch() {
+        // 产品族子串：仅包含命中（非精确/前缀）时唯一候选也不直接启动，交由模型裁决
+        val wetype = AppInfo(packageName = "com.tencent.wetype", appName = "微信输入法", isSystemApp = false)
+
+        val result = AppInfoMatcher.matchByName(listOf(wetype), "信输入")
+
+        assertEquals(AppMatchResult.Candidates(listOf(wetype)), result)
+    }
+
+    @Test
+    fun matchByName_prefersExactOverWeakerTiers() {
+        val result = AppInfoMatcher.matchByName(apps, "QQ")
+
+        assertEquals(AppMatchResult.Found(apps[1]), result)
+    }
+
+    @Test
+    fun matchByName_returnsNotFoundWhenNoLabelMatches() {
+        val result = AppInfoMatcher.matchByName(apps, "邮箱")
+
+        assertEquals(AppMatchResult.NotFound, result)
     }
 }

--- a/agent-runtime/src/test/java/com/niki914/zafiro/chat/BuiltinToolTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/zafiro/chat/BuiltinToolTest.kt
@@ -2,10 +2,10 @@ package com.niki914.zafiro.chat
 
 import com.niki914.zafiro.chat.agentic.buildin.BuiltinToolRegistry
 import com.niki914.zafiro.chat.agentic.buildin.BuiltinToolResult
+import com.niki914.zafiro.chat.agentic.buildin.impl.FindInstalledAppsBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.LaunchAppBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.MemoryBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.OpenUriBuiltin
-import com.niki914.zafiro.chat.agentic.buildin.impl.SearchAppsBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.TerminalBuiltin
 import com.niki914.okia.tooling.ToolWireName
 import kotlinx.serialization.SerializationException
@@ -48,6 +48,7 @@ class BuiltinToolTest {
         assertEquals(
             listOf(
                 "execute_python",
+                "find_installed_apps",
                 "launch_app",
                 "load_skill",
                 "memory",
@@ -56,7 +57,6 @@ class BuiltinToolTest {
                 "py_meta_tools",
                 "screen_operation_accessibility",
                 "screen_operation_shell",
-                "search_apps",
                 "terminal",
             ),
             registry.all().map { it.name }.sorted()
@@ -69,7 +69,7 @@ class BuiltinToolTest {
         assertEquals("py_meta_tools", registry.find("py_meta_tools")?.name)
         assertEquals("screen_operation_accessibility", registry.find("screen_operation_accessibility")?.name)
         assertEquals("screen_operation_shell", registry.find("screen_operation_shell")?.name)
-        assertEquals("search_apps", registry.find("search_apps")?.name)
+        assertEquals("find_installed_apps", registry.find("find_installed_apps")?.name)
         assertEquals("terminal", registry.find("terminal")?.name)
     }
 
@@ -79,7 +79,7 @@ class BuiltinToolTest {
             LaunchAppBuiltin(),
             MemoryBuiltin(),
             OpenUriBuiltin(),
-            SearchAppsBuiltin(),
+            FindInstalledAppsBuiltin(),
             TerminalBuiltin(),
             com.niki914.zafiro.chat.agentic.buildin.impl.PyMetaToolsBuiltin(),
         ).forEach { tool ->

--- a/app/src/main/assets/skills/phone-use/SKILL.md
+++ b/app/src/main/assets/skills/phone-use/SKILL.md
@@ -25,7 +25,7 @@ Two auxiliary tools for app discovery and launching:
 
 | Tool | Purpose |
 |:-----|:--------|
-| `search_apps` | Search installed apps by name or package name |
+| `find_installed_apps` | Find installed apps by name or package name |
 | `launch_app` | Launch an app by package name or fuzzy app name |
 
 ## Tool Reference
@@ -42,9 +42,9 @@ Primary tool for reading the screen and interacting with labeled UI nodes. The Y
 
 **FALLBACK** — prefer `screen_operation_accessibility` when possible. All operations use screen-pixel coordinates via shell (`input tap/swipe/keyevent`). Coordinates MUST come from the most recently returned screen tree — never hallucinate coordinates. Every successful write operation auto-returns the updated YAML tree.
 
-### launch_app / search_apps
+### launch_app / find_installed_apps
 
-Launch by exact `package_name` or fuzzy `app_name`. If `app_name` matches multiple apps, the tool returns a candidate list — pick one `package_name` and call again. Use `search_apps` first when the target app name is ambiguous.
+Launch by exact `package_name` or fuzzy `app_name`. If `app_name` matches multiple apps, the tool returns a candidate list — pick one `package_name` and call again. Use `find_installed_apps` first when the target app name is ambiguous.
 
 ## Workflow
 
@@ -57,7 +57,7 @@ launch_app(app_name: "Settings")
 If ambiguous, search first then launch by package name:
 
 ```
-search_apps(query: "settings")
+find_installed_apps(query: "settings")
 launch_app(package_name: "com.android.settings")
 ```
 

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/ToolPresentation.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/ToolPresentation.kt
@@ -57,7 +57,7 @@ object ToolPresentation {
         "notify" -> R.string.ui_tool_display_notify
         "open_uri" -> R.string.ui_tool_display_open_uri
         "read_custom_tool" -> R.string.ui_tool_display_read_custom_tool
-        "search_apps" -> R.string.ui_tool_display_search_apps
+        "find_installed_apps" -> R.string.ui_tool_display_find_installed_apps
         "screen_operation_accessibility" -> R.string.ui_tool_display_screen_operation_accessibility
         "screen_operation_shell" -> R.string.ui_tool_display_screen_operation_shell
         else -> null

--- a/app/src/main/java/com/niki914/zafiro/repo/BuiltinToolGroups.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/BuiltinToolGroups.kt
@@ -38,7 +38,7 @@ object BuiltinToolGroups {
             titleRes = R.string.builtin_tool_group_android_native,
             summaryRes = R.string.builtin_tool_group_android_native_summary,
             mode = BuiltinToolGroupMode.PER_TOOL,
-            members = listOf("open_uri", "launch_app", "search_apps", "notify"),
+            members = listOf("open_uri", "launch_app", "find_installed_apps", "notify"),
         ),
         BuiltinToolGroup(
             id = "screen_operation",

--- a/app/src/main/res/raw/seed_py_launch_wechat.py
+++ b/app/src/main/res/raw/seed_py_launch_wechat.py
@@ -1,13 +1,24 @@
+import shlex
 import subprocess
+import sys
+
+
+def su_run(args, timeout=15):
+    """在 root 下执行命令；找不到 su 时抛 FileNotFoundError。"""
+    cmd = ["su", "-c", " ".join(shlex.quote(a) for a in args)]
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
 
 
 def main():
     '''启动微信 (Launch WeChat).'''
-    result = subprocess.run(
-        ["am", "start", "-n", "com.tencent.mm/com.tencent.mm.ui.LauncherUI"],
-        capture_output=True, text=True, timeout=10,
-    )
+    # 非 root 直接 am start 会 SecurityException: Permission Denied；经 su 执行，
+    # 首次调用会弹出 su 授权对话框，同意后启动。
+    try:
+        result = su_run(["am", "start", "-n", "com.tencent.mm/com.tencent.mm.ui.LauncherUI"])
+    except FileNotFoundError:
+        print("未找到 su：需要 root（Magisk / KernelSU 授权后重试）", file=sys.stderr)
+        raise SystemExit(2)
     if result.returncode != 0:
-        print(result.stderr.strip())
+        print((result.stderr or result.stdout).strip())
         raise SystemExit(1)
     print("WeChat launched.")

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -314,7 +314,7 @@
     <string name="ui_tool_display_notify">通知</string>
     <string name="ui_tool_display_open_uri">開啟連結</string>
     <string name="ui_tool_display_read_custom_tool">讀取自訂工具</string>
-    <string name="ui_tool_display_search_apps">搜尋應用</string>
+    <string name="ui_tool_display_find_installed_apps">尋找應用程式</string>
     <string name="ui_tool_display_screen_operation_accessibility">螢幕操作</string>
     <string name="ui_tool_display_screen_operation_shell">螢幕操作</string>
     <string name="dialog_cancel">取消</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -359,7 +359,7 @@
     <string name="ui_tool_display_notify">Notify</string>
     <string name="ui_tool_display_open_uri">Open URI</string>
     <string name="ui_tool_display_read_custom_tool">Read Custom Tool</string>
-    <string name="ui_tool_display_search_apps">Search Apps</string>
+    <string name="ui_tool_display_find_installed_apps">Find installed apps</string>
     <string name="ui_tool_display_screen_operation_accessibility">Screen Operation</string>
     <string name="ui_tool_display_screen_operation_shell">Screen Operation</string>
     <string name="dialog_cancel">Cancel</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -359,7 +359,7 @@
     <string name="ui_tool_display_notify">Notificación</string>
     <string name="ui_tool_display_open_uri">Abrir enlace</string>
     <string name="ui_tool_display_read_custom_tool">Leer herramienta personalizada</string>
-    <string name="ui_tool_display_search_apps">Buscar apps</string>
+    <string name="ui_tool_display_find_installed_apps">Buscar apps instaladas</string>
     <string name="ui_tool_display_screen_operation_accessibility">Operaciones de pantalla</string>
     <string name="ui_tool_display_screen_operation_shell">Operaciones de pantalla</string>
     <string name="dialog_cancel">Cancelar</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -358,7 +358,7 @@
     <string name="ui_tool_display_notify">通知</string>
     <string name="ui_tool_display_open_uri">リンクを開く</string>
     <string name="ui_tool_display_read_custom_tool">カスタムツール読み込み</string>
-    <string name="ui_tool_display_search_apps">アプリ検索</string>
+    <string name="ui_tool_display_find_installed_apps">アプリを探す</string>
     <string name="ui_tool_display_screen_operation_accessibility">画面操作</string>
     <string name="ui_tool_display_screen_operation_shell">画面操作</string>
     <string name="dialog_cancel">キャンセル</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -358,7 +358,7 @@
     <string name="ui_tool_display_notify">通知</string>
     <string name="ui_tool_display_open_uri">打开链接</string>
     <string name="ui_tool_display_read_custom_tool">读取自定义工具</string>
-    <string name="ui_tool_display_search_apps">搜索应用</string>
+    <string name="ui_tool_display_find_installed_apps">查找应用</string>
     <string name="ui_tool_display_screen_operation_accessibility">屏幕操作</string>
     <string name="ui_tool_display_screen_operation_shell">屏幕操作</string>
     <string name="dialog_cancel">取消</string>


### PR DESCRIPTION
## Changes

### find_installed_apps (was search_apps)

The old tool name collided lexically with information-search requests: "搜索 X" frequently routed to app search instead of web search. Renamed to `find_installed_apps` and rescored its description to serve opening apps only. `launch_app`'s APP_NOT_FOUND hint no longer binds to the find tool.

### Multilingual app label matching

`AppInfoCache` now indexes labels across system default + zh-CN/zh-TW/en/ja/es (via `createPackageContext` + `createConfigurationContext`), so a query in any of those languages hits the exact label regardless of device locale — e.g. "微信" matches WeChat's zh label on an English-locale device, where the indexed label used to be only "WeChat".

`AppInfoMatcher` gains match tiers: exact (any label) > prefix > contains. Contains-only matches now return candidates for the model to decide instead of auto-launching, fixing single-substring collisions such as 微信 vs 微信输入法.

### py_launch_wechat via su

Non-root `am start` from the app process fails with SecurityException. The seed tool now runs through `su` (same convention as seed_py_install_apk); the first call triggers the superuser grant dialog, which is the expected interaction.

Note: `seedPyTools()` only backfills missing tools — existing installs keep the old `py_launch_wechat` code until the tool is deleted in settings (re-seeded on next startup) or edited manually.

## Testing

- `AppInfoMatcherTest` rewritten: cross-locale exact match (WeChat regression), prefix single/multi, contains-only → candidates, exact-beats-weak-tiers
- `BuiltinToolTest` / registry tests updated for the rename
- `:agent-runtime:testDebugUnitTest` and `:app:testDebugUnitTest` pass