### PR TITLE
fix: notify unsupported host version once per version; About page link and feedback language fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,10 @@
-# Zafiro Agent 启动文档
-
-## 作用
-
-本文件用于在每次会话开始前为 Agent 注入最小且稳定的仓库上下文，使其不必从零猜测项目结构、信息来源与首选工作路径。
+# AGENT RULES
 
 ## 项目定位
 
-Zafiro 是一个 Android Xposed 模块。它在语音助手 App 中截获用户 query，交给 LLM 运行时生成回答，再注入回宿主 UI 替换原生回复。
+Zafiro 是一个 Android 应用，使用 Kotlin 技术栈。它通过 compose UI 结合 Root/Shizuku 等权限给 Agent 提供丰富的脚手架。同时支持通过基于 Binder + LSPosed 的接管系统将部分厂商语音助手换源为 Zafiro
+
+重要优先级: 主应用 > Okia > py >> 宿主
 
 ### 术语（你在对话中会用到这些词）
 
@@ -23,11 +21,8 @@ Zafiro 是一个 Android Xposed 模块。它在语音助手 App 中截获用户 
 - **主 App 进程**：运行 `AgentRuntimeService`（前台 Service，Binder IPC），持有 store 持久化的本地访问权
 - **两条 IPC 通道**：`XIpcBridge`（配置读写/通知，走 `StoreClient` Binder 接口） + `AgentRuntimeService`（LLM query 提交与 `RenderFrame` 流式回调）
 
-## 工作原则
+## Engineering principles
 
-- 默认先理解上下文，再动手修改
-- 当前实现以源码为准，设计文档仅代表意图
-- 只在任务明确需要时扩散阅读范围，避免盲目全仓搜索
 - Do not preserve backward compatibility. Remove obsolete paths instead of adding compatibility layers, fallbacks, or migrations.
 - Choose the simplest implementation that fully meets the current requirements. Avoid speculative abstractions, configuration, and indirection.
 - Grow the system in layers. Start from the smallest version that works end to end, and add each new capability on top of a product that already works. Never trade a working product for unfinished complexity.
@@ -35,110 +30,92 @@ Zafiro 是一个 Android Xposed 模块。它在语音助手 App 中截获用户 
 - Prefer established, well-maintained libraries when they reduce overall complexity or improve reliability. Do not reimplement common functionality without a clear reason.
 - Lean on the dependencies already in the project before writing your own implementation or adding packages. Do not assume a library lacks a capability without checking its documentation and types.
 - Make architectural decisions for the long term. Do not accept a stopgap that only works for now and is meant to be replaced later.
-- Do not take a screenshot or try to 'see' the results since you are not a vision model and you CANNOT understand images. Just simply implement, and use `open` to ask the user to validate. Ask the user for help if needed instead of bury yourself in a problem that could be very easy for the user but hard for you, such as refactor code with Android Studio. (Stuff like that——that could be solved with a few simple steps by the user)
-- If the difficulty is huge (greater than 6 out of 10), and it's not very necessary to implement the feature(ROI), feel free to negotiate with the user and manage Up. (Requirement Adjustment)
+- Ask the user for help when a task is easy for the user but hard for you, such as refactoring code in Android Studio.
+- When a feature is hard to implement (difficulty above 6/10) and low in value, negotiate scope with the user before building it.
+- Use the `android` CLI for Android-related operations: build, install, device management, screenshots, UI inspection. Load the `android-cli` skill first.
+- Only implement code changes when the user explicitly requests implementation (e.g., 开发 / 改 / 开始实现). Otherwise, plan and discuss without editing files.
+- Before implementing, present the proposed solution and get the user's decision on the design.
+- The user wants to decide anything that affects architecture or code quality. Surface such decisions for them to make. For trivial choices that no architect would weigh in on, decide yourself and mention them in passing.
+- After implementing, recap the key changes. Do not commit unless the user asks.
 
-1. 使用标准术语。已有通用说法的概念不要另造表述。
-2. 不要使用比喻。如果一个说法需要读者推断其指代对象，改为直接说明。
-3. 表头和分类名使用中性名词，如“问题”“现象”“影响”“结果”。
-4. 不使用“是 X，不是 Y”的对比句式。
-5. 表格条目不要求每条都包含数字或结论。部分条目可以只说明发生了什么。
-6. 未查明原因的问题写“原因未查明”。
-7. 不使用口语词。
-8. 不使用拟人表述。
+## 中文写作规范
 
-规则 1：使用标准术语
+适用于所有中文写作：报告、文档、总结及其他成文内容。
 
-超长度 / 超不超长度 → 截断 / 是否触及长度上限
-Ray 的端口会跟自己撞 → 多个任务的 Ray 抢占同一端口
-臂 → 方案
-只看长度那条线 → 长度启发式基线
-刷奖励 → 奖励被优化但评测指标未改善
-存档 → checkpoint
+### 规则 1：使用标准术语
 
-规则 2：不发明比喻作为术语
+已有通用说法的概念不另造表述。
 
-血统 → 基座来源
-8 个不同血统 → 8 个不同基座的模型
-那是尺寸差异，不是血统差异 → 原有区间由 Qwen 的 14B、32B、72B 构成，差异来自参数量而非基座
-已经吃掉一半空间 → 已覆盖一半区间
-变成了一个认题目的检索器 → 退化为问题识别，与学习价值无关
-挑出来的题目看上去健康得多 → 选中问题的截断比例更低
-误差范围还盖着基准线 → 置信区间与基线重叠
+- 超长度 / 超不超长度 → 截断 / 是否触及长度上限
+- Ray 的端口会跟自己撞 → 多个任务的 Ray 抢占同一端口
+- 臂 → 方案
+- 只看长度那条线 → 长度启发式基线
+- 刷奖励 → 奖励被优化但评测指标未改善
+- 存档 → checkpoint
 
-规则 3：表头和分类名使用中性名词
+### 规则 2：不发明比喻作为术语
 
-坑 / 代价和教训 → 问题 / 影响
-把握 → 确认程度
-怎么做的 → 实验设置
-重挑一次还剩多少重合 → 重采样后的重合率
-有几种不同取值 → 取值数量
-还在跑的 → 进行中
-一个必须关掉的开关 → 需要关闭的过滤器
+- 血统 → 基座来源
+- 8 个不同血统 → 8 个不同基座的模型
+- 那是尺寸差异，不是血统差异 → 原有区间由 Qwen 的 14B、32B、72B 构成，差异来自参数量而非基座
+- 已经吃掉一半空间 → 已覆盖一半区间
+- 变成了一个认题目的检索器 → 退化为问题识别，与学习价值无关
+- 挑出来的题目看上去健康得多 → 选中问题的截断比例更低
+- 误差范围还盖着基准线 → 置信区间与基线重叠
 
-章节状态标签需要保持一致。
+### 规则 3：表头和分类名使用中性名词
 
-如果前面使用：
+- 坑 / 代价和教训 → 问题 / 影响
+- 把握 → 确认程度
+- 怎么做的 → 实验设置
+- 重挑一次还剩多少重合 → 重采样后的重合率
+- 有几种不同取值 → 取值数量
+- 还在跑的 → 进行中
+- 一个必须关掉的开关 → 需要关闭的过滤器
 
-已完成
-已确认
-未达到基线
-结论待定
+章节状态标签使用统一集合：已完成、已确认、未达到基线、结论待定。出现其他表述（如“做通了”“意外发现”“需要修”）时，替换为集合中最接近的标签。
 
-后面出现了：
+### 规则 4：不使用“是 X，不是 Y”的对比句式
 
-做通了
-意外发现
-需要修
-没有买到想要的
+- 梯度对齐：是噪声，不是信号 → 梯度对齐：三项检查结果均在噪声范围内
+- 我们买到了血统上的多样性，但没有买到能力上的多样性 → 新增模型覆盖了更多基座，但正确率均低于原有区间下界
+- 考法和用法对不上 → 评测口径为成对比较，与实际使用方式不一致
+- 稳定是靠粗糙换来的 → 取值数量少的指标重合率高
+- 越稳定的指标越挑不出东西，越挑得出东西的指标越不稳定 → 重合率与取值数量呈反向关系
 
-统一使用前面部分的中性状态标签。
+### 规则 5：条目可以不包含数字或结论
 
-规则 4：不使用“是 X，不是 Y”的对比句式
+部分条目只说明发生了什么，即为完整。
 
-梯度对齐：是噪声，不是信号 → 梯度对齐：三项检查结果均在噪声范围内
-我们买到了血统上的多样性，但没有买到能力上的多样性 → 新增模型覆盖了更多基座，但正确率均低于原有区间下界
-考法和用法对不上 → 评测口径为成对比较，与实际使用方式不一致
-稳定是靠粗糙换来的 → 取值数量少的指标重合率高
-越稳定的指标越挑不出东西，越挑得出东西的指标越不稳定 → 重合率与取值数量呈反向关系
+例：对照组为随机选取的 32 个问题。
 
-规则 5：允许条目不包含数字或结论
+### 规则 6：未查明原因时写“原因未查明”
 
-例如：
+前文已写明“原因未查明”时，后文不补充未经验证的解释。
 
-对照组为随机选取的 32 个问题。
+- 这可能也解释了前文那个现象 → 该现象与截断的关系尚未验证
 
-这条内容已经完整，不需要继续补充其他方案与对照组的关系。
+### 规则 7：不使用口语词
 
-规则 6：未查明原因时直接写“原因未查明”
+- 赢得很干脆 → 差值为 0.030
+- 测得更准 / 测得更糙 → 估计精度更高 / 更低
+- 可选的余地很小 → 候选范围小
+- 基本上等于抓阄 → 接近随机选取
+- 本来就分不出高下 → 真实差距低于可分辨范围
+- 白跑 / 白占 → 无效运行 / 空占
+- 不是白捡的 → 需要 79 GPU·小时
+- 一个致命问题 → 主要问题
+- 有事后找补的嫌疑 → 该切分方式在观察结果之后确定
+- 原因不复杂 → 删除
+- 既然预测这条路走不通，那就退一步 → 删除，直接进入实验设置
 
-前文已经写明“原因未查明”时，后文不要继续补充未经验证的解释。
+### 规则 8：不使用拟人表述
 
-这可能也解释了前文那个现象 → 该现象与截断的关系尚未验证
-
-第十章“后来查明了机制”之后的内容已经得到确认，可以保留。
-
-规则 7：不使用口语词
-
-赢得很干脆 → 差值为 0.030
-测得更准 / 测得更糙 → 估计精度更高 / 更低
-可选的余地很小 → 候选范围小
-基本上等于抓阄 → 接近随机选取
-本来就分不出高下 → 真实差距低于可分辨范围
-白跑 / 白占 → 无效运行 / 空占
-不是白捡的 → 需要 79 GPU·小时
-一个致命问题 → 主要问题
-有事后找补的嫌疑 → 该切分方式在观察结果之后确定
-原因不复杂 → 删除
-既然预测这条路走不通，那就退一步 → 删除，直接进入实验设置
-
-规则 8：不使用拟人表述
-
-天生需要几百到上千次采样 → 该信号所需的采样量为几百到上千次
-一旦超就制造出参差 → 截断发生时会增大奖励方差
-24 步训练只挪动 0.05 → 24 步训练后正确率变化为 0.05
-超得越彻底反而越稳定 → 截断率越高，奖励方差越低
-回答内容本身的好坏参差 → 答案质量的差异
+- 天生需要几百到上千次采样 → 该信号所需的采样量为几百到上千次
+- 一旦超就制造出参差 → 截断发生时会增大奖励方差
+- 24 步训练只挪动 0.05 → 24 步训练后正确率变化为 0.05
+- 超得越彻底反而越稳定 → 截断率越高，奖励方差越低
+- 回答内容本身的好坏参差 → 答案质量的差异
 
 ## 首选模式
 
@@ -149,7 +126,7 @@ Ray 的端口会跟自己撞 → 多个任务的 Ray 抢占同一端口
 - `asc-director-old`
   - 用于新增功能、方案设计、技术调研、任务拆解、页面开发、模块重构、Bug 修复方案
   - 适合多阶段任务，不适合回答单个局部源码问题
-- `context-engineering`
+- `prompt-engineering` + `context-engineering`
   - 用于编写或修改提示词、Agent 文档、Skill 文档、任务说明
   - 凡是目标读者主要是 Agent 而不是人类用户，优先加载它
 - `release-new-version`

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/AboutSettingsContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/AboutSettingsContent.kt
@@ -1,6 +1,8 @@
 package com.niki914.zafiro.app.ui.content
 
+import android.content.Context
 import android.content.res.Configuration
+import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Feedback
@@ -14,6 +16,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.os.LocaleListCompat
 import com.niki914.zafiro.app.BuildConfig
 import com.niki914.zafiro.app.R
 import com.niki914.uikit.infra.ProvideLiquidScreenContentForPreview
@@ -48,7 +51,7 @@ fun AboutSettingsContent() {
             when (effect) {
                 is AboutSettingsEffect.OpenUri -> uriHandler.openUri(effect.uri)
                 is AboutSettingsEffect.OpenFeedbackIssue -> {
-                    val body = context.resources.getString(effect.bodyTemplateRes)
+                    val body = context.localizedString(effect.bodyTemplateRes, effect.languageTag)
                     uriHandler.openUri(buildIssueUri(effect.title, body))
                 }
             }
@@ -128,6 +131,14 @@ private fun aboutSettingsSpec(
     )
 }
 
+// 用应用内语言设置解析字符串；空 tag 跟随系统默认解析
+private fun Context.localizedString(@StringRes res: Int, tag: String): String {
+    if (tag.isBlank()) return resources.getString(res)
+    val config = Configuration(resources.configuration)
+    config.setLocale(LocaleListCompat.forLanguageTags(tag).get(0))
+    return createConfigurationContext(config).getString(res)
+}
+
 private fun aboutSettingsRowId(id: AboutSettingsItemId): String =
     "$ABOUT_SETTINGS_ROW_ID_PREFIX${id.name}"
 
@@ -191,7 +202,7 @@ private fun previewAboutSettingsUiState(): AboutSettingsUiState {
             AboutSettingsItemUiState(
                 id = AboutSettingsItemId.AuthorHomepage,
                 titleRes = R.string.ui_settings_about_author_homepage,
-                uri = "https://github.com/niki914",
+                uri = "https://niki914.github.io/",
             ),
             AboutSettingsItemUiState(
                 id = AboutSettingsItemId.Github,

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/AboutSettingsState.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/AboutSettingsState.kt
@@ -2,8 +2,10 @@ package com.niki914.zafiro.app.ui.model
 
 import android.net.Uri
 import androidx.annotation.StringRes
+import androidx.core.os.LocaleListCompat
 import com.niki914.zafiro.app.R
 import com.niki914.uikit.base.ComposeMVIViewModel
+import com.niki914.zafiro.repo.XRepo
 
 enum class AboutSettingsItemId {
     AuthorHomepage,
@@ -38,6 +40,7 @@ sealed interface AboutSettingsEffect {
     data class OpenFeedbackIssue(
         val title: String,
         @StringRes val bodyTemplateRes: Int,
+        val languageTag: String,
     ) : AboutSettingsEffect
 }
 
@@ -54,7 +57,7 @@ class AboutSettingsViewModel :
         }
     }
 
-    private fun openItem(id: AboutSettingsItemId) {
+    private suspend fun openItem(id: AboutSettingsItemId) {
         val item = currentState.items.firstOrNull { it.id == id } ?: return
         when {
             item.uri != null -> sendEffect(AboutSettingsEffect.OpenUri(item.uri))
@@ -62,7 +65,8 @@ class AboutSettingsViewModel :
                 sendEffect(
                     AboutSettingsEffect.OpenFeedbackIssue(
                         item.feedbackTitle,
-                        item.bodyTemplateRes
+                        item.bodyTemplateRes,
+                        XRepo.languageTag()
                     )
                 )
         }
@@ -74,7 +78,7 @@ private fun aboutSettingsItems(): List<AboutSettingsItemUiState> {
         AboutSettingsItemUiState(
             id = AboutSettingsItemId.AuthorHomepage,
             titleRes = R.string.ui_settings_about_author_homepage,
-            uri = "https://github.com/niki914",
+            uri = "https://niki914.github.io/",
         ),
         AboutSettingsItemUiState(
             id = AboutSettingsItemId.Github,

--- a/app/src/main/java/com/niki914/zafiro/runtime/service/AgentRuntimeService.kt
+++ b/app/src/main/java/com/niki914/zafiro/runtime/service/AgentRuntimeService.kt
@@ -9,7 +9,6 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.net.Uri
 import android.os.Binder
 import android.os.Build
 import android.os.DeadObjectException
@@ -27,6 +26,7 @@ import com.niki914.zafiro.runtime.ipc.IAgentStoreService
 import com.niki914.zafiro.runtime.ipc.IRenderFrameCallback
 import com.niki914.zafiro.runtime.ipc.RenderFrame
 import com.niki914.store.HostApp
+import com.niki914.store.StoreDescriptorRegistry
 import com.niki914.store.XIpcStoreRepository
 import com.niki914.store.displayNameFor
 import kotlinx.coroutines.CancellationException
@@ -39,6 +39,8 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.atomic.AtomicReference
+import org.json.JSONObject
+import com.niki914.zafiro.app.MainActivity
 import com.niki914.zafiro.app.R as AppR
 
 class AgentRuntimeService : Service() {
@@ -77,6 +79,7 @@ class AgentRuntimeService : Service() {
         private const val MAX_QUERY_LENGTH = 8192
         private const val STORE_CHANNEL_ID = "nexus_xservice_default_channel"
         private const val STORE_CHANNEL_NAME = "Zafiro"
+        private const val UNSUPPORTED_NOTIFIED_FIELD = "unsupported_version_notified"
     }
 
     private fun createNotificationChannel() {
@@ -239,7 +242,7 @@ class AgentRuntimeService : Service() {
             if (!validateCaller()) return
             val t = title ?: return
             val c = content ?: return
-            postNotificationImpl(t, c, uri)
+            postNotificationImpl(t, c, createContentIntent(uri))
         }
 
         override fun postNetworkErrorNotification() {
@@ -258,32 +261,69 @@ class AgentRuntimeService : Service() {
         ) {
             if (!validateCaller()) return
             val ctx = this@AgentRuntimeService
+            val dedupKey = "${hostPackageName.orEmpty()}:${hostVersion.orEmpty()}"
+            if (isUnsupportedVersionNotified(dedupKey)) {
+                Logger.d(LOG_TAG, "unsupported notification suppressed key=$dedupKey")
+                return
+            }
             val hostApp = HostApp.fromPackageName(hostPackageName)
             val hostName = hostApp?.let { ctx.displayNameFor(it) }
                 ?: ctx.getString(AppR.string.fallback_assistant_name)
             val version = hostVersion ?: ""
-            val issueUri = Uri.Builder()
-                .scheme("https")
-                .authority("github.com")
-                .path("/niki914/zafiro/issues/new")
-                .appendQueryParameter(
-                    "title",
-                    ctx.getString(AppR.string.notif_unsupported_issue_title)
-                )
-                .appendQueryParameter(
-                    "body",
-                    ctx.getString(AppR.string.notif_unsupported_issue_body, hostName, version)
-                )
-                .build()
-                .toString()
             postNotificationImpl(
                 ctx.getString(AppR.string.notif_unsupported_version_title),
                 ctx.getString(AppR.string.notif_unsupported_version_body, hostName, version),
-                issueUri
+                createAppLaunchPendingIntent()
             )
+            markUnsupportedVersionNotified(dedupKey)
         }
 
-        private fun postNotificationImpl(title: String, content: String, uri: String?) {
+        private fun isUnsupportedVersionNotified(key: String): Boolean {
+            val root = runCatching {
+                JSONObject(
+                    runBlocking {
+                        XIpcStoreRepository.readJson(
+                            this@AgentRuntimeService,
+                            StoreDescriptorRegistry.APP_STATE_ID
+                        )
+                    }
+                )
+            }.getOrNull() ?: return false
+            return root.optJSONObject(UNSUPPORTED_NOTIFIED_FIELD)?.optBoolean(key) == true
+        }
+
+        // ponytail: read-modify-write on app.state is not atomic across calls; a
+        // simultaneous Breeno+XiaoAi notify could drop one marker, which self-heals
+        // by re-notifying on the next host load
+        private fun markUnsupportedVersionNotified(key: String) {
+            runCatching {
+                runBlocking {
+                    val root = JSONObject(
+                        XIpcStoreRepository.readJson(
+                            this@AgentRuntimeService,
+                            StoreDescriptorRegistry.APP_STATE_ID
+                        )
+                    )
+                    val notified = root.optJSONObject(UNSUPPORTED_NOTIFIED_FIELD) ?: JSONObject().also {
+                        root.put(UNSUPPORTED_NOTIFIED_FIELD, it)
+                    }
+                    notified.put(key, true)
+                    XIpcStoreRepository.writeJson(
+                        this@AgentRuntimeService,
+                        StoreDescriptorRegistry.APP_STATE_ID,
+                        root.toString()
+                    )
+                }
+            }.onFailure { t ->
+                Logger.w(LOG_TAG, "mark unsupported notified failed key=$key error=$t")
+            }
+        }
+
+        private fun postNotificationImpl(
+            title: String,
+            content: String,
+            contentIntent: PendingIntent?
+        ) {
             fun hasPermission(): Boolean {
                 return Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || ContextCompat.checkSelfPermission(
                     this@AgentRuntimeService,
@@ -301,11 +341,9 @@ class AgentRuntimeService : Service() {
                 .setPriority(NotificationCompat.PRIORITY_MAX)
                 .setAutoCancel(true)
 
-            createContentIntent(uri)?.let { contentIntent ->
-                builder.setContentIntent(contentIntent)
-            }
+            contentIntent?.let { builder.setContentIntent(it) }
             NotificationManagerCompat.from(this@AgentRuntimeService).notify(
-                notificationId(title, content, uri),
+                notificationId(title, content),
                 builder.build()
             )
         }
@@ -319,6 +357,19 @@ class AgentRuntimeService : Service() {
                 NotificationManager.IMPORTANCE_DEFAULT
             )
             manager.createNotificationChannel(channel)
+        }
+
+        // MainActivity is launchMode=singleTask; NEW_TASK reuses the existing task
+        // and routes through onNewIntent, so no duplicate activity is created
+        private fun createAppLaunchPendingIntent(): PendingIntent? {
+            val intent = Intent(this@AgentRuntimeService, MainActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            return PendingIntent.getActivity(
+                this@AgentRuntimeService,
+                0,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
         }
 
         private fun createContentIntent(uri: String?): PendingIntent? {
@@ -345,10 +396,9 @@ class AgentRuntimeService : Service() {
                 ?: android.R.drawable.ic_dialog_info
         }
 
-        private fun notificationId(title: String, content: String, uri: String?): Int {
+        private fun notificationId(title: String, content: String): Int {
             var result = title.hashCode()
             result = 31 * result + content.hashCode()
-            result = 31 * result + (uri?.hashCode() ?: 0)
             return result
         }
     }

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -360,8 +360,6 @@
     <string name="fallback_assistant_name">助手</string>
     <string name="notif_unsupported_version_title">宿主版本未適配</string>
     <string name="notif_unsupported_version_body">當前%1$s版本還未被 Zafiro 支援\n宿主版本：%2$s</string>
-    <string name="notif_unsupported_issue_title">[BUG] 宿主版本未適配</string>
-    <string name="notif_unsupported_issue_body">## 問題描述\n當前%1$s版本還未被 Zafiro 支援\n宿主版本：%2$s\n\n## 復現步驟\n\n\n## 設備資訊\n- 助手：%1$s\n- 助手版本：%2$s\n- 模組版本：</string>
     <string name="feedback_bug_template">## 問題描述\n\n## 復現步驟\n\n## 預期行為\n\n## 實際行為\n\n## 設備資訊\n- Android 版本：\n- 助手（小布或其他）：\n- 模組版本：\n\n## 更多\n可以補充日誌、截圖錄屏等資訊，以便於我們理解</string>
 
     <string name="ui_settings_appearance">外觀</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -309,8 +309,6 @@
     <string name="notif_network_error_body">Network connection failed. Please check your network and try again.</string>
     <string name="notif_unsupported_version_title">Unsupported Host Version</string>
     <string name="notif_unsupported_version_body">The current %1$s version is not yet supported by Zafiro\nHost version: %2$s</string>
-    <string name="notif_unsupported_issue_title">[BUG] Unsupported host version</string>
-    <string name="notif_unsupported_issue_body">## Issue Description\nThe current version of %1$s is not yet supported by Zafiro\nHost version: %2$s\n\n## Steps to Reproduce\n\n\n## Device Info\n- Assistant: %1$s\n- Assistant version: %2$s\n- Module version:</string>
 
     <!-- Fallback -->
     <string name="fallback_assistant_name">Assistant</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -343,8 +343,6 @@
     <string name="fallback_assistant_name">Asistente</string>
     <string name="notif_unsupported_version_title">Versión de la app host no compatible</string>
     <string name="notif_unsupported_version_body">La versión actual de %1$s aún no es compatible con Zafiro\nVersión de la app host: %2$s</string>
-    <string name="notif_unsupported_issue_title">[BUG] Versión de la app host no compatible</string>
-    <string name="notif_unsupported_issue_body">## Descripción del problema\nLa versión actual de %1$s aún no es compatible con Zafiro\nVersión de la app host: %2$s\n\n## Pasos para reproducir\n\n\n## Información del dispositivo\n- Asistente: %1$s\n- Versión del asistente: %2$s\n- Versión del módulo:</string>
 
     <string name="feedback_bug_template">## Descripción del problema\n\n## Pasos para reproducir\n\n## Comportamiento esperado\n\n## Comportamiento real\n\n## Información del dispositivo\n- Versión de Android:\n- Asistente (Breeno u otro):\n- Versión del módulo:\n\n## Información adicional\nPuede adjuntar registros, capturas o grabaciones de pantalla para ayudarnos a entender el problema.</string>
     <string name="conversation_fork_title">Fork · %1$s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -342,8 +342,6 @@
     <string name="fallback_assistant_name">アシスタント</string>
     <string name="notif_unsupported_version_title">ホストバージョン未対応</string>
     <string name="notif_unsupported_version_body">現在の%1$sバージョンはまだ Zafiro に対応していません\nホストバージョン：%2$s</string>
-    <string name="notif_unsupported_issue_title">[BUG] ホストバージョン未対応</string>
-    <string name="notif_unsupported_issue_body">## 問題の説明\n現在の%1$sバージョンはまだ Zafiro に対応していません\nホストバージョン：%2$s\n\n## 再現手順\n\n\n## デバイス情報\n- アシスタント：%1$s\n- アシスタントのバージョン：%2$s\n- モジュールのバージョン：</string>
 
     <string name="feedback_bug_template">## 問題の説明\n\n## 再現手順\n\n## 期待される動作\n\n## 実際の動作\n\n## デバイス情報\n- Android バージョン：\n- アシスタント（Breeno またはその他）：\n- モジュールのバージョン：\n\n## その他\n理解を深めるため、ログやスクリーンショット、画面録画などを添付できます</string>
     <string name="conversation_fork_title">Fork · %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -342,8 +342,6 @@
     <string name="fallback_assistant_name">助手</string>
     <string name="notif_unsupported_version_title">宿主版本未适配</string>
     <string name="notif_unsupported_version_body">当前%1$s版本还未被 Zafiro 支持\n宿主版本：%2$s</string>
-    <string name="notif_unsupported_issue_title">[BUG] 宿主版本未适配</string>
-    <string name="notif_unsupported_issue_body">## 问题描述\n当前%1$s版本还未被 Zafiro 支持\n宿主版本：%2$s\n\n## 复现步骤\n\n\n## 设备信息\n- 助手：%1$s\n- 助手版本：%2$s\n- 模块版本：</string>
 
     <string name="feedback_bug_template">## 问题描述\n\n## 复现步骤\n\n## 预期行为\n\n## 实际行为\n\n## 设备信息\n- Android 版本：\n- 助手（小布或其他）：\n- 模块版本：\n\n## 更多\n可以补充日志、截图录屏等信息，以便于我们理解</string>
     <string name="conversation_fork_title">Fork · %1$s</string>


### PR DESCRIPTION
## Changes

### Unsupported-version notification
- Dedup in `AgentRuntimeService`: notification is sent once per host `(packageName, versionName)`, state persisted in the `app.state` store under `unsupported_version_notified`; a host update produces a new key and notifies again
- Removed the GitHub issue link; tapping the notification now launches `MainActivity` (singleTask reuses the existing task via `onNewIntent`, no duplicate activity when the main process is alive)
- Dropped unused `notif_unsupported_issue_*` strings across all locales

### About page
- Author homepage link changed to https://niki914.github.io/
- Feature/issue feedback templates now resolve with the in-app language setting (`createConfigurationContext` from `languageTag`) instead of the system locale; empty tag (follow system) keeps default resolution

## Validation
- `:app:compileDebugKotlin` passes
- Manual: cold-start host twice with unsupported version -> one notification; tap -> main UI opens