### PR TITLE
Error feedback rework: typed errors, retry visibility, configurable timeout

### DIFF
--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/LLMController.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/LLMController.kt
@@ -1,11 +1,11 @@
 package com.niki914.zafiro.chat
 
-import android.content.Context
 import com.niki914.logging.Logger
 import com.niki914.okia.Okia
 import com.niki914.okia.TurnOptions
 import com.niki914.okia.conversation.Conversation
 import com.niki914.okia.conversation.SessionSnapshot
+import com.niki914.okia.error.RetryPolicy
 import com.niki914.okia.hooks.Hooks
 import com.niki914.okia.loop.TurnResult
 import com.niki914.okia.mcp.McpDiscoveryState
@@ -23,7 +23,6 @@ import com.niki914.okia.tooling.ToolDescriptor
 import com.niki914.okia.tooling.ToolKind
 import com.niki914.okia.tooling.ToolRegistry
 import com.niki914.xposed.api.util.LockState
-import com.niki914.zafiro.R
 import com.niki914.zafiro.chat.agentic.LocalToolExecutor
 import com.niki914.zafiro.chat.agentic.PromptComposer
 import com.niki914.zafiro.chat.agentic.PromptComposerInput
@@ -64,7 +63,7 @@ import com.niki914.zafiro.settings.model.RuntimeLlmConfig as LlmConfig
 object LLMController {
     private const val LOG_TAG = "niki914_nexus_LLMController"
     internal const val CONFIG_REQUIRED_MESSAGE = "请先填写配置" // <--- TODO res
-    private const val LLM_IDLE_TIMEOUT_SECONDS = 30L
+    internal const val NO_IDLE_TIMEOUT_SECONDS = Long.MAX_VALUE / 1000
 
     private val promptComposer =
         PromptComposer()
@@ -185,6 +184,8 @@ object LLMController {
             baseSystemPrompt = llmConfig.prompt,
             finalSystemPrompt = llmConfig.prompt,
             proxy = llmConfig.proxy,
+            idleTimeoutSeconds = llmConfig.idleTimeoutSeconds,
+            retryMaxAttempts = llmConfig.retryMaxAttempts,
         )
         // 会话实例按协议重建；协议切换 = close + 新实例，但树经 restore 延续
         // （P1 #3：export 当前树给新协议实例，会话 id + 历史跨 Provider 保留）
@@ -300,12 +301,10 @@ object LLMController {
 
     fun stream(
         query: String,
-        context: Context,
         fromUserInterface: Boolean = false,
     ): Flow<LlmStreamEvent> = channelFlow {
         // 确认型执行规则按来源区分：UI 直连可弹窗；宿主路径默认拒绝（英文错误回给 Agent）
         ToolPermissionCoordinator.canRequestUserConfirmation = fromUserInterface
-        val defaultErrorMessage = context.getString(R.string.error_llm_request_failed)
         try {
             val state = try {
                 refresh()
@@ -315,13 +314,10 @@ object LLMController {
                     throw throwable
                 }
                 runtimeState ?: run {
-                    // 用户可见错误文案在 IPC 前用资源本地化。CONFIG_REQUIRED 的异常
-                    // message 是内部码（ValidationTest 以 const 断言它），不直接展示
-                    val message = if (throwable.toUserErrorCode() == LlmErrorCode.ConfigRequired) {
-                        context.getString(R.string.error_config_required)
-                    } else {
-                        throwable.toUserErrorMessage(defaultErrorMessage)
-                    }
+                    // 原文透传不造文案：异常 message 多为内部码（ConfigRequired）或
+                    // 英文原文，翻译归直接消费方（UI toAssistantErrorUi / Service map）
+                    val code = throwable.toUserErrorCode()
+                    val message = throwable.message?.trim()?.ifEmpty { null }
                     Logger.e(
                         LOG_TAG,
                         "refresh failed errorType=${throwable.eventTypeName()} message=$message"
@@ -330,14 +326,14 @@ object LLMController {
                         LlmStreamEvent.Error(
                             message = message,
                             throwable = throwable,
-                            code = throwable.toUserErrorCode(),
+                            code = code,
                         )
                     )
                     return@channelFlow
                 }
             }
             if (state == null) {
-                send(LlmStreamEvent.Error(defaultErrorMessage))
+                send(LlmStreamEvent.Error(message = null, code = null))
                 return@channelFlow
             }
             Logger.i(
@@ -350,8 +346,18 @@ object LLMController {
 
             val startedAtMs = System.currentTimeMillis()
             var streamErrorReported = false
+            var streamTerminated = false
             var firstFrameLogged = false
             val sink: SendChannel<LlmStreamEvent> = this
+
+            /** 发送事件并维护终态标记（Error/Completed 已发则 [streamTerminated] 置位）。 */
+            suspend fun emit(event: LlmStreamEvent) {
+                if (event is LlmStreamEvent.Error) streamErrorReported = true
+                if (event is LlmStreamEvent.Error || event is LlmStreamEvent.Completed) {
+                    streamTerminated = true
+                }
+                sink.send(event)
+            }
             try {
                 Logger.i(
                     LOG_TAG,
@@ -377,8 +383,7 @@ object LLMController {
                         text = effectiveQuery,
                         options = TurnOptions(systemPrompt = state.snapshot.config.finalSystemPrompt),
                     ) { event ->
-                        val mapped =
-                            LlmStreamEventMapper.map(event, startedAtMs, defaultErrorMessage)
+                        val mapped = LlmStreamEventMapper.map(event, startedAtMs)
                         mapped?.let {
                             if (!firstFrameLogged && it is LlmStreamEvent.TextDelta) {
                                 firstFrameLogged = true
@@ -389,7 +394,6 @@ object LLMController {
                                 )
                             }
                             if (it is LlmStreamEvent.Error && !streamErrorReported) {
-                                streamErrorReported = true
                                 Logger.e(
                                     LOG_TAG,
                                     "stream error stage=session_event code=${it.code} " +
@@ -398,7 +402,7 @@ object LLMController {
                                             "elapsedMs=${System.currentTimeMillis() - startedAtMs}"
                                 )
                             }
-                            sink.send(it)
+                            emit(it)
                         }
                     }
                 } catch (throwable: Throwable) {
@@ -412,12 +416,12 @@ object LLMController {
                             LOG_TAG,
                             "stream error stage=send code=${throwable.toUserErrorCode()} " +
                                     "errorType=${throwable.eventTypeName()} " +
-                                    "message=${throwable.toUserErrorMessage(defaultErrorMessage)} " +
+                                    "message=${throwable.message} " +
                                     "elapsedMs=${System.currentTimeMillis() - startedAtMs}"
                         )
-                        send(
+                        emit(
                             LlmStreamEvent.Error(
-                                message = throwable.toUserErrorMessage(defaultErrorMessage),
+                                message = throwable.message?.trim()?.ifEmpty { null },
                                 throwable = throwable,
                                 code = throwable.toUserErrorCode(),
                             )
@@ -435,13 +439,25 @@ object LLMController {
                                 "message=${error.message} " +
                                 "elapsedMs=${System.currentTimeMillis() - startedAtMs}"
                     )
-                    send(
+                    emit(
                         LlmStreamEvent.Error(
-                            message = error.message.trim().ifEmpty { defaultErrorMessage },
+                            message = error.message.trim().ifEmpty { null },
                             throwable = error.cause,
-                            code = null,
+                            code = RetryableErrorClassifier.classify(error),
                         )
                     )
+                }
+                // 流终态守卫：保证流结束前已发过 Error 或 Completed——
+                // 最初「无反馈卡住」bug 的直接防御（异常路径漏发终态时，
+                // UI 不能停在无限生成态）
+                if (!streamTerminated) {
+                    Logger.w(
+                        LOG_TAG,
+                        "stream ended without terminal event, emitting guard error " +
+                                "resultType=${result?.let { it::class.simpleName } ?: "null"} " +
+                                "elapsedMs=${System.currentTimeMillis() - startedAtMs}"
+                    )
+                    emit(LlmStreamEvent.Error(message = null, code = null))
                 }
                 if (!streamErrorReported) {
                     Logger.i(
@@ -455,14 +471,14 @@ object LLMController {
                 }
                 Logger.e(
                     LOG_TAG,
-                    "stream error stage=send code=${throwable.toUserErrorCode()} " +
+                    "stream error stage=outer code=${throwable.toUserErrorCode()} " +
                             "errorType=${throwable.eventTypeName()} " +
-                            "message=${throwable.toUserErrorMessage(defaultErrorMessage)} " +
+                            "message=${throwable.message} " +
                             "elapsedMs=${System.currentTimeMillis() - startedAtMs}"
                 )
-                send(
+                emit(
                     LlmStreamEvent.Error(
-                        message = throwable.toUserErrorMessage(defaultErrorMessage),
+                        message = throwable.message?.trim()?.ifEmpty { null },
                         throwable = throwable,
                         code = throwable.toUserErrorCode(),
                     )
@@ -562,7 +578,9 @@ object LLMController {
             apiKey = config.apiKey
             model = config.model
             hooks += killToolResourcesHook
-            idleTimeoutSeconds = LLM_IDLE_TIMEOUT_SECONDS
+            // null = 不超时（General Settings 提供「不限时」选项）
+            idleTimeoutSeconds = config.idleTimeoutSeconds ?: NO_IDLE_TIMEOUT_SECONDS
+            retryPolicy = RetryPolicy(maxAttempts = config.retryMaxAttempts)
             toolRegistry = this@LLMController.toolRegistry
         }
     }
@@ -724,13 +742,6 @@ object LLMController {
         if (config.endpoint.isBlank() || config.model.isBlank()) {
             throw LlmConfigRequiredException()
         }
-    }
-
-    private fun Throwable.toUserErrorMessage(fallbackMessage: String): String {
-        return message
-            ?.trim()
-            ?.takeIf { it.isNotEmpty() }
-            ?: fallbackMessage
     }
 
     private fun Throwable.toUserErrorCode(): LlmErrorCode? {

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/LLMController.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/LLMController.kt
@@ -86,7 +86,7 @@ object LLMController {
     )
 
     private var runtimeState: RuntimeState? = null
-    private var okia: Okia? = null
+    internal var okia: Okia? = null
     private var sessionProtocol: LlmProtocol? = null
 
     // T3：当前会话快照统一流（持久化器观察它做消息级增量落盘，D3-8）。
@@ -195,6 +195,10 @@ object LLMController {
             endpoint = configWithoutRuntimePrompt.endpoint
             apiKey = configWithoutRuntimePrompt.apiKey
             model = configWithoutRuntimePrompt.model
+            // 热更新超时/重试策略：实例复用时也要跟随设置变化，否则改设置要冷启才生效
+            idleTimeoutSeconds = configWithoutRuntimePrompt.idleTimeoutSeconds
+                ?: NO_IDLE_TIMEOUT_SECONDS
+            retryPolicy = RetryPolicy(maxAttempts = configWithoutRuntimePrompt.retryMaxAttempts)
             // T2b：MCP 服务器配置进 OKIA（McpDiscovery 发现后注册进同一 toolRegistry）
             mcpServers = toOkiaMcpServers(resolvedTools.mcpServers)
         }

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/LlmModels.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/LlmModels.kt
@@ -16,6 +16,8 @@ data class ResolvedLlmConfig(
     val baseSystemPrompt: String,
     val finalSystemPrompt: String,
     val proxy: String = "",
+    val idleTimeoutSeconds: Long? = 60L,
+    val retryMaxAttempts: Int = 3,
 )
 
 data class ResolvedTools(

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/LlmStreamEvent.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/LlmStreamEvent.kt
@@ -44,9 +44,23 @@ sealed interface LlmStreamEvent {
     ) : LlmStreamEvent
 
     data class Error(
-        val message: String,
+        /** 原始错误文本；null = 无可用原文，消费端按 code/兜底文案渲染。 */
+        val message: String?,
         val throwable: Throwable? = null,
         val code: LlmErrorCode? = null,
+        /** RetryExhausted 专属：已耗尽的重试次数（来自 RetryScheduled 事件，非字符串解析）。 */
+        val attempts: Int? = null,
+    ) : LlmStreamEvent
+
+    /**
+     * 传输层自动重试已排定（瞬时状态，不落盘）。UI 展示 retry 卡片，
+     * 下一个流事件到达即清除。reason 为原始错误文本（英文，来自上游/传输层）。
+     */
+    data class Retrying(
+        val attempt: Int,
+        val maxAttempts: Int,
+        val delayMs: Long,
+        val reason: String,
     ) : LlmStreamEvent
 
     /** 回合正常结束（纯终态标记；显示文本一律以 TextDelta 累积为准）。 */
@@ -65,6 +79,7 @@ enum class LlmErrorCode {
     RetryExhausted,
     HookFailed,
     ToolExecutionFailed,
+    IdleTimeout,
 }
 
 data class ToolCallStatus(

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/RetryableErrorClassifier.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/RetryableErrorClassifier.kt
@@ -1,0 +1,66 @@
+package com.niki914.zafiro.chat
+
+import com.niki914.okia.error.LLMError
+import com.niki914.okia.error.LLMErrorCode
+
+/**
+ * 错误分类器：okia 的 LLMError → 更细的 Zafiro LlmErrorCode。
+ *
+ * okia 的 Transport 是个杂项桶（socket hang up / ECONNRESET / 5xx 全在里面），
+ * UI 标题只能笼统归"网络异常"。这里按错误原文正则细分（对齐 pi
+ * provider-retry 的模式表），让 Overloaded / RateLimit / Timeout 各自可辨。
+ *
+ * 只影响展示分类：okia 传输层的重试决策仍由它自己的 RetryPolicy 决定，
+ * 本分类器不做任何重试判断。错误原文透传不替换。
+ */
+object RetryableErrorClassifier {
+
+    // 匹配顺序即优先级：specific → generic。全小写比对。
+    private val patterns: List<Pair<Regex, LlmErrorCode>> = listOf(
+        // 服务过载
+        Regex("overloaded|server is (?:over)?busy|temporarily unavailable|please try again later") to LlmErrorCode.Overloaded,
+        // 限流
+        Regex("\\brate limit\\b|\\b429\\b|too many requests") to LlmErrorCode.RateLimit,
+        // 配额/计费（不重试类，单列让 UI 可区分）
+        Regex("insufficient_quota|billing|\\bquota\\b") to LlmErrorCode.Quota,
+        // 鉴权
+        Regex("invalid[\\s_-]*api[\\s_-]*key|unauthorized|\\b401\\b|\\b403\\b|authentication") to LlmErrorCode.Auth,
+        // 流式截断（上游断流，SSE 提前结束）
+        Regex("stream ended without|stream (?:was )?(?:terminated|closed)|incomplete chunked encoding") to LlmErrorCode.Transport,
+        // 空闲/请求超时（okia 的框架级 IdleTimeout 走独立事件，此处匹配传输层超时）
+        Regex("\\btimeout\\b|timed?\\s*-?\\s*out|\\betimedout\\b|\\b408\\b") to LlmErrorCode.IdleTimeout,
+        // 连接类
+        Regex("socket hang up|econnreset|econnrefused|enotfound|eai_again|connection (?:error|refused|reset|closed)|network") to LlmErrorCode.Transport,
+        // 5xx 服务器错误
+        Regex("\\b5\\d{2}\\b") to LlmErrorCode.Overloaded,
+    )
+
+    /**
+     * 分类 okia 错误。okia 自带的细粒度 code 直接透传；Transport（杂项桶）
+     * 按原文正则细分（message + statusCode + cause 链）。
+     */
+    fun classify(error: LLMError): LlmErrorCode = when (error.code) {
+        LLMErrorCode.Auth -> LlmErrorCode.Auth
+        LLMErrorCode.Quota -> LlmErrorCode.Quota
+        LLMErrorCode.RateLimit -> LlmErrorCode.RateLimit
+        LLMErrorCode.Overloaded -> LlmErrorCode.Overloaded
+        LLMErrorCode.ContextOverflow -> LlmErrorCode.Parse
+        LLMErrorCode.Parse -> LlmErrorCode.Parse
+        LLMErrorCode.HookFailed -> LlmErrorCode.HookFailed
+        LLMErrorCode.ToolExecutionFailed -> LlmErrorCode.ToolExecutionFailed
+        LLMErrorCode.RetryExhausted -> LlmErrorCode.RetryExhausted
+        LLMErrorCode.Transport -> classifyByPattern(error)
+    }
+
+    private fun classifyByPattern(error: LLMError): LlmErrorCode {
+        val haystack = buildString {
+            append(error.message)
+            error.statusCode?.let { append(" ").append(it) }
+            error.cause?.message?.let { append(" ").append(it) }
+        }.lowercase()
+        patterns.forEach { (regex, code) ->
+            if (regex.containsMatchIn(haystack)) return code
+        }
+        return LlmErrorCode.Transport
+    }
+}

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/stream/LlmStreamEventMapper.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/stream/LlmStreamEventMapper.kt
@@ -5,11 +5,11 @@ import com.niki914.okia.event.TurnEvent
 import com.niki914.okia.message.AssistantMessage
 import com.niki914.okia.message.ContentBlock
 import com.niki914.okia.message.ToolCallOutcome
+import com.niki914.zafiro.chat.RetryableErrorClassifier
 import com.niki914.zafiro.chat.LlmErrorCode
 import com.niki914.zafiro.chat.LlmStreamEvent
 import com.niki914.zafiro.chat.ToolCallKind
 import com.niki914.zafiro.chat.ToolCallStatus
-import com.niki914.okia.error.LLMErrorCode as OkiaLLMErrorCode
 
 /**
  * TurnEvent → LlmStreamEvent 映射器（OKIA 接入 T1 重写）。
@@ -37,15 +37,19 @@ object LlmStreamEventMapper {
     private var activeThinkingIndex: Int? = null
     private var activeThinkingText: String = ""
 
+    /** 本回合已排定的重试次数（RetryScheduled 累计；TurnStarted 重置）。
+     *  RetryExhausted 时随 Error 事件结构化携带，不反向解析错误串。 */
+    private var retryAttemptsScheduled = 0
+
     fun map(
         event: TurnEvent,
         startedAtMs: Long,
-        defaultErrorMessage: String,
     ): LlmStreamEvent? {
         val mapped = when (event) {
             is TurnEvent.TurnStarted -> {
                 accumulatedText = ""
                 resetThinkingState()
+                retryAttemptsScheduled = 0
                 LlmStreamEvent.RoundStarted
             }
 
@@ -91,20 +95,27 @@ object LlmStreamEventMapper {
             is TurnEvent.TurnFailed -> {
                 accumulatedText = ""
                 resetThinkingState()
+                val classified = RetryableErrorClassifier.classify(event.error)
                 LlmStreamEvent.Error(
-                    message = event.error.message.trim().ifEmpty { defaultErrorMessage },
+                    message = event.error.message.trim().ifEmpty { null },
                     throwable = event.error.cause,
-                    code = event.error.code.toZafiroCode(),
+                    code = classified,
+                    attempts = if (classified == LlmErrorCode.RetryExhausted) {
+                        retryAttemptsScheduled
+                    } else {
+                        null
+                    },
                 )
             }
 
-            // 超时也视为回合终止：清思考在途态（不合成——正常流不会走到这里）
+            // 超时也视为回合终止：清思考在途态（不合成——正常流不会走到这里）。
+            // 文案归 UI 层（toAssistantErrorUi 按 IdleTimeout 出专属标题），此处只带类型。
             is TurnEvent.TurnIdleTimeout -> {
                 resetThinkingState()
                 LlmStreamEvent.Error(
-                    message = defaultErrorMessage,
+                    message = null,
                     throwable = null,
-                    code = LlmErrorCode.Transport,
+                    code = LlmErrorCode.IdleTimeout,
                 )
             }
 
@@ -147,6 +158,20 @@ object LlmStreamEventMapper {
                 null
             }
 
+            // 重试已排定：透传为 Retrying（UI 展示 retry 卡片，流恢复即清除）；
+            // 重试会重发同一请求，partial 丢弃不 commit，故重试边界重置文本累积，
+            // 让成功尝试的全量重放与 UI 累积重新对齐（避免重复/缺段）。
+            is TurnEvent.RetryScheduled -> {
+                accumulatedText = ""
+                retryAttemptsScheduled = event.attempt
+                LlmStreamEvent.Retrying(
+                    attempt = event.attempt,
+                    maxAttempts = event.maxAttempts,
+                    delayMs = event.delayMs,
+                    reason = event.reason,
+                )
+            }
+
             // 工具意图阶段：名字已知、参数在途——透传为 ToolPending，UI 以 Running 占位（转圈、不可展开）。
             // 身份取自事件字段：发起中的调用未进 partial.content，从 partial 里取不到。
             // Delta 不透传（无需参数实时预览）；Ready 与 Running 几乎同时，走 Running 即可。
@@ -157,8 +182,7 @@ object LlmStreamEventMapper {
                 )
             )
 
-            is TurnEvent.ToolCallDelta, is TurnEvent.ToolCallReady,
-            is TurnEvent.RetryScheduled -> null
+            is TurnEvent.ToolCallDelta, is TurnEvent.ToolCallReady -> null
 
             // 用户停止：不映射为错误事件（停止由消费端 cancel 表达）；
             // 若思考块仍在途，为最后一块合成 ThinkingEnded（被掐也算完成）。
@@ -240,23 +264,6 @@ object LlmStreamEventMapper {
         is ToolCallOutcome.Intercepted -> content
         is ToolCallOutcome.Interrupted -> content
         is ToolCallOutcome.Unknown -> content
-    }
-
-    /**
-     * okia LLMErrorCode → Zafiro LlmErrorCode。ContextOverflow 归 Parse
-     * （上下文溢出，用户可感知的模型端内容问题）。
-     */
-    private fun OkiaLLMErrorCode.toZafiroCode(): LlmErrorCode = when (this) {
-        OkiaLLMErrorCode.Auth -> LlmErrorCode.Auth
-        OkiaLLMErrorCode.Quota -> LlmErrorCode.Quota
-        OkiaLLMErrorCode.RateLimit -> LlmErrorCode.RateLimit
-        OkiaLLMErrorCode.Overloaded -> LlmErrorCode.Overloaded
-        OkiaLLMErrorCode.ContextOverflow -> LlmErrorCode.Parse
-        OkiaLLMErrorCode.Transport -> LlmErrorCode.Transport
-        OkiaLLMErrorCode.Parse -> LlmErrorCode.Parse
-        OkiaLLMErrorCode.HookFailed -> LlmErrorCode.HookFailed
-        OkiaLLMErrorCode.ToolExecutionFailed -> LlmErrorCode.ToolExecutionFailed
-        OkiaLLMErrorCode.RetryExhausted -> LlmErrorCode.RetryExhausted
     }
 
     private fun ContentBlock.ToolCall.toStatus(): ToolCallStatus =

--- a/agent-runtime/src/main/java/com/niki914/zafiro/settings/model/RuntimeSettingsModels.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/settings/model/RuntimeSettingsModels.kt
@@ -12,6 +12,10 @@ data class RuntimeLlmConfig(
     val memoryPrompt: String = "",
     val memories: List<String> = emptyList(),
     val takeoverKeywords: List<String> = emptyList(),
+    /** 流式空闲超时秒数；null = 不超时（Long.MAX_VALUE）。 */
+    val idleTimeoutSeconds: Long? = 60L,
+    /** 传输层自动重试次数。 */
+    val retryMaxAttempts: Int = 3,
 )
 
 enum class RuntimeAgentMemoryMode {

--- a/agent-runtime/src/main/res/values-b+zh+Hant/strings.xml
+++ b/agent-runtime/src/main/res/values-b+zh+Hant/strings.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="error_llm_request_failed">請求失敗，請重試</string>
     <string name="error_config_required">請先填寫配置</string>
 </resources>

--- a/agent-runtime/src/main/res/values-en/strings.xml
+++ b/agent-runtime/src/main/res/values-en/strings.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="error_llm_request_failed">Request failed. Please try again.</string>
     <string name="error_config_required">Please configure your model first</string>
 </resources>

--- a/agent-runtime/src/main/res/values/strings.xml
+++ b/agent-runtime/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="error_llm_request_failed">请求失败，请重试</string>
     <string name="error_config_required">请先填写配置</string>
 </resources>

--- a/agent-runtime/src/test/java/com/niki914/zafiro/chat/LLMControllerOkiaTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/zafiro/chat/LLMControllerOkiaTest.kt
@@ -1,6 +1,5 @@
 package com.niki914.zafiro.chat
 
-import android.content.Context
 import com.niki914.okia.Okia
 import com.niki914.okia.OkiaDependencies
 import com.niki914.okia.conversation.ConversationEntry
@@ -42,8 +41,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
 
 class LLMControllerOkiaTest {
 
@@ -163,7 +160,7 @@ class LLMControllerOkiaTest {
         LLMController.okiaFactory =
             LLMController.OkiaFactory { _, _, _ -> openOkiaWithStubLoop(loop) }
 
-        val events = LLMController.stream("hello", mockContext()).toList()
+        val events = LLMController.stream("hello").toList()
 
         assertEquals(LlmStreamEvent.RoundStarted, events[0])
         assertEquals("hi", (events[1] as LlmStreamEvent.TextDelta).delta)
@@ -196,7 +193,7 @@ class LLMControllerOkiaTest {
         LLMController.okiaFactory =
             LLMController.OkiaFactory { _, _, _ -> openOkiaWithStubLoop(loop) }
 
-        val events = LLMController.stream("hello", mockContext()).toList()
+        val events = LLMController.stream("hello").toList()
 
         val error = events.first { it is LlmStreamEvent.Error } as LlmStreamEvent.Error
         assertEquals("boom", error.message)
@@ -221,7 +218,7 @@ class LLMControllerOkiaTest {
         LLMController.okiaFactory =
             LLMController.OkiaFactory { _, _, _ -> openOkiaWithStubLoop(loop) }
 
-        LLMController.stream("hello", mockContext()).toList()
+        LLMController.stream("hello").toList()
 
         val snapshot = capturedSnapshots.single()
         assertTrue(snapshot.systemPrompt.orEmpty().contains("Base"))
@@ -249,10 +246,10 @@ class LLMControllerOkiaTest {
         LLMController.okiaFactory =
             LLMController.OkiaFactory { _, _, _ -> openOkiaWithStubLoop(blockingLoop) }
 
-        val firstJob = launch { LLMController.stream("q1", mockContext()).toList() }
+        val firstJob = launch { LLMController.stream("q1").toList() }
         entered.await()
         // 第二个并发 send：OKIA 活跃回合契约抛 IllegalStateException → TurnConflict
-        val secondEvents = LLMController.stream("q2", mockContext()).toList()
+        val secondEvents = LLMController.stream("q2").toList()
         val error = secondEvents.first { it is LlmStreamEvent.Error } as LlmStreamEvent.Error
         assertEquals(LlmErrorCode.TurnConflict, error.code)
 
@@ -411,10 +408,6 @@ class LLMControllerOkiaTest {
         )
     }
 
-    private fun mockContext(): Context = mock(Context::class.java).apply {
-        `when`(getString(com.niki914.zafiro.R.string.error_llm_request_failed))
-            .thenReturn("Request failed")
-    }
 
     private fun stubLoop(
         events: List<TurnEvent>,

--- a/agent-runtime/src/test/java/com/niki914/zafiro/chat/LLMControllerOkiaTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/zafiro/chat/LLMControllerOkiaTest.kt
@@ -81,6 +81,36 @@ class LLMControllerOkiaTest {
     }
 
     @Test
+    fun refresh_appliesTimeoutAndRetryToExistingSessionHot() = runTest {
+        // 实例复用路径（协议不变）：改设置后 refresh() 应热更新 idle timeout / retry policy，
+        // 否则改设置要冷启才生效（回归：曾只在新实例时写入）
+        installRuntimeSettingsGatewayForTest(
+            FakeRuntimeSettingsGateway(
+                llmConfig = validLlmConfig(idleTimeoutSeconds = 30L, retryMaxAttempts = 1),
+            )
+        )
+        LLMController.okiaFactory = LLMController.OkiaFactory { _, _, _ ->
+            openOkiaWithStubLoop(stubLoop(emptyList(), TurnResult.Completed(CompletionReason.Stop)))
+        }
+
+        LLMController.refresh()
+        assertEquals(30L, LLMController.okia?.config()?.idleTimeoutSeconds)
+        assertEquals(1, LLMController.okia?.config()?.retryPolicy?.maxAttempts)
+
+        // 同一实例复用，仅改设置 → 热更新生效
+        val gateway = installRuntimeSettingsGatewayForTest(
+            FakeRuntimeSettingsGateway(
+                llmConfig = validLlmConfig(idleTimeoutSeconds = 90L, retryMaxAttempts = 5),
+            )
+        )
+        gateway.llmConfig = validLlmConfig(idleTimeoutSeconds = 90L, retryMaxAttempts = 5)
+        LLMController.refresh()
+
+        assertEquals(90L, LLMController.okia?.config()?.idleTimeoutSeconds)
+        assertEquals(5, LLMController.okia?.config()?.retryPolicy?.maxAttempts)
+    }
+
+    @Test
     fun refresh_registersOnlyEnabledLocalTools() = runTest {
         installRuntimeSettingsGatewayForTest(
             FakeRuntimeSettingsGateway(
@@ -398,6 +428,8 @@ class LLMControllerOkiaTest {
         provider: String = "deepseek",
         protocol: String = LlmProtocol.OpenAiResponses.wireId,
         prompt: String = "Base prompt",
+        idleTimeoutSeconds: Long? = 60L,
+        retryMaxAttempts: Int = 3,
     ): RuntimeLlmConfig {
         return RuntimeLlmConfig(
             provider = provider,
@@ -405,6 +437,8 @@ class LLMControllerOkiaTest {
             endpoint = "https://example.com/v1",
             model = "deepseek-chat",
             prompt = prompt,
+            idleTimeoutSeconds = idleTimeoutSeconds,
+            retryMaxAttempts = retryMaxAttempts,
         )
     }
 

--- a/agent-runtime/src/test/java/com/niki914/zafiro/chat/LLMControllerRefreshSkillTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/zafiro/chat/LLMControllerRefreshSkillTest.kt
@@ -1,6 +1,5 @@
 package com.niki914.zafiro.chat
 
-import android.content.Context
 import com.niki914.zafiro.chat.util.SilentLoggerRule
 import com.niki914.zafiro.settings.model.RuntimeLlmConfig
 import com.niki914.zafiro.settings.model.RuntimeSkillMetadata
@@ -12,8 +11,6 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
 
 class LLMControllerRefreshSkillTest {
     @get:Rule
@@ -65,12 +62,8 @@ class LLMControllerRefreshSkillTest {
         val previous = LLMController.refresh()
         gateway.failListEnabledSkills = IllegalStateException("skills failed")
 
-        val context = mock(Context::class.java).apply {
-            `when`(getString(com.niki914.zafiro.R.string.error_llm_request_failed))
-                .thenReturn("Request failed")
-        }
         val firstEvent = withTimeoutOrNull(1_000) {
-            LLMController.stream("q", context).firstOrNull()
+            LLMController.stream("q").firstOrNull()
         }
 
         assertEquals(2, gateway.listEnabledSkillsCallCount)

--- a/agent-runtime/src/test/java/com/niki914/zafiro/chat/RetryableErrorClassifierTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/zafiro/chat/RetryableErrorClassifierTest.kt
@@ -1,0 +1,88 @@
+package com.niki914.zafiro.chat
+
+import com.niki914.okia.error.LLMError
+import com.niki914.okia.error.LLMErrorCode
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RetryableErrorClassifierTest {
+
+    private fun classify(
+        code: LLMErrorCode,
+        message: String,
+        statusCode: Int? = null,
+        cause: Throwable? = null,
+    ): LlmErrorCode = RetryableErrorClassifier.classify(LLMError(code, message, cause, statusCode))
+
+    @Test
+    fun `okia fine-grained codes pass through unchanged`() {
+        assertEquals(LlmErrorCode.Auth, classify(LLMErrorCode.Auth, "invalid key"))
+        assertEquals(LlmErrorCode.Quota, classify(LLMErrorCode.Quota, "quota"))
+        assertEquals(LlmErrorCode.RateLimit, classify(LLMErrorCode.RateLimit, "slow down"))
+        assertEquals(LlmErrorCode.Overloaded, classify(LLMErrorCode.Overloaded, "busy"))
+        assertEquals(LlmErrorCode.Parse, classify(LLMErrorCode.Parse, "bad json"))
+        assertEquals(
+            LlmErrorCode.Parse,
+            classify(LLMErrorCode.ContextOverflow, "context too long"),
+        )
+        assertEquals(LlmErrorCode.RetryExhausted, classify(LLMErrorCode.RetryExhausted, "retry exhausted (Transport)"))
+        assertEquals(LlmErrorCode.HookFailed, classify(LLMErrorCode.HookFailed, "hook"))
+        assertEquals(
+            LlmErrorCode.ToolExecutionFailed,
+            classify(LLMErrorCode.ToolExecutionFailed, "tool"),
+        )
+    }
+
+    @Test
+    fun `Transport overloads classify as Overloaded`() {
+        assertEquals(
+            LlmErrorCode.Overloaded,
+            classify(LLMErrorCode.Transport, "The server is overloaded"),
+        )
+        assertEquals(
+            LlmErrorCode.Overloaded,
+            classify(LLMErrorCode.Transport, "service temporarily unavailable"),
+        )
+        assertEquals(LlmErrorCode.Overloaded, classify(LLMErrorCode.Transport, "upstream error", statusCode = 503))
+    }
+
+    @Test
+    fun `Transport rate limits classify as RateLimit`() {
+        assertEquals(LlmErrorCode.RateLimit, classify(LLMErrorCode.Transport, "rate limit exceeded"))
+        assertEquals(LlmErrorCode.RateLimit, classify(LLMErrorCode.Transport, "HTTP 429", statusCode = 429))
+        assertEquals(LlmErrorCode.RateLimit, classify(LLMErrorCode.Transport, "too many requests"))
+    }
+
+    @Test
+    fun `Transport timeouts classify as IdleTimeout`() {
+        assertEquals(LlmErrorCode.IdleTimeout, classify(LLMErrorCode.Transport, "request timeout"))
+        assertEquals(LlmErrorCode.IdleTimeout, classify(LLMErrorCode.Transport, "connection timed out"))
+        assertEquals(LlmErrorCode.IdleTimeout, classify(LLMErrorCode.Transport, "ETIMEDOUT", cause = RuntimeException("ETIMEDOUT")))
+    }
+
+    @Test
+    fun `Transport connection errors classify as Transport`() {
+        assertEquals(LlmErrorCode.Transport, classify(LLMErrorCode.Transport, "socket hang up"))
+        assertEquals(LlmErrorCode.Transport, classify(LLMErrorCode.Transport, "ECONNRESET", cause = RuntimeException("ECONNRESET")))
+        assertEquals(LlmErrorCode.Transport, classify(LLMErrorCode.Transport, "connection refused"))
+    }
+
+    @Test
+    fun `Transport stream truncation classifies as Transport`() {
+        assertEquals(
+            LlmErrorCode.Transport,
+            classify(LLMErrorCode.Transport, "stream ended without a final response"),
+        )
+    }
+
+    @Test
+    fun `auth keywords in transport message classify as Auth`() {
+        assertEquals(LlmErrorCode.Auth, classify(LLMErrorCode.Transport, "HTTP 401", statusCode = 401))
+        assertEquals(LlmErrorCode.Auth, classify(LLMErrorCode.Transport, "invalid api key"))
+    }
+
+    @Test
+    fun `unrecognized transport message stays Transport`() {
+        assertEquals(LlmErrorCode.Transport, classify(LLMErrorCode.Transport, "something weird happened"))
+    }
+}

--- a/agent-runtime/src/test/java/com/niki914/zafiro/chat/RuntimeSettingsTestFakes.kt
+++ b/agent-runtime/src/test/java/com/niki914/zafiro/chat/RuntimeSettingsTestFakes.kt
@@ -27,7 +27,7 @@ internal fun installRuntimeSettingsGatewayForTest(
 }
 
 internal class FakeRuntimeSettingsGateway(
-    private val llmConfig: RuntimeLlmConfig = RuntimeLlmConfig(),
+    var llmConfig: RuntimeLlmConfig = RuntimeLlmConfig(),
     customPyTools: List<RuntimeCustomPyTool> = emptyList(),
     builtinTools: List<RuntimeBuiltinToolSetting> = defaultBuiltinToolSettings(),
     memories: List<String> = emptyList(),

--- a/agent-runtime/src/test/java/com/niki914/zafiro/chat/agentic/stream/LlmStreamEventMapperTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/zafiro/chat/agentic/stream/LlmStreamEventMapperTest.kt
@@ -28,8 +28,7 @@ class LlmStreamEventMapperTest {
         val result = LlmStreamEventMapper.map(
             TurnEvent.TurnStarted("hello"),
             startedAtMs = 0L,
-            defaultErrorMessage = "default error",
-        )
+            )
         assertEquals(LlmStreamEvent.RoundStarted, result)
     }
 
@@ -39,15 +38,13 @@ class LlmStreamEventMapperTest {
         LlmStreamEventMapper.map(
             TurnEvent.TextStarted(0, AssistantMessage(content = listOf(ContentBlock.Text("he")))),
             startedAtMs = 0L,
-            defaultErrorMessage = "default error",
-        )
+            )
         val partial = AssistantMessage(content = listOf(ContentBlock.Text("helo")))
         val startedAtMs = System.currentTimeMillis() - 500L
         val result = LlmStreamEventMapper.map(
             TurnEvent.TextDelta(index = 0, delta = "lo", partial = partial),
             startedAtMs = startedAtMs,
-            defaultErrorMessage = "default error",
-        )
+            )
         val delta = result as LlmStreamEvent.TextDelta
         assertEquals("lo", delta.delta)
         assertEquals("helo", delta.fullText)
@@ -61,8 +58,7 @@ class LlmStreamEventMapperTest {
         val started = LlmStreamEventMapper.map(
             TurnEvent.TextStarted(0, AssistantMessage(listOf(ContentBlock.Text("你好")))),
             0L,
-            "default error",
-        ) as LlmStreamEvent.TextDelta
+                    ) as LlmStreamEvent.TextDelta
         assertEquals("你好", started.delta)
         assertEquals("你好", started.fullText)
 
@@ -74,8 +70,7 @@ class LlmStreamEventMapperTest {
                 AssistantMessage(listOf(ContentBlock.Text("你好！有什么")))
             ),
             0L,
-            "default error",
-        ) as LlmStreamEvent.TextDelta
+                    ) as LlmStreamEvent.TextDelta
         assertEquals("！有什么", next.delta)
         assertEquals("你好！有什么", next.fullText)
 
@@ -89,15 +84,14 @@ class LlmStreamEventMapperTest {
         LlmStreamEventMapper.map(
             TurnEvent.TextStarted(0, AssistantMessage(listOf(ContentBlock.Text("first")))),
             0L,
-            "default error",
-        )
+                    )
         assertNull(
             LlmStreamEventMapper.map(
                 TurnEvent.TextEnded(
                     0,
                     "first",
                     AssistantMessage(emptyList())
-                ), 0L, "default error"
+                ), 0L
             )
         )
 
@@ -105,8 +99,7 @@ class LlmStreamEventMapperTest {
         val next = LlmStreamEventMapper.map(
             TurnEvent.TextStarted(0, AssistantMessage(listOf(ContentBlock.Text("second")))),
             0L,
-            "default error",
-        ) as LlmStreamEvent.TextDelta
+                    ) as LlmStreamEvent.TextDelta
         assertEquals("second", next.delta)
     }
 
@@ -115,19 +108,16 @@ class LlmStreamEventMapperTest {
         LlmStreamEventMapper.map(
             TurnEvent.TextStarted(0, AssistantMessage(listOf(ContentBlock.Text("answer1")))),
             0L,
-            "default error",
-        )
+                    )
         LlmStreamEventMapper.map(
             TurnEvent.TurnCompleted(AssistantMessage(listOf(ContentBlock.Text("answer1")))),
             0L,
-            "default error",
-        )
+                    )
 
         val next = LlmStreamEventMapper.map(
             TurnEvent.TextStarted(0, AssistantMessage(listOf(ContentBlock.Text("answer2")))),
             0L,
-            "default error",
-        ) as LlmStreamEvent.TextDelta
+                    ) as LlmStreamEvent.TextDelta
         assertEquals("answer2", next.delta)
         assertEquals("answer2", next.fullText)
     }
@@ -140,8 +130,7 @@ class LlmStreamEventMapperTest {
         val result = LlmStreamEventMapper.map(
             TurnEvent.ToolRunning(0, call, AssistantMessage(emptyList())),
             0L,
-            "default error",
-        )
+                    )
         val running = result as LlmStreamEvent.ToolRunning
         assertEquals("c1", running.call.callId)
         assertEquals("search", running.call.name)
@@ -158,8 +147,7 @@ class LlmStreamEventMapperTest {
                 AssistantMessage(emptyList())
             ),
             0L,
-            "default error",
-        )
+                    )
         val succeeded = result as LlmStreamEvent.ToolSucceeded
         assertEquals("payload", succeeded.outputText)
     }
@@ -175,8 +163,7 @@ class LlmStreamEventMapperTest {
                 AssistantMessage(emptyList())
             ),
             0L,
-            "default error",
-        )
+                    )
         assertEquals(LlmStreamEvent.ToolSucceeded::class, result!!::class)
     }
 
@@ -191,8 +178,7 @@ class LlmStreamEventMapperTest {
                 AssistantMessage(emptyList())
             ),
             0L,
-            "default error",
-        )
+                    )
         val failed = result as LlmStreamEvent.ToolFailed
         assertEquals("denied", failed.message)
     }
@@ -208,8 +194,7 @@ class LlmStreamEventMapperTest {
                 AssistantMessage(emptyList())
             ),
             0L,
-            "default error",
-        )
+                    )
         val failed = result as LlmStreamEvent.ToolFailed
         assertEquals("boom", failed.message)
         assertEquals("detail", failed.resultText)
@@ -226,8 +211,7 @@ class LlmStreamEventMapperTest {
                 AssistantMessage(emptyList())
             ),
             0L,
-            "default error",
-        )
+                    )
         assertEquals("failed", (result as LlmStreamEvent.ToolFailed).message)
     }
 
@@ -241,8 +225,7 @@ class LlmStreamEventMapperTest {
         val started = LlmStreamEventMapper.map(
             TurnEvent.ToolCallStarted(0, partial, callId = "c1", toolName = "terminal"),
             0L,
-            "default error",
-        )
+                    )
         val pending = started as LlmStreamEvent.ToolPending
         assertEquals("c1", pending.call.callId)
         assertEquals("terminal", pending.call.name)
@@ -250,124 +233,168 @@ class LlmStreamEventMapperTest {
         val dropped = listOf(
             TurnEvent.ToolCallDelta(0, "{}", partial),
             TurnEvent.ToolCallReady(0, call, partial),
-            TurnEvent.RetryScheduled(1, 3, 100L, "rate limit"),
         )
         dropped.forEach {
-            assertNull(LlmStreamEventMapper.map(it, 0L, "default error"))
+            assertNull(LlmStreamEventMapper.map(it, 0L))
         }
     }
 
+    @Test
+    fun `RetryScheduled maps to Retrying event`() {
+        val result = LlmStreamEventMapper.map(
+            TurnEvent.RetryScheduled(1, 3, 100L, "rate limit"),
+            0L,
+                    )
+        val mapped = result as LlmStreamEvent.Retrying
+        assertEquals(1, mapped.attempt)
+        assertEquals(3, mapped.maxAttempts)
+        assertEquals(100L, mapped.delayMs)
+        assertEquals("rate limit", mapped.reason)
+    }
+
+    @Test
+    fun `TurnFailed with RetryExhausted carries scheduled attempts`() {
+        // attempts 来自 RetryScheduled 事件流（结构化），不反向解析错误串
+        LlmStreamEventMapper.map(TurnEvent.TurnStarted("q"), 0L)
+        LlmStreamEventMapper.map(TurnEvent.RetryScheduled(1, 3, 100L, "transport"), 0L)
+        LlmStreamEventMapper.map(TurnEvent.RetryScheduled(2, 3, 100L, "transport"), 0L)
+        LlmStreamEventMapper.map(TurnEvent.RetryScheduled(3, 3, 100L, "transport"), 0L)
+        val error = LLMError(OkiaLLMErrorCode.RetryExhausted, "retry exhausted (Transport)")
+        val result = LlmStreamEventMapper.map(
+            TurnEvent.TurnFailed(AssistantMessage(emptyList()), error),
+            0L,
+        )
+        val mapped = result as LlmStreamEvent.Error
+        assertEquals(LlmErrorCode.RetryExhausted, mapped.code)
+        assertEquals(3, mapped.attempts)
+    }
+
+    @Test
+    fun `TurnFailed without retries has null attempts`() {
+        val error = LLMError(OkiaLLMErrorCode.Transport, "connection reset")
+        val result = LlmStreamEventMapper.map(
+            TurnEvent.TurnFailed(AssistantMessage(emptyList()), error),
+            0L,
+        )
+        assertNull((result as LlmStreamEvent.Error).attempts)
+    }
+
+    @Test
+    fun `RetryScheduled resets text accumulation`() {
+        val partial = assistantPartial("hello world")
+        LlmStreamEventMapper.map(TurnEvent.TextStarted(0, partial), 0L)
+
+        LlmStreamEventMapper.map(TurnEvent.RetryScheduled(1, 3, 100L, "x"), 0L)
+
+        // 重试后成功尝试的全量重放应完整成为 delta（累积已重置）
+        val replay = LlmStreamEventMapper.map(
+            TurnEvent.TextStarted(0, assistantPartial("fresh text")),
+            0L,
+                    ) as LlmStreamEvent.TextDelta
+        assertEquals("fresh text", replay.delta)
+    }
+
     // ── 思考块：全量两态，Mapper 分配回合内单调 id ───────────────────────────
+
+    private fun assistantPartial(text: String) =
+        AssistantMessage(content = listOf(ContentBlock.Text(text)))
 
     private fun thinkingPartial(text: String) =
         AssistantMessage(content = listOf(ContentBlock.Thinking(text)))
 
     @Test
     fun `ThinkingStarted maps to ThinkingStarted with fresh id and full text`() {
-        LlmStreamEventMapper.map(TurnEvent.TurnStarted("q"), 0L, "default error")
+        LlmStreamEventMapper.map(TurnEvent.TurnStarted("q"), 0L)
         val result = LlmStreamEventMapper.map(
             TurnEvent.ThinkingStarted(1, thinkingPartial("deep think")),
             0L,
-            "default error",
-        )
+                    )
         assertEquals(LlmStreamEvent.ThinkingStarted(0, "deep think"), result)
     }
 
     @Test
     fun `ThinkingDelta re-emits ThinkingStarted with same id and updated full text`() {
-        LlmStreamEventMapper.map(TurnEvent.TurnStarted("q"), 0L, "default error")
+        LlmStreamEventMapper.map(TurnEvent.TurnStarted("q"), 0L)
         LlmStreamEventMapper.map(
             TurnEvent.ThinkingStarted(1, thinkingPartial("dee")),
             0L,
-            "default error",
-        )
+                    )
         val result = LlmStreamEventMapper.map(
             TurnEvent.ThinkingDelta(1, "p", thinkingPartial("deep think")),
             0L,
-            "default error",
-        )
+                    )
         assertEquals(LlmStreamEvent.ThinkingStarted(0, "deep think"), result)
     }
 
     @Test
     fun `ThinkingEnded maps to ThinkingEnded with final content`() {
-        LlmStreamEventMapper.map(TurnEvent.TurnStarted("q"), 0L, "default error")
+        LlmStreamEventMapper.map(TurnEvent.TurnStarted("q"), 0L)
         LlmStreamEventMapper.map(
             TurnEvent.ThinkingStarted(1, thinkingPartial("deep think")),
             0L,
-            "default error",
-        )
+                    )
         val result = LlmStreamEventMapper.map(
             TurnEvent.ThinkingEnded(1, "deep think", thinkingPartial("deep think")),
             0L,
-            "default error",
-        )
+                    )
         assertEquals(LlmStreamEvent.ThinkingEnded(0, "deep think"), result)
     }
 
     @Test
     fun `New round reusing same index gets a distinct id (no merge across tool rounds)`() {
-        LlmStreamEventMapper.map(TurnEvent.TurnStarted("q"), 0L, "default error")
+        LlmStreamEventMapper.map(TurnEvent.TurnStarted("q"), 0L)
         // 第一轮：index=0 的思考块
         val first = LlmStreamEventMapper.map(
             TurnEvent.ThinkingStarted(0, thinkingPartial("first block")),
             0L,
-            "default error",
-        )
+                    )
         LlmStreamEventMapper.map(
             TurnEvent.ThinkingEnded(0, "first block", thinkingPartial("first block")),
             0L,
-            "default error",
-        )
+                    )
         // 第二轮（工具轮后 StreamState 重建）：index 又回到 0，必须是新 id
         val second = LlmStreamEventMapper.map(
             TurnEvent.ThinkingStarted(0, thinkingPartial("second block")),
             0L,
-            "default error",
-        )
+                    )
         assertEquals(LlmStreamEvent.ThinkingStarted(0, "first block"), first)
         assertEquals(LlmStreamEvent.ThinkingStarted(1, "second block"), second)
     }
 
     @Test
     fun `Thinking with blank text produces no event`() {
-        LlmStreamEventMapper.map(TurnEvent.TurnStarted("q"), 0L, "default error")
+        LlmStreamEventMapper.map(TurnEvent.TurnStarted("q"), 0L)
         assertNull(
             LlmStreamEventMapper.map(
                 TurnEvent.ThinkingStarted(0, thinkingPartial("")),
                 0L,
-                "default error",
-            )
+                            )
         )
         assertNull(
             LlmStreamEventMapper.map(
                 TurnEvent.ThinkingDelta(0, "", thinkingPartial("  ")),
                 0L,
-                "default error",
-            )
+                            )
         )
         assertNull(
             LlmStreamEventMapper.map(
                 TurnEvent.ThinkingEnded(0, "", thinkingPartial("")),
                 0L,
-                "default error",
-            )
+                            )
         )
     }
 
     @Test
     fun `TurnAborted with active thinking maps to ThinkingEnded (interrupted counts as done)`() {
-        LlmStreamEventMapper.map(TurnEvent.TurnStarted("q"), 0L, "default error")
+        LlmStreamEventMapper.map(TurnEvent.TurnStarted("q"), 0L)
         LlmStreamEventMapper.map(
             TurnEvent.ThinkingStarted(3, thinkingPartial("half thought")),
             0L,
-            "default error",
-        )
+                    )
         val result = LlmStreamEventMapper.map(
             TurnEvent.TurnAborted(AssistantMessage(emptyList()), StopCause.UserStop),
             0L,
-            "default error",
-        )
+                    )
         assertEquals(LlmStreamEvent.ThinkingEnded(0, "half thought"), result)
     }
 
@@ -376,8 +403,7 @@ class LlmStreamEventMapperTest {
         val result = LlmStreamEventMapper.map(
             TurnEvent.TurnAborted(AssistantMessage(emptyList()), StopCause.UserStop),
             0L,
-            "default error",
-        )
+                    )
         assertNull(result)
     }
 
@@ -388,8 +414,7 @@ class LlmStreamEventMapperTest {
         val result = LlmStreamEventMapper.map(
             TurnEvent.TurnCompleted(AssistantMessage(content = listOf(ContentBlock.Text("answer")))),
             0L,
-            "default error",
-        )
+                    )
         assertEquals(LlmStreamEvent.Completed, result)
     }
 
@@ -399,8 +424,7 @@ class LlmStreamEventMapperTest {
         val result = LlmStreamEventMapper.map(
             TurnEvent.TurnFailed(AssistantMessage(emptyList()), error),
             0L,
-            "default error",
-        )
+                    )
         val mapped = result as LlmStreamEvent.Error
         assertEquals("boom", mapped.message)
         assertEquals(LlmErrorCode.Transport, mapped.code)
@@ -412,8 +436,7 @@ class LlmStreamEventMapperTest {
         val result = LlmStreamEventMapper.map(
             TurnEvent.TurnFailed(AssistantMessage(emptyList()), error),
             0L,
-            "default error",
-        )
+                    )
         assertEquals(LlmErrorCode.Auth, (result as LlmStreamEvent.Error).code)
     }
 
@@ -423,42 +446,42 @@ class LlmStreamEventMapperTest {
         val result = LlmStreamEventMapper.map(
             TurnEvent.TurnFailed(AssistantMessage(emptyList()), error),
             0L,
-            "default error",
-        )
+                    )
         assertEquals(LlmErrorCode.Parse, (result as LlmStreamEvent.Error).code)
     }
 
     @Test
-    fun `TurnFailed with blank message falls back to default`() {
+    fun `TurnFailed with blank message yields null message`() {
+        // 兜底文案归 UI/Service 层，mapper 原文透传不造字符串
         val error = LLMError(OkiaLLMErrorCode.Auth, " ")
         val result = LlmStreamEventMapper.map(
             TurnEvent.TurnFailed(AssistantMessage(emptyList()), error),
             0L,
-            "default error",
         )
-        assertEquals("default error", (result as LlmStreamEvent.Error).message)
+        assertNull((result as LlmStreamEvent.Error).message)
     }
 
     @Test
-    fun `TurnIdleTimeout maps to Error with default message and Transport code`() {
+    fun `TurnIdleTimeout maps to Error with null message and IdleTimeout code`() {
+        // 文案归 UI 层：mapper 只带类型，message 为空
         val result = LlmStreamEventMapper.map(
             TurnEvent.TurnIdleTimeout(AssistantMessage(emptyList())),
             0L,
-            "default error",
         )
         val mapped = result as LlmStreamEvent.Error
-        assertEquals("default error", mapped.message)
-        assertEquals(LlmErrorCode.Transport, mapped.code)
+        assertNull(mapped.message)
+        assertEquals(LlmErrorCode.IdleTimeout, mapped.code)
     }
 
     @Test
     fun `TurnAborted does not produce an error event`() {
+        // Mapper 是单例有状态：先重置（真实使用中每个回合由 TurnStarted 触发重置）
+        LlmStreamEventMapper.map(TurnEvent.TurnStarted("q"), 0L)
         assertNull(
             LlmStreamEventMapper.map(
                 TurnEvent.TurnAborted(AssistantMessage(emptyList()), StopCause.UserStop),
                 0L,
-                "default error",
-            )
+                            )
         )
     }
 }

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/CollapsibleBlock.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/CollapsibleBlock.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
@@ -116,6 +117,10 @@ fun CollapsibleBlock(
     onToggle: () -> Unit,
     modifier: Modifier = Modifier,
     isRunning: Boolean = false,
+    /** 容器色；默认 surfaceContainerLow（Thinking/Tool 现状）。retry/error 块传 container 色。 */
+    containerColor: Color = MaterialTheme.colorScheme.surfaceContainerLow,
+    /** true = 常展开展示形态：无尾部槽位、toggle 不生效；按压反馈保留（错误展示用）。 */
+    nonCollapsible: Boolean = false,
     content: @Composable ColumnScope.() -> Unit = {},
 ) {
     val interaction = remember { MutableInteractionSource() }
@@ -166,7 +171,7 @@ fun CollapsibleBlock(
     )
 
     val shape = remember(radiusDp) { G2FieldShape(radiusDp) }
-    val surface = MaterialTheme.colorScheme.surfaceContainerLow
+    val surface = containerColor
 
     Column(
         modifier = modifier
@@ -179,7 +184,8 @@ fun CollapsibleBlock(
             .clickable(
                 interactionSource = interaction,
                 indication = null,
-                onClick = onToggle,
+                // 不可折叠形态只保留按压反馈，toggle 不触发
+                onClick = { if (!nonCollapsible) onToggle() },
             )
             .padding(vertical = BlockContainerPadY),
     ) {
@@ -210,8 +216,11 @@ fun CollapsibleBlock(
                 modifier = Modifier.weight(1f),
             )
             Spacer(modifier = Modifier.width(BlockRowGap))
-            // 尾部槽位：tonal 圆底与左图标对称，内容在 chevron（完成）↔ loader（运行中）间切换
-            Box(
+            // 尾部槽位：tonal 圆底与左图标对称，内容在 chevron（完成）↔ loader（运行中）间切换；
+            // 不可折叠形态整个槽位（含圆底）不渲染
+            if (nonCollapsible) {
+                Spacer(Modifier.size(BlockIconDot))
+            } else Box(
                 modifier = Modifier
                     .size(BlockIconDot)
                     .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f), CircleShape),

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/GeneralSettingsContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/GeneralSettingsContent.kt
@@ -33,6 +33,8 @@ import kotlinx.coroutines.runBlocking
 private const val LANGUAGE_ROW_ID = "general.language"
 private const val APPEARANCE_ROW_ID = "general.appearance"
 private const val LOAD_LAST_ROW_ID = "general.load_last"
+private const val IDLE_TIMEOUT_ROW_ID = "general.idle_timeout"
+private const val RETRY_ATTEMPTS_ROW_ID = "general.retry_attempts"
 
 private const val LANGUAGE_TAG_ZH_CN = "zh-CN"
 private const val LANGUAGE_TAG_ZH_TW = "zh-TW"
@@ -68,11 +70,17 @@ fun GeneralSettingsContent(onPush: (ZafiroPage) -> Unit = {}) {
     var savedLanguageTag by rememberSaveable { mutableStateOf<String?>(null) }
     var loadLastConversation by rememberSaveable { mutableStateOf(false) }
     var showLanguageDialog by rememberSaveable { mutableStateOf(false) }
+    var idleTimeoutSeconds by rememberSaveable { mutableStateOf(60L) }
+    var retryMaxAttempts by rememberSaveable { mutableStateOf(3) }
+    var showIdleTimeoutDialog by rememberSaveable { mutableStateOf(false) }
+    var showRetryDialog by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         runCatching {
             savedLanguageTag = XRepo.languageTag()
             loadLastConversation = XRepo.loadLastConversationOnStartup()
+            idleTimeoutSeconds = XRepo.llmIdleTimeoutSeconds()
+            retryMaxAttempts = XRepo.llmRetryMaxAttempts()
         }.onFailure {
             Logger.w("niki914_nexus_GeneralSettings", "load failed ${it.message}")
         }
@@ -104,6 +112,16 @@ fun GeneralSettingsContent(onPush: (ZafiroPage) -> Unit = {}) {
                         title = stringResource(R.string.ui_settings_general_load_last_conversation),
                         checked = loadLastConversation,
                     ),
+                    SettingsRowSpec.Navigation(
+                        id = IDLE_TIMEOUT_ROW_ID,
+                        title = stringResource(R.string.ui_settings_general_idle_timeout),
+                        currentState = idleTimeoutLabel(idleTimeoutSeconds),
+                    ),
+                    SettingsRowSpec.Navigation(
+                        id = RETRY_ATTEMPTS_ROW_ID,
+                        title = stringResource(R.string.ui_settings_general_retry_attempts),
+                        currentState = retryAttemptsLabel(retryMaxAttempts),
+                    ),
                 ),
             ),
         ),
@@ -118,6 +136,10 @@ fun GeneralSettingsContent(onPush: (ZafiroPage) -> Unit = {}) {
                         showLanguageDialog = true
                     } else if (action.id == APPEARANCE_ROW_ID) {
                         onPush(ThemeSettingsPage)
+                    } else if (action.id == IDLE_TIMEOUT_ROW_ID) {
+                        showIdleTimeoutDialog = true
+                    } else if (action.id == RETRY_ATTEMPTS_ROW_ID) {
+                        showRetryDialog = true
                     }
 
                 is SettingsRowAction.ToggleChanged ->
@@ -158,6 +180,40 @@ fun GeneralSettingsContent(onPush: (ZafiroPage) -> Unit = {}) {
             )
         },
     )
+
+    val idleTimeoutOptions = idleTimeoutOptions()
+    SingleChoiceLiquidDialog(
+        visible = showIdleTimeoutDialog,
+        onDismissRequest = { showIdleTimeoutDialog = false },
+        title = stringResource(R.string.ui_settings_general_idle_timeout),
+        hint = stringResource(R.string.ui_settings_general_idle_timeout_summary),
+        options = idleTimeoutOptions,
+        selectedId = idleTimeoutSeconds.toString(),
+        optionId = { it.seconds.toString() },
+        optionLabel = { it.label },
+        onSelect = { option ->
+            idleTimeoutSeconds = option.seconds
+            showIdleTimeoutDialog = false
+            scope.launch { XRepo.setLlmIdleTimeoutSeconds(option.seconds) }
+        },
+    )
+
+    val retryOptions = retryAttemptsOptions()
+    SingleChoiceLiquidDialog(
+        visible = showRetryDialog,
+        onDismissRequest = { showRetryDialog = false },
+        title = stringResource(R.string.ui_settings_general_retry_attempts),
+        hint = stringResource(R.string.ui_settings_general_retry_summary),
+        options = retryOptions,
+        selectedId = retryMaxAttempts.toString(),
+        optionId = { it.toString() },
+        optionLabel = { it.toString() },
+        onSelect = { option ->
+            retryMaxAttempts = option
+            showRetryDialog = false
+            scope.launch { XRepo.setLlmRetryMaxAttempts(option) }
+        },
+    )
 }
 
 @Composable
@@ -174,3 +230,31 @@ private fun appearanceSummary(): String {
         ?: stringResource(R.string.ui_theme_color_dynamic)
     return "$modeLabel · $colorLabel"
 }
+
+data class IdleTimeoutOption(
+    /** 持久化值：0 = 不超时。 */
+    val seconds: Long,
+    val label: String,
+)
+
+@Composable
+private fun idleTimeoutLabel(seconds: Long): String {
+    return idleTimeoutOptions().firstOrNull { it.seconds == seconds }?.label
+        ?: "$seconds"
+}
+
+@Composable
+private fun idleTimeoutOptions(): List<IdleTimeoutOption> {
+    val offLabel = stringResource(R.string.ui_settings_general_idle_timeout_off)
+    return listOf(
+        IdleTimeoutOption(seconds = 0L, label = offLabel),
+        IdleTimeoutOption(seconds = 30L, label = "30s"),
+        IdleTimeoutOption(seconds = 60L, label = "60s"),
+        IdleTimeoutOption(seconds = 90L, label = "90s"),
+        IdleTimeoutOption(seconds = 120L, label = "120s"),
+    )
+}
+
+private fun retryAttemptsLabel(attempts: Int): String = attempts.toString()
+
+private fun retryAttemptsOptions(): List<Int> = listOf(0, 1, 2, 3, 5)

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/HomeChatComponents.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/HomeChatComponents.kt
@@ -64,7 +64,7 @@ internal data class AssistantErrorUi(
     val body: String? = null,
 )
 
-internal fun toAssistantErrorUi(message: String, code: LlmErrorCode?): AssistantErrorUi {
+internal fun toAssistantErrorUi(message: String?, code: LlmErrorCode?, attempts: Int? = null): AssistantErrorUi {
     return when (code) {
         // 配置问题：用户可行动的引导（唯一本地化正文）
         LlmErrorCode.ConfigRequired -> AssistantErrorUi(
@@ -75,20 +75,36 @@ internal fun toAssistantErrorUi(message: String, code: LlmErrorCode?): Assistant
         // 服务器/网络异常（用户选的服务器）：标题分类 + 原始 message 透传。
         // Parse 也归此类：400 系客户端错误（模型名无效等）是用户配置/服务器问题，
         // 与 Auth 同类，不应算内部错误（正文 message 给出具体原因）。
+        // message 为空（controller 不再兜底字符串）时由 bodyRes 兜底。
+        // RetryExhausted 带 attempts：标题反映"重试已耗尽"而非泛网络错误
+        LlmErrorCode.RetryExhausted if attempts != null -> AssistantErrorUi(
+            titleRes = R.string.ui_home_error_retry_exhausted_title,
+            bodyRes = if (message.isNullOrBlank()) R.string.ui_home_error_retry_body else null,
+            body = message?.trim()?.ifEmpty { null },
+        )
+
         LlmErrorCode.Auth, LlmErrorCode.Quota, LlmErrorCode.RateLimit,
         LlmErrorCode.Overloaded, LlmErrorCode.Transport, LlmErrorCode.Parse,
         LlmErrorCode.RetryExhausted,
             -> AssistantErrorUi(
             titleRes = R.string.ui_home_error_network_title,
-            body = message.trim().ifEmpty { null },
+            bodyRes = if (message.isNullOrBlank()) R.string.ui_home_error_retry_body else null,
+            body = message?.trim()?.ifEmpty { null },
+        )
+
+        // 响应空闲超时：专属标题，秒数不进错误串（用户只需知道超时了）
+        LlmErrorCode.IdleTimeout -> AssistantErrorUi(
+            titleRes = R.string.ui_home_error_idle_timeout_title,
+            bodyRes = if (message.isNullOrBlank()) R.string.ui_home_error_retry_body else null,
+            body = message?.trim()?.ifEmpty { null },
         )
 
         // 内部错误（我们的问题 / 未知）：标题分类 + 原始 message 透传，空则兜底
         LlmErrorCode.TurnConflict, LlmErrorCode.HookFailed,
         LlmErrorCode.ToolExecutionFailed, null,
             -> {
-            val normalized = message.trim()
-            if (normalized.isEmpty()) {
+            val normalized = message?.trim()
+            if (normalized.isNullOrEmpty()) {
                 AssistantErrorUi(
                     titleRes = R.string.ui_home_error_internal_title,
                     bodyRes = R.string.ui_home_error_retry_body,
@@ -103,7 +119,7 @@ internal fun toAssistantErrorUi(message: String, code: LlmErrorCode?): Assistant
     }
 }
 
-internal fun toAssistantErrorUi(message: String): AssistantErrorUi {
+internal fun toAssistantErrorUi(message: String?): AssistantErrorUi {
     return toAssistantErrorUi(message = message, code = null)
 }
 
@@ -315,8 +331,9 @@ private fun DrawScope.drawUserBubbleTail(color: Color) {
 
 @Composable
 fun AssistantErrorBlock(
-    message: String,
+    message: String?,
     code: LlmErrorCode? = null,
+    attempts: Int? = null,
     modifier: Modifier = Modifier,
 ) {
     val colorScheme = MaterialTheme.colorScheme
@@ -349,6 +366,51 @@ fun AssistantErrorBlock(
                 color = colorScheme.onErrorContainer,
                 textAlign = TextAlign.Center,
             )
+        }
+    }
+}
+
+@Composable
+fun AssistantRetryingBlock(
+    attempt: Int,
+    maxAttempts: Int,
+    reason: String,
+    modifier: Modifier = Modifier,
+) {
+    val colorScheme = MaterialTheme.colorScheme
+    val shape = G2BubbleShape(18.dp)
+    // 原始错误文本透传（英文，来自上游/传输层）；空则只显示标题
+    val normalizedReason = reason.trim()
+    BoxWithConstraints(
+        modifier = modifier.fillMaxWidth(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            modifier = Modifier
+                .widthIn(max = maxWidth * 0.82f)
+                .clip(shape)
+                .background(
+                    colorScheme.secondaryContainer.copy(alpha = 0.68f),
+                    shape,
+                )
+                .padding(horizontal = 18.dp, vertical = 14.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.ui_home_retrying_title, attempt, maxAttempts),
+                style = MaterialTheme.typography.labelLarge,
+                color = colorScheme.onSecondaryContainer,
+                textAlign = TextAlign.Center,
+            )
+            if (normalizedReason.isNotEmpty()) {
+                Text(
+                    text = normalizedReason,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = colorScheme.onSecondaryContainer.copy(alpha = 0.8f),
+                    textAlign = TextAlign.Center,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/HomeChatComponents.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/HomeChatComponents.kt
@@ -338,7 +338,7 @@ fun AssistantErrorBlock(
 ) {
     val colorScheme = MaterialTheme.colorScheme
     val shape = G2BubbleShape(18.dp)
-    val errorUi = toAssistantErrorUi(message = message, code = code)
+    val errorUi = toAssistantErrorUi(message = message, code = code, attempts = attempts)
     val body = errorUi.bodyRes?.let { stringResource(it) } ?: errorUi.body.orEmpty()
 
     BoxWithConstraints(
@@ -366,51 +366,6 @@ fun AssistantErrorBlock(
                 color = colorScheme.onErrorContainer,
                 textAlign = TextAlign.Center,
             )
-        }
-    }
-}
-
-@Composable
-fun AssistantRetryingBlock(
-    attempt: Int,
-    maxAttempts: Int,
-    reason: String,
-    modifier: Modifier = Modifier,
-) {
-    val colorScheme = MaterialTheme.colorScheme
-    val shape = G2BubbleShape(18.dp)
-    // 原始错误文本透传（英文，来自上游/传输层）；空则只显示标题
-    val normalizedReason = reason.trim()
-    BoxWithConstraints(
-        modifier = modifier.fillMaxWidth(),
-        contentAlignment = Alignment.Center,
-    ) {
-        Column(
-            modifier = Modifier
-                .widthIn(max = maxWidth * 0.82f)
-                .clip(shape)
-                .background(
-                    colorScheme.secondaryContainer.copy(alpha = 0.68f),
-                    shape,
-                )
-                .padding(horizontal = 18.dp, vertical = 14.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(6.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.ui_home_retrying_title, attempt, maxAttempts),
-                style = MaterialTheme.typography.labelLarge,
-                color = colorScheme.onSecondaryContainer,
-                textAlign = TextAlign.Center,
-            )
-            if (normalizedReason.isNotEmpty()) {
-                Text(
-                    text = normalizedReason,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = colorScheme.onSecondaryContainer.copy(alpha = 0.8f),
-                    textAlign = TextAlign.Center,
-                )
-            }
         }
     }
 }

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
@@ -788,6 +788,15 @@ private fun HomeChatTurnItem(
                                 AssistantErrorBlock(
                                     message = block.message,
                                     code = block.code,
+                                    attempts = block.attempts,
+                                )
+                            }
+
+                            is HomeChatBlock.Retrying -> {
+                                AssistantRetryingBlock(
+                                    attempt = block.attempt,
+                                    maxAttempts = block.maxAttempts,
+                                    reason = block.reason,
                                 )
                             }
 

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
@@ -33,7 +33,9 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LoadingIndicator
@@ -785,19 +787,55 @@ private fun HomeChatTurnItem(
                             }
 
                             is HomeChatBlock.Error -> {
-                                AssistantErrorBlock(
+                                val errorUi = toAssistantErrorUi(
                                     message = block.message,
                                     code = block.code,
                                     attempts = block.attempts,
                                 )
+                                CollapsibleBlock(
+                                    icon = Icons.Filled.ErrorOutline,
+                                    title = stringResource(errorUi.titleRes),
+                                    isExpanded = true,
+                                    onToggle = {},
+                                    containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                                    nonCollapsible = true,
+                                ) {
+                                    val body = errorUi.bodyRes?.let { stringResource(it) }
+                                        ?: errorUi.body.orEmpty()
+                                    if (body.isNotEmpty()) {
+                                        ToolResultText(
+                                            text = body,
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        )
+                                    }
+                                }
                             }
 
                             is HomeChatBlock.Retrying -> {
-                                AssistantRetryingBlock(
-                                    attempt = block.attempt,
-                                    maxAttempts = block.maxAttempts,
-                                    reason = block.reason,
-                                )
+                                // 常展开、不可折叠（与 Error 块不同：retry 是进行中的转态，
+                                // 收起无意义）；重试成功即整个块消失
+                                CollapsibleBlock(
+                                    icon = Icons.Filled.Refresh,
+                                    title = stringResource(R.string.ui_home_retrying_title),
+                                    isExpanded = true,
+                                    onToggle = {},
+                                    isRunning = true,
+                                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                    nonCollapsible = true,
+                                ) {
+                                    val count = stringResource(
+                                        R.string.ui_home_retrying_attempt,
+                                        block.attempt,
+                                        block.maxAttempts,
+                                    )
+                                    ToolResultText(
+                                        text = if (block.reason.isBlank()) count
+                                        else "$count: ${block.reason.trim()}",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
                             }
 
                             is HomeChatBlock.Thinking -> {

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/HomeChatState.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/HomeChatState.kt
@@ -6,7 +6,6 @@ import com.niki914.okia.conversation.SessionSnapshot
 import com.niki914.okia.message.ContentBlock
 import com.niki914.okia.message.Message
 import com.niki914.uikit.base.ComposeMVIViewModel
-import com.niki914.xposed.api.util.ContextProvider
 import com.niki914.zafiro.app.conversation.ConversationFormatter
 import com.niki914.zafiro.app.conversation.ConversationRecord
 import com.niki914.zafiro.app.conversation.ConversationRepo
@@ -21,7 +20,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 
 internal interface HomeConversationStore {
     suspend fun lastOpenedConversationId(): String
@@ -97,7 +95,23 @@ sealed interface HomeChatBlock {
     data class Text(val text: String) : HomeChatBlock
     data class Thinking(val id: Int, val text: String) : HomeChatBlock
     data class Tool(val status: HomeToolStatus) : HomeChatBlock
-    data class Error(val message: String, val code: LlmErrorCode? = null) : HomeChatBlock
+    data class Error(
+        val message: String?,
+        val code: LlmErrorCode? = null,
+        /** RetryExhausted 专属：已耗尽的重试次数。 */
+        val attempts: Int? = null,
+    ) : HomeChatBlock
+
+    /**
+     * 瞬时重试提示：传输层自动重试进行中。不进持久化状态（落盘无意义），
+     * 下一个流事件到达即清除（见 [HomeChatViewModel.applyEvent]）。
+     */
+    data class Retrying(
+        val attempt: Int,
+        val maxAttempts: Int,
+        val delayMs: Long,
+        val reason: String,
+    ) : HomeChatBlock
 }
 
 data class HomeChatTurn(
@@ -174,7 +188,6 @@ private object LlmHomeChatRuntime : HomeChatRuntime {
     override fun stream(query: String): Flow<LlmStreamEvent> =
         LLMController.stream(
             query = query,
-            context = runBlocking { ContextProvider.await() },
             fromUserInterface = true,
         )
 
@@ -312,7 +325,11 @@ class HomeChatViewModel internal constructor(
                 // 新回合开始：清除旧错误卡片（瞬态 UI 态，T3 TODO②——
                 // 错误只在当轮显示，下一轮发起即消失）
                 turns = turns.map { turn ->
-                    turn.copy(blocks = turn.blocks.filterNot { it is HomeChatBlock.Error })
+                    turn.copy(
+                        blocks = turn.blocks.filterNot {
+                            it is HomeChatBlock.Error || it is HomeChatBlock.Retrying
+                        },
+                    )
                 } + HomeChatTurn(id = turnId, userText = query),
                 isGenerating = true,
                 lastEventName = null,
@@ -444,11 +461,15 @@ class HomeChatViewModel internal constructor(
     private suspend fun applyEvent(turnId: Long, event: LlmStreamEvent) {
         when (event) {
             LlmStreamEvent.RoundStarted -> updateState { copy(isGenerating = true) }
-            is LlmStreamEvent.TextDelta -> updateTurn(turnId) {
-                it.appendText(event.delta)
+            is LlmStreamEvent.TextDelta -> {
+                clearRetrying(turnId)
+                updateTurn(turnId) {
+                    it.appendText(event.delta)
+                }
             }
 
             is LlmStreamEvent.ThinkingStarted -> {
+                clearRetrying(turnId)
                 updateState {
                     val turnIndex = turns.indexOfFirst { it.id == turnId }
                     if (turnIndex == -1) return@updateState this
@@ -484,19 +505,26 @@ class HomeChatViewModel internal constructor(
             }
 
             is LlmStreamEvent.ThinkingEnded -> {
+                clearRetrying(turnId)
                 updateTurn(turnId) { it.upsertThinking(event.id, event.text) }
                 // 思考结束：只摘 active 指针（停止滚动跟随），块保持展开不收起
                 updateState { copy(activeThinkingKey = null) }
             }
 
-            is LlmStreamEvent.ToolPending -> updateTurn(turnId) {
-                // 占位行：仅名字已知，Running 态转圈、不可展开；后续 ToolRunning 按 callId 原地更新
-                it.updateTool(event.call, HomeToolState.Running)
+            is LlmStreamEvent.ToolPending -> {
+                clearRetrying(turnId)
+                updateTurn(turnId) {
+                    // 占位行：仅名字已知，Running 态转圈、不可展开；后续 ToolRunning 按 callId 原地更新
+                    it.updateTool(event.call, HomeToolState.Running)
+                }
             }
 
-            is LlmStreamEvent.ToolRunning -> updateTurn(turnId) {
-                // updateTool 而非 appendTool：参数构建期可能已插入占位行，按 callId 原地更新
-                it.updateTool(event.call, HomeToolState.Running)
+            is LlmStreamEvent.ToolRunning -> {
+                clearRetrying(turnId)
+                updateTurn(turnId) {
+                    // updateTool 而非 appendTool：参数构建期可能已插入占位行，按 callId 原地更新
+                    it.updateTool(event.call, HomeToolState.Running)
+                }
             }
 
             is LlmStreamEvent.ToolSucceeded -> updateTurn(turnId) {
@@ -518,7 +546,35 @@ class HomeChatViewModel internal constructor(
                     LOG_TAG,
                     "apply error turnId=$turnId code=${event.code} message=${event.message}"
                 )
-                applyError(turnId = turnId, message = event.message, code = event.code)
+                clearRetrying(turnId)
+                applyError(
+                    turnId = turnId,
+                    message = event.message,
+                    code = event.code,
+                    attempts = event.attempts,
+                )
+            }
+
+            is LlmStreamEvent.Retrying -> {
+                Logger.w(
+                    LOG_TAG,
+                    "apply retrying turnId=$turnId attempt=${event.attempt}/${event.maxAttempts} " +
+                            "delayMs=${event.delayMs} reason=${event.reason}"
+                )
+                updateTurn(turnId) { turn ->
+                    // 同回合只有一张 retry 卡片：替换旧的，不叠加
+                    val withoutStale = turn.copy(
+                        blocks = turn.blocks.filterNot { it is HomeChatBlock.Retrying },
+                    )
+                    withoutStale.copy(
+                        blocks = withoutStale.blocks + HomeChatBlock.Retrying(
+                            attempt = event.attempt,
+                            maxAttempts = event.maxAttempts,
+                            delayMs = event.delayMs,
+                            reason = event.reason,
+                        ),
+                    )
+                }
             }
 
             is LlmStreamEvent.Completed -> {
@@ -799,9 +855,30 @@ class HomeChatViewModel internal constructor(
         return sessionId
     }
 
-    private fun applyError(turnId: Long, message: String, code: LlmErrorCode?) {
+    private fun clearRetrying(turnId: Long) {
+        val turns = currentState.turns
+        val index = turns.indexOfFirst { it.id == turnId }
+        if (index == -1) return
+        if (turns[index].blocks.none { it is HomeChatBlock.Retrying }) return
+        updateState {
+            copy(
+                turns = turns.toMutableList().also { list ->
+                    list[index] = list[index].copy(
+                        blocks = list[index].blocks.filterNot { it is HomeChatBlock.Retrying },
+                    )
+                },
+            )
+        }
+    }
+
+    private fun applyError(
+        turnId: Long,
+        message: String?,
+        code: LlmErrorCode?,
+        attempts: Int? = null,
+    ) {
         updateTurn(turnId) {
-            it.appendError(message, code)
+            it.appendError(message, code, attempts)
         }
         updateState { copy(isGenerating = false, activeThinkingKey = null) }
     }
@@ -844,9 +921,13 @@ class HomeChatViewModel internal constructor(
         }
     }
 
-    private fun HomeChatTurn.appendError(message: String, code: LlmErrorCode?): HomeChatTurn {
-        if (message.isBlank()) return this
-        return copy(blocks = blocks + HomeChatBlock.Error(message = message, code = code))
+    private fun HomeChatTurn.appendError(
+        message: String?,
+        code: LlmErrorCode?,
+        attempts: Int? = null,
+    ): HomeChatTurn {
+        // message 为空也保留卡片：code 已承载错误类型，UI 按类型兕底文案
+        return copy(blocks = blocks + HomeChatBlock.Error(message = message, code = code, attempts = attempts))
     }
 
     private fun HomeChatTurn.appendTool(
@@ -923,6 +1004,7 @@ class HomeChatViewModel internal constructor(
     private fun eventName(event: LlmStreamEvent): String = when (event) {
         LlmStreamEvent.RoundStarted -> "RoundStarted"
         is LlmStreamEvent.TextDelta -> "TextDelta"
+        is LlmStreamEvent.Retrying -> "Retrying"
         is LlmStreamEvent.ThinkingStarted -> "ThinkingStarted"
         is LlmStreamEvent.ThinkingEnded -> "ThinkingEnded"
         is LlmStreamEvent.ToolRunning -> "ToolRunning"

--- a/app/src/main/java/com/niki914/zafiro/chat/LlmStreamCollectors.kt
+++ b/app/src/main/java/com/niki914/zafiro/chat/LlmStreamCollectors.kt
@@ -78,6 +78,9 @@ private sealed interface RenderSegment {
     data class Thinking(val label: String) : RenderSegment
 
     data class Error(val value: String) : RenderSegment
+
+    /** 瞬时重试状态行：流恢复即移除。 */
+    data class Retrying(val event: LlmStreamEvent.Retrying) : RenderSegment
 }
 
 private class FullTextProjector(
@@ -143,7 +146,7 @@ private class FullTextProjector(
 
             is LlmStreamEvent.Error -> {
                 val isFirstFrame = segments.isEmpty()
-                appendError(event.message)
+                appendError(event)
                 listOf(
                     LlmTextFrame(
                         text = renderSegments(),
@@ -153,6 +156,12 @@ private class FullTextProjector(
                 )
             }
 
+            is LlmStreamEvent.Retrying -> {
+                // 瞬时状态行：与工具/思考行同层展示，流恢复后由后续事件自然覆盖消失
+                segments += RenderSegment.Retrying(event)
+                listOf(LlmTextFrame(renderSegments(), isFirst = false, isFinal = false))
+            }
+
             is LlmStreamEvent.Completed ->
                 listOf(LlmTextFrame(renderSegments(), isFirst = false, isFinal = true))
         }
@@ -160,6 +169,8 @@ private class FullTextProjector(
 
     private fun appendText(text: String) {
         if (text.isEmpty()) return
+        // 流恢复（重试成功 / 正常续传）：瞬时 retry 状态行退场
+        segments.removeAll { it is RenderSegment.Retrying }
         assistantText.append(text)
         val last = segments.lastOrNull()
         if (last is RenderSegment.Text) {
@@ -169,8 +180,10 @@ private class FullTextProjector(
         }
     }
 
-    private fun appendError(message: String) {
-        val normalized = message.trim()
+    private fun appendError(event: LlmStreamEvent.Error) {
+        // message 为空（IdleTimeout/守卫错误等无原文场景）时不注入空 Error 块：
+        // code 类型由宿主侧状态行不表达，本路径只呈现原文，空 = 静默终态
+        val normalized = event.message?.trim() ?: return
         if (normalized.isEmpty()) return
         segments += RenderSegment.Error(normalized)
     }
@@ -250,7 +263,7 @@ private class ChunkTextProjector(
 
             is LlmStreamEvent.Error -> {
                 val isFirstFrame = fullText.isEmpty()
-                appendErrorLine(event.message)
+                appendErrorLine(event)
                 listOf(
                     LlmTextFrame(
                         text = fullText.toString(),
@@ -260,6 +273,11 @@ private class ChunkTextProjector(
                 )
             }
 
+            is LlmStreamEvent.Retrying -> {
+                appendRetryLine(event)
+                listOf(LlmTextFrame(fullText.toString(), isFirst = false, isFinal = false))
+            }
+
             is LlmStreamEvent.Completed ->
                 listOf(LlmTextFrame(fullText.toString(), isFirst = false, isFinal = true))
         }
@@ -267,6 +285,11 @@ private class ChunkTextProjector(
 
     private fun appendText(text: String) {
         if (text.isEmpty()) return
+        // 流恢复：瞬时 retry 状态行退场
+        if (retryLineStart >= 0 && retryLineStart <= fullText.length) {
+            fullText.delete(retryLineStart, fullText.length)
+            retryLineStart = -1
+        }
         if (lastWasToolLine && fullText.isNotEmpty() && fullText.last() != '\n' && !text.startsWith(
                 "\n"
             )
@@ -296,8 +319,25 @@ private class ChunkTextProjector(
         lastWasToolLine = true
     }
 
-    private fun appendErrorLine(message: String) {
-        val normalized = message.trim()
+    private var retryLineStart = -1
+
+    private fun appendRetryLine(event: LlmStreamEvent.Retrying) {
+        // 同回合只有一行 retry 状态：替换旧行（记录行起点），流恢复时移除
+        if (retryLineStart >= 0 && retryLineStart <= fullText.length) {
+            fullText.delete(retryLineStart, fullText.length)
+        }
+        if (fullText.isNotEmpty() && fullText.last() != '\n') {
+            fullText.append('\n')
+        }
+        retryLineStart = fullText.length
+        fullText.append("`[Retrying ${event.attempt}/${event.maxAttempts}]`")
+        fullText.append('\n')
+        lastWasToolLine = true
+    }
+
+    private fun appendErrorLine(event: LlmStreamEvent.Error) {
+        // 同 Full 路径：message 为空不注入空错误行
+        val normalized = event.message?.trim() ?: return
         if (normalized.isEmpty()) return
         if (fullText.isNotEmpty() && fullText.last() != '\n') {
             fullText.append('\n')
@@ -314,6 +354,7 @@ private fun MutableList<RenderSegment>.render(): String {
             is RenderSegment.Text -> builder.appendTextSegment(segment.value)
             is RenderSegment.Tool -> builder.appendToolSegment(segment)
             is RenderSegment.Thinking -> builder.appendThinkingSegment(segment.label)
+            is RenderSegment.Retrying -> builder.appendThinkingSegment("Retrying ${segment.event.attempt}/${segment.event.maxAttempts}")
             // "## Error" 是注入宿主 markdown 的代码块结构标题，本地化会破坏注入内容一致性，保持原样
             is RenderSegment.Error -> builder.appendTextSegment("## Error\n```\n${segment.value}\n```")
         }

--- a/app/src/main/java/com/niki914/zafiro/repo/AppStateSettingsCodec.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/AppStateSettingsCodec.kt
@@ -1,6 +1,8 @@
 package com.niki914.zafiro.repo
 
 import com.niki914.zafiro.repo.SettingsJsonCodecUtils.boolean
+import com.niki914.zafiro.repo.SettingsJsonCodecUtils.int
+import com.niki914.zafiro.repo.SettingsJsonCodecUtils.long
 import com.niki914.zafiro.repo.SettingsJsonCodecUtils.parseObject
 import com.niki914.zafiro.repo.SettingsJsonCodecUtils.string
 import kotlinx.serialization.json.JsonObject
@@ -19,6 +21,10 @@ internal data class AppStateSettings(
     val themeMode: String = "dark",
     /** 主题种子色 ARGB hex；空串 = 跟随壁纸动态色。 */
     val themeSeedColor: String = "FF52DBC9",
+    /** 流式空闲超时秒数；0 = 不超时。 */
+    val llmIdleTimeoutSeconds: Long = 60L,
+    /** 传输层自动重试次数。 */
+    val llmRetryMaxAttempts: Int = 3,
 )
 
 internal object AppStateSettingsCodec {
@@ -36,6 +42,8 @@ internal object AppStateSettingsCodec {
             ),
             themeMode = root.string(THEME_MODE_KEY).ifBlank { "dark" },
             themeSeedColor = root.string(THEME_SEED_COLOR_KEY).ifBlank { "FF52DBC9" },
+            llmIdleTimeoutSeconds = root.long(LLM_IDLE_TIMEOUT_KEY, default = 60L),
+            llmRetryMaxAttempts = root.int(LLM_RETRY_ATTEMPTS_KEY, default = 3),
         )
     }
 
@@ -50,6 +58,8 @@ internal object AppStateSettingsCodec {
                 LOAD_LAST_CONVERSATION_KEY to JsonPrimitive(state.loadLastConversationOnStartup),
                 THEME_MODE_KEY to JsonPrimitive(state.themeMode),
                 THEME_SEED_COLOR_KEY to JsonPrimitive(state.themeSeedColor),
+                LLM_IDLE_TIMEOUT_KEY to JsonPrimitive(state.llmIdleTimeoutSeconds),
+                LLM_RETRY_ATTEMPTS_KEY to JsonPrimitive(state.llmRetryMaxAttempts),
             )
         ).toString()
     }
@@ -62,4 +72,6 @@ internal object AppStateSettingsCodec {
     private const val LOAD_LAST_CONVERSATION_KEY = "load_last_conversation_on_startup"
     private const val THEME_MODE_KEY = "theme_mode"
     private const val THEME_SEED_COLOR_KEY = "theme_seed_color"
+    private const val LLM_IDLE_TIMEOUT_KEY = "llm_idle_timeout_seconds"
+    private const val LLM_RETRY_ATTEMPTS_KEY = "llm_retry_max_attempts"
 }

--- a/app/src/main/java/com/niki914/zafiro/repo/SettingsJsonCodecUtils.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/SettingsJsonCodecUtils.kt
@@ -8,8 +8,10 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
 
 internal object SettingsJsonCodecUtils {
     fun parseObject(json: String): JsonObject {
@@ -28,6 +30,14 @@ internal object SettingsJsonCodecUtils {
 
     fun JsonObject.boolean(key: String, default: Boolean): Boolean {
         return (this[key] as? JsonPrimitive)?.booleanOrNull ?: default
+    }
+
+    fun JsonObject.long(key: String, default: Long): Long {
+        return (this[key] as? JsonPrimitive)?.longOrNull ?: default
+    }
+
+    fun JsonObject.int(key: String, default: Int): Int {
+        return (this[key] as? JsonPrimitive)?.intOrNull ?: default
     }
 
     fun JsonObject.obj(key: String): JsonObject? {

--- a/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
@@ -285,6 +285,30 @@ object XRepo {
             .loadLastConversationOnStartup
     }
 
+    suspend fun llmIdleTimeoutSeconds(): Long {
+        return AppStateSettingsCodec.parse(readJson(StoreDescriptorRegistry.APP_STATE_ID))
+            .llmIdleTimeoutSeconds
+    }
+
+    suspend fun setLlmIdleTimeoutSeconds(value: Long) {
+        updateJson(StoreDescriptorRegistry.APP_STATE_ID) { json ->
+            val current = AppStateSettingsCodec.parse(json)
+            AppStateSettingsCodec.encode(current.copy(llmIdleTimeoutSeconds = value))
+        }
+    }
+
+    suspend fun llmRetryMaxAttempts(): Int {
+        return AppStateSettingsCodec.parse(readJson(StoreDescriptorRegistry.APP_STATE_ID))
+            .llmRetryMaxAttempts
+    }
+
+    suspend fun setLlmRetryMaxAttempts(value: Int) {
+        updateJson(StoreDescriptorRegistry.APP_STATE_ID) { json ->
+            val current = AppStateSettingsCodec.parse(json)
+            AppStateSettingsCodec.encode(current.copy(llmRetryMaxAttempts = value))
+        }
+    }
+
     suspend fun setLoadLastConversationOnStartup(value: Boolean) {
         updateJson(StoreDescriptorRegistry.APP_STATE_ID) { json ->
             val current = AppStateSettingsCodec.parse(json)

--- a/app/src/main/java/com/niki914/zafiro/repo/XRepoRuntimeGateway.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/XRepoRuntimeGateway.kt
@@ -27,6 +27,8 @@ class XRepoRuntimeGateway(
             proxy = active?.proxy.orEmpty(),
             prompt = doc.prompt,
             memories = memories,
+            idleTimeoutSeconds = repo.llmIdleTimeoutSeconds().takeIf { it > 0L },
+            retryMaxAttempts = repo.llmRetryMaxAttempts(),
         )
     }
 

--- a/app/src/main/java/com/niki914/zafiro/runtime/service/AgentRuntimeService.kt
+++ b/app/src/main/java/com/niki914/zafiro/runtime/service/AgentRuntimeService.kt
@@ -24,8 +24,11 @@ import com.niki914.store.XIpcStoreRepository
 import com.niki914.store.displayNameFor
 import com.niki914.zafiro.app.MainActivity
 import com.niki914.zafiro.chat.LLMController
+import com.niki914.zafiro.chat.LlmErrorCode
+import com.niki914.zafiro.chat.LlmStreamEvent
 import com.niki914.zafiro.chat.ToolStatusLabels
 import com.niki914.zafiro.chat.collectAsFull
+import kotlinx.coroutines.flow.map
 import com.niki914.zafiro.runtime.ipc.IAgentRuntimeService
 import com.niki914.zafiro.runtime.ipc.IAgentStoreService
 import com.niki914.zafiro.runtime.ipc.IRenderFrameCallback
@@ -410,7 +413,27 @@ class AgentRuntimeService : Service() {
         Logger.i(LOG_TAG, "turn started queryLength=${query.length}")
         var firstFrameSent = false
         try {
-            LLMController.stream(query, this@AgentRuntimeService).collectAsFull(
+            LLMController.stream(query)
+                // 数据变展示的边界（有 Context 的消费方负责本地化）：
+                // 无原文的错误（ConfigRequired/IdleTimeout/守卫）在此翻译，
+                // 有原文的错误原样透传；宿主进程只收渲染好的文本
+                .map { event ->
+                    if (event is LlmStreamEvent.Error && event.message == null) {
+                        event.copy(
+                            message = when (event.code) {
+                                LlmErrorCode.ConfigRequired ->
+                                    getString(AppR.string.ui_home_error_config_required_title)
+                                LlmErrorCode.IdleTimeout ->
+                                    getString(AppR.string.ui_home_error_idle_timeout_title)
+                                else ->
+                                    getString(AppR.string.runtime_error_internal)
+                            },
+                        )
+                    } else {
+                        event
+                    }
+                }
+                .collectAsFull(
                 labels = ToolStatusLabels(
                     called = getString(AppR.string.ui_tool_status_called),
                     running = getString(AppR.string.ui_tool_status_running),

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -67,7 +67,8 @@
     <string name="ui_home_error_idle_timeout_title">回應逾時</string>
     <string name="ui_home_error_retry_exhausted_title">多次自動重試後仍失敗</string>
     <string name="ui_home_error_internal_title">內部錯誤</string>
-    <string name="ui_home_retrying_title">網路波動，正在重試（第 %1$d/%2$d 次）…</string>
+    <string name="ui_home_retrying_title">網路波動，正在重試…</string>
+    <string name="ui_home_retrying_attempt">重試 %1$d/%2$d</string>
     <string name="runtime_error_internal">內部錯誤</string>
     <string name="ui_home_history_content_description">對話歷史</string>
     <string name="ui_conversation_history_back_content_description">返回</string>

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -64,7 +64,10 @@
     <string name="ui_home_error_config_required_title">模型配置不完整</string>
     <string name="ui_home_error_config_required_body">請前往填寫模型配置。</string>
     <string name="ui_home_error_network_title">網路異常</string>
+    <string name="ui_home_error_idle_timeout_title">回應逾時</string>
+    <string name="ui_home_error_retry_exhausted_title">多次自動重試後仍失敗</string>
     <string name="ui_home_error_internal_title">內部錯誤</string>
+    <string name="ui_home_retrying_title">網路波動，正在重試（第 %1$d/%2$d 次）…</string>
     <string name="runtime_error_internal">內部錯誤</string>
     <string name="ui_home_history_content_description">對話歷史</string>
     <string name="ui_conversation_history_back_content_description">返回</string>
@@ -325,6 +328,11 @@
     <string name="ui_settings_general_language">語言</string>
     <string name="ui_settings_general_language_follow_system">跟隨系統</string>
     <string name="ui_settings_general_load_last_conversation">啟動時載入上次對話</string>
+    <string name="ui_settings_general_idle_timeout">回應空閒逾時</string>
+    <string name="ui_settings_general_idle_timeout_summary">伺服器長時間無回應時終止回合</string>
+    <string name="ui_settings_general_idle_timeout_off">不逾時</string>
+    <string name="ui_settings_general_retry_attempts">自動重試次數</string>
+    <string name="ui_settings_general_retry_summary">請求失敗後的自動重試</string>
     <string name="ui_settings_saved_configuration_title">已儲存配置</string>
     <string name="ui_settings_saved_configuration_delete_title">刪除配置</string>
     <string name="ui_settings_saved_configuration_delete_text">該配置將被刪除，此操作無法復原。</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -65,7 +65,10 @@
     <string name="ui_home_error_config_required_title">Model configuration is incomplete</string>
     <string name="ui_home_error_config_required_body">Please go fill in the model configuration.</string>
     <string name="ui_home_error_network_title">Network error</string>
+    <string name="ui_home_error_idle_timeout_title">Response timed out</string>
+    <string name="ui_home_error_retry_exhausted_title">Automatic retries exhausted</string>
     <string name="ui_home_error_internal_title">Internal error</string>
+    <string name="ui_home_retrying_title">Network hiccup, retrying (attempt %1$d/%2$d)…</string>
     <string name="runtime_error_internal">Internal error</string>
     <string name="ui_home_history_content_description">Conversation history</string>
     <string name="ui_conversation_history_back_content_description">Back</string>
@@ -368,6 +371,11 @@
     <string name="ui_settings_general_language">Language</string>
     <string name="ui_settings_general_language_follow_system">Follow system</string>
     <string name="ui_settings_general_load_last_conversation">Load last conversation on startup</string>
+    <string name="ui_settings_general_idle_timeout">Idle timeout</string>
+    <string name="ui_settings_general_idle_timeout_summary">End the turn when the server stays silent too long</string>
+    <string name="ui_settings_general_idle_timeout_off">No timeout</string>
+    <string name="ui_settings_general_retry_attempts">Auto retries</string>
+    <string name="ui_settings_general_retry_summary">Automatic retries after a failed request</string>
     <string name="ui_settings_saved_configuration_title">Saved configurations</string>
     <string name="ui_settings_saved_configuration_delete_title">Delete configuration</string>
     <string name="ui_settings_saved_configuration_delete_text">This configuration will be deleted and cannot be recovered.</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -68,7 +68,8 @@
     <string name="ui_home_error_idle_timeout_title">Response timed out</string>
     <string name="ui_home_error_retry_exhausted_title">Automatic retries exhausted</string>
     <string name="ui_home_error_internal_title">Internal error</string>
-    <string name="ui_home_retrying_title">Network hiccup, retrying (attempt %1$d/%2$d)…</string>
+    <string name="ui_home_retrying_title">Network hiccup, retrying…</string>
+    <string name="ui_home_retrying_attempt">Retrying %1$d/%2$d</string>
     <string name="runtime_error_internal">Internal error</string>
     <string name="ui_home_history_content_description">Conversation history</string>
     <string name="ui_conversation_history_back_content_description">Back</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -68,7 +68,8 @@
     <string name="ui_home_error_idle_timeout_title">Tiempo de espera agotado</string>
     <string name="ui_home_error_retry_exhausted_title">Reintentos automáticos agotados</string>
     <string name="ui_home_error_internal_title">Error interno</string>
-    <string name="ui_home_retrying_title">Problema de red, reintentando (intento %1$d/%2$d)…</string>
+    <string name="ui_home_retrying_title">Problema de red, reintentando…</string>
+    <string name="ui_home_retrying_attempt">Reintento %1$d/%2$d</string>
     <string name="runtime_error_internal">Error interno</string>
     <string name="ui_home_history_content_description">Historial de conversaciones</string>
     <string name="ui_conversation_history_back_content_description">Volver</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -65,7 +65,10 @@
     <string name="ui_home_error_config_required_title">Configuración del modelo incompleta</string>
     <string name="ui_home_error_config_required_body">Complete la configuración del modelo antes de continuar.</string>
     <string name="ui_home_error_network_title">Error de red</string>
+    <string name="ui_home_error_idle_timeout_title">Tiempo de espera agotado</string>
+    <string name="ui_home_error_retry_exhausted_title">Reintentos automáticos agotados</string>
     <string name="ui_home_error_internal_title">Error interno</string>
+    <string name="ui_home_retrying_title">Problema de red, reintentando (intento %1$d/%2$d)…</string>
     <string name="runtime_error_internal">Error interno</string>
     <string name="ui_home_history_content_description">Historial de conversaciones</string>
     <string name="ui_conversation_history_back_content_description">Volver</string>
@@ -368,6 +371,11 @@
     <string name="ui_settings_general_language">Idioma</string>
     <string name="ui_settings_general_language_follow_system">Usar el del sistema</string>
     <string name="ui_settings_general_load_last_conversation">Cargar la última conversación al iniciar</string>
+    <string name="ui_settings_general_idle_timeout">Tiempo de inactividad</string>
+    <string name="ui_settings_general_idle_timeout_summary">Termina el turno si el servidor no responde</string>
+    <string name="ui_settings_general_idle_timeout_off">Sin límite</string>
+    <string name="ui_settings_general_retry_attempts">Reintentos automáticos</string>
+    <string name="ui_settings_general_retry_summary">Reintentos automáticos tras un error de solicitud</string>
     <string name="ui_settings_saved_configuration_title">Configuraciones guardadas</string>
     <string name="ui_settings_saved_configuration_delete_title">Eliminar configuración</string>
     <string name="ui_settings_saved_configuration_delete_text">Esta configuración se eliminará y la acción no se podrá deshacer.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -67,7 +67,8 @@
     <string name="ui_home_error_idle_timeout_title">応答がタイムアウトしました</string>
     <string name="ui_home_error_retry_exhausted_title">自動リトライがすべて失敗しました</string>
     <string name="ui_home_error_internal_title">内部エラー</string>
-    <string name="ui_home_retrying_title">ネットワーク障害のため再試行中（%1$d/%2$d 回目）…</string>
+    <string name="ui_home_retrying_title">ネットワーク障害のため再試行中…</string>
+    <string name="ui_home_retrying_attempt">再試行 %1$d/%2$d</string>
     <string name="runtime_error_internal">内部エラー</string>
     <string name="ui_home_history_content_description">会話履歴</string>
     <string name="ui_conversation_history_back_content_description">戻る</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -64,7 +64,10 @@
     <string name="ui_home_error_config_required_title">モデル設定が不完全です</string>
     <string name="ui_home_error_config_required_body">モデル設定を完了してください。</string>
     <string name="ui_home_error_network_title">ネットワークエラー</string>
+    <string name="ui_home_error_idle_timeout_title">応答がタイムアウトしました</string>
+    <string name="ui_home_error_retry_exhausted_title">自動リトライがすべて失敗しました</string>
     <string name="ui_home_error_internal_title">内部エラー</string>
+    <string name="ui_home_retrying_title">ネットワーク障害のため再試行中（%1$d/%2$d 回目）…</string>
     <string name="runtime_error_internal">内部エラー</string>
     <string name="ui_home_history_content_description">会話履歴</string>
     <string name="ui_conversation_history_back_content_description">戻る</string>
@@ -367,6 +370,11 @@
     <string name="ui_settings_general_language">言語</string>
     <string name="ui_settings_general_language_follow_system">システムに従う</string>
     <string name="ui_settings_general_load_last_conversation">起動時に前回の会話を読み込む</string>
+    <string name="ui_settings_general_idle_timeout">応答アイドルタイムアウト</string>
+    <string name="ui_settings_general_idle_timeout_summary">サーバーが長時間無応答のときにターンを終了します</string>
+    <string name="ui_settings_general_idle_timeout_off">タイムアウトなし</string>
+    <string name="ui_settings_general_retry_attempts">自動リトライ回数</string>
+    <string name="ui_settings_general_retry_summary">リクエスト失敗後の自動リトライ</string>
     <string name="ui_settings_saved_configuration_title">保存済みの設定</string>
     <string name="ui_settings_saved_configuration_delete_title">設定の削除</string>
     <string name="ui_settings_saved_configuration_delete_text">この設定は削除されます。この操作は元に戻せません。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,7 +64,10 @@
     <string name="ui_home_error_config_required_title">模型配置不完整</string>
     <string name="ui_home_error_config_required_body">请前往填写模型配置。</string>
     <string name="ui_home_error_network_title">网络异常</string>
+    <string name="ui_home_error_idle_timeout_title">响应超时</string>
+    <string name="ui_home_error_retry_exhausted_title">多次自动重试后仍失败</string>
     <string name="ui_home_error_internal_title">内部错误</string>
+    <string name="ui_home_retrying_title">网络波动，正在重试（第 %1$d/%2$d 次）…</string>
     <string name="runtime_error_internal">内部错误</string>
     <string name="ui_home_history_content_description">对话历史</string>
     <string name="ui_conversation_history_back_content_description">返回</string>
@@ -367,6 +370,11 @@
     <string name="ui_settings_general_language">语言</string>
     <string name="ui_settings_general_language_follow_system">跟随系统</string>
     <string name="ui_settings_general_load_last_conversation">启动时载入上次对话</string>
+    <string name="ui_settings_general_idle_timeout">响应空闲超时</string>
+    <string name="ui_settings_general_idle_timeout_summary">服务器长时间无响应时终止回合</string>
+    <string name="ui_settings_general_idle_timeout_off">不超时</string>
+    <string name="ui_settings_general_retry_attempts">自动重试次数</string>
+    <string name="ui_settings_general_retry_summary">请求失败后的自动重试</string>
     <string name="ui_settings_saved_configuration_title">已保存配置</string>
     <string name="ui_settings_saved_configuration_delete_title">删除配置</string>
     <string name="ui_settings_saved_configuration_delete_text">该配置将被删除，此操作无法恢复。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,7 +67,8 @@
     <string name="ui_home_error_idle_timeout_title">响应超时</string>
     <string name="ui_home_error_retry_exhausted_title">多次自动重试后仍失败</string>
     <string name="ui_home_error_internal_title">内部错误</string>
-    <string name="ui_home_retrying_title">网络波动，正在重试（第 %1$d/%2$d 次）…</string>
+    <string name="ui_home_retrying_title">网络波动，正在重试…</string>
+    <string name="ui_home_retrying_attempt">重试 %1$d/%2$d</string>
     <string name="runtime_error_internal">内部错误</string>
     <string name="ui_home_history_content_description">对话历史</string>
     <string name="ui_conversation_history_back_content_description">返回</string>

--- a/app/src/test/java/com/niki914/zafiro/app/ui/content/AssistantErrorUiFormatterTest.kt
+++ b/app/src/test/java/com/niki914/zafiro/app/ui/content/AssistantErrorUiFormatterTest.kt
@@ -30,13 +30,61 @@ class AssistantErrorUiFormatterTest {
     }
 
     @Test
-    fun toAssistantErrorUi_networkBlankMessageHasNoBody() {
+    fun toAssistantErrorUi_networkBlankMessageFallsBackToBodyRes() {
+        // controller 不再造兜底字符串：空原文由 bodyRes 兜底
         assertEquals(
             AssistantErrorUi(
                 titleRes = R.string.ui_home_error_network_title,
+                bodyRes = R.string.ui_home_error_retry_body,
                 body = null,
             ),
             toAssistantErrorUi("  ", LlmErrorCode.RateLimit),
+        )
+    }
+
+    @Test
+    fun toAssistantErrorUi_nullMessageFallsBackToBodyRes() {
+        assertEquals(
+            AssistantErrorUi(
+                titleRes = R.string.ui_home_error_network_title,
+                bodyRes = R.string.ui_home_error_retry_body,
+                body = null,
+            ),
+            toAssistantErrorUi(null, LlmErrorCode.Transport),
+        )
+    }
+
+    @Test
+    fun toAssistantErrorUi_idleTimeoutHasDedicatedTitle() {
+        assertEquals(
+            AssistantErrorUi(
+                titleRes = R.string.ui_home_error_idle_timeout_title,
+                bodyRes = R.string.ui_home_error_retry_body,
+                body = null,
+            ),
+            toAssistantErrorUi(null, LlmErrorCode.IdleTimeout),
+        )
+    }
+
+    @Test
+    fun toAssistantErrorUi_retryExhaustedWithAttemptsHasDedicatedTitle() {
+        assertEquals(
+            AssistantErrorUi(
+                titleRes = R.string.ui_home_error_retry_exhausted_title,
+                body = "retry exhausted (Transport)",
+            ),
+            toAssistantErrorUi("retry exhausted (Transport)", LlmErrorCode.RetryExhausted, attempts = 3),
+        )
+    }
+
+    @Test
+    fun toAssistantErrorUi_retryExhaustedWithoutAttemptsUsesNetworkTitle() {
+        assertEquals(
+            AssistantErrorUi(
+                titleRes = R.string.ui_home_error_network_title,
+                body = "retry exhausted (Transport)",
+            ),
+            toAssistantErrorUi("retry exhausted (Transport)", LlmErrorCode.RetryExhausted),
         )
     }
 


### PR DESCRIPTION
## Summary

Cherry-picked from local main (commits 99d0b582 + 536a4a83) on top of #165's TextPacer rework.

- **Root cause fix**: 30s idle timeout surfaced as opaque "Request failed. Please try again."; okia's automatic retry events (RetryScheduled) were silently dropped
- **agent-runtime**: `LlmStreamEvent.Error` gains nullable message + structured `attempts`; new `RetryableErrorClassifier` (regex-based, pi-mode table); mapper passes `Retrying` through; `LLMController` zero Context/localization; stream terminal-state guard
- **Settings hot-reload**: changing idle timeout / retry attempts now applies to the already-running Okia instance (was cold-start only); regression test added
- **UI**: Error (tertiaryContainer, ⚠️) and Retrying (secondaryContainer, 🔄+loader) unified as `CollapsibleBlock` with new `nonCollapsible` form — no tail chevron slot, no toggle, but press feedback (corner morph + scale) preserved
- General Settings: idle timeout + retry attempt rows, 5 languages

## Conflicts with #165

Both commits touched `HomeChatComponents.kt` / `HomePageContent.kt` / `HomeChatState.kt` which #165 rewrote. Git auto-merged cleanly; verified no remaining references to the deleted reveal system, and `:app`/`:agent-runtime` compile. Unit tests: 2 pre-existing flaky failures in `AboutSettingsViewModelTest` (UncompletedCoroutinesError) reproduce on local main too — unrelated to this change.

## Test plan

- [x] `compileDebugKotlin` for :app and :agent-runtime
- [x] unit tests run; only pre-existing AboutSettingsViewModelTest flake fails
- [x] device check: error/retry cards render non-collapsible, press-scale works, chevron slot gone
