### PR TITLE
feat: home chat turn state cleanup, dismiss copy row with animation

### DIFF
--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.background
@@ -700,6 +701,7 @@ private fun HomeChatTurnItem(
         AnimatedVisibility(
             visible = showActionRow && actionSource == ActionSource.User,
             enter = expandVertically() + fadeIn(),
+            exit = shrinkVertically() + fadeOut(),
         ) {
             TurnActionRow(
                 source = ActionSource.User,

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/HomeChatState.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/HomeChatState.kt
@@ -336,6 +336,10 @@ class HomeChatViewModel internal constructor(
                 streamEventCount = 0,
                 activeThinkingKey = null,
                 autoExpandedThinking = emptySet(),
+                // 旧回合的操作行（复制/重试）随新回合消失：旧 turn 失去 isLastTurn 后
+                // canToggleUserAction 变 false，不清则操作行永远挂着无法收回
+                expandedActionTurnId = null,
+                expandedActionSource = null,
             )
         }
         draftSaveJob?.cancel()

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/ToolPresentation.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/ToolPresentation.kt
@@ -2,7 +2,6 @@ package com.niki914.zafiro.app.ui.model
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.MenuBook
-import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.Terminal
@@ -25,8 +24,9 @@ import kotlinx.serialization.json.jsonPrimitive
  * 预留演进：后续可改为 agent 传的意图字段，直接展示"这个操作是要干啥"（如"罗列文件"），不再依赖参数猜。
  */
 object ToolPresentation {
-    /** Thinking 图标（用户待定，暂用四角星星）。 */
-    val Thinking = Icons.Filled.AutoAwesome
+    /** Thinking 图标：自绘 spark drawable（ic_thinking）。 */
+    val Thinking: ImageVector
+        @Composable get() = ImageVector.vectorResource(R.drawable.ic_thinking)
 
     private val TerminalIcon = Icons.Filled.Terminal
     private val Skill = Icons.AutoMirrored.Filled.MenuBook

--- a/app/src/main/res/drawable/ic_thinking.xml
+++ b/app/src/main/res/drawable/ic_thinking.xml
@@ -1,46 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Thinking spark icon. Glyph bbox 28.28x28.28 (39.86..68.14) at 80% of canvas:
+     viewport 35.35x35.35, translate (-3.535, -3.535) centers the glyph. -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="108dp"
-    android:height="108dp"
-    android:viewportWidth="108"
-    android:viewportHeight="108">
-  <path
-      android:pathData="M68.14,39.86L48.13,45.73C48.13,47.71 47,48.84 45.02,48.84L39.86,68.14"
-      android:strokeLineJoin="round"
-      android:strokeWidth="2"
-      android:fillColor="#00000000"
-      android:strokeColor="#FFFFFF"
-      android:strokeLineCap="round"/>
-  <path
-      android:pathData="M68.14,39.86L51.67,49.26C50.96,50.54 49.83,51.67 48.56,52.37L39.86,68.14"
-      android:strokeLineJoin="round"
-      android:strokeWidth="1.5"
-      android:fillColor="#00000000"
-      android:strokeColor="#FFFFFF"
-      android:strokeLineCap="round"/>
-  <path
-      android:pathData="M68.14,39.86L58.74,56.33C57.46,57.04 56.33,58.17 55.63,59.44L39.86,68.14"
-      android:strokeLineJoin="round"
-      android:strokeWidth="1.5"
-      android:fillColor="#00000000"
-      android:strokeColor="#FFFFFF"
-      android:strokeLineCap="round"/>
-  <path
-      android:pathData="M68.14,39.86L62.27,59.87C60.29,59.87 59.16,61 59.16,62.98L39.86,68.14"
-      android:strokeLineJoin="round"
-      android:strokeWidth="2"
-      android:fillColor="#00000000"
-      android:strokeColor="#FFFFFF"
-      android:strokeLineCap="round"/>
-  <path
-      android:pathData="M48.13,45.73L62.27,59.87"
-      android:strokeWidth="1.5"
-      android:fillColor="#00000000"
-      android:strokeColor="#FFFFFF"
-      android:strokeLineCap="round"/>
-  <path
-      android:pathData="M45.02,48.84L59.16,62.98"
-      android:strokeWidth="1.5"
-      android:fillColor="#00000000"
-      android:strokeColor="#FFFFFF"
-      android:strokeLineCap="round"/>
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="35.35"
+    android:viewportHeight="35.35">
+    <group
+        android:translateX="-36.325"
+        android:translateY="-36.325">
+        <path
+            android:pathData="M68.14,39.86L48.13,45.73C48.13,47.71 47,48.84 45.02,48.84L39.86,68.14"
+            android:strokeLineJoin="round"
+            android:strokeWidth="2"
+            android:fillColor="#00000000"
+            android:strokeColor="#FFFFFF"
+            android:strokeLineCap="round" />
+        <path
+            android:pathData="M68.14,39.86L51.67,49.26C50.96,50.54 49.83,51.67 48.56,52.37L39.86,68.14"
+            android:strokeLineJoin="round"
+            android:strokeWidth="1.5"
+            android:fillColor="#00000000"
+            android:strokeColor="#FFFFFF"
+            android:strokeLineCap="round" />
+        <path
+            android:pathData="M68.14,39.86L58.74,56.33C57.46,57.04 56.33,58.17 55.63,59.44L39.86,68.14"
+            android:strokeLineJoin="round"
+            android:strokeWidth="1.5"
+            android:fillColor="#00000000"
+            android:strokeColor="#FFFFFF"
+            android:strokeLineCap="round" />
+        <path
+            android:pathData="M68.14,39.86L62.27,59.87C60.29,59.87 59.16,61 59.16,62.98L39.86,68.14"
+            android:strokeLineJoin="round"
+            android:strokeWidth="2"
+            android:fillColor="#00000000"
+            android:strokeColor="#FFFFFF"
+            android:strokeLineCap="round" />
+        <path
+            android:pathData="M48.13,45.73L62.27,59.87"
+            android:strokeWidth="1.5"
+            android:fillColor="#00000000"
+            android:strokeColor="#FFFFFF"
+            android:strokeLineCap="round" />
+        <path
+            android:pathData="M45.02,48.84L59.16,62.98"
+            android:strokeWidth="1.5"
+            android:fillColor="#00000000"
+            android:strokeColor="#FFFFFF"
+            android:strokeLineCap="round" />
+    </group>
 </vector>

--- a/app/src/main/res/drawable/ic_thinking.xml
+++ b/app/src/main/res/drawable/ic_thinking.xml
@@ -1,0 +1,46 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <path
+      android:pathData="M68.14,39.86L48.13,45.73C48.13,47.71 47,48.84 45.02,48.84L39.86,68.14"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#FFFFFF"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M68.14,39.86L51.67,49.26C50.96,50.54 49.83,51.67 48.56,52.37L39.86,68.14"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#FFFFFF"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M68.14,39.86L58.74,56.33C57.46,57.04 56.33,58.17 55.63,59.44L39.86,68.14"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#FFFFFF"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M68.14,39.86L62.27,59.87C60.29,59.87 59.16,61 59.16,62.98L39.86,68.14"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#FFFFFF"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M48.13,45.73L62.27,59.87"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#FFFFFF"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M45.02,48.84L59.16,62.98"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#FFFFFF"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/test/java/com/niki914/zafiro/app/ui/model/HomeChatControllerTest.kt
+++ b/app/src/test/java/com/niki914/zafiro/app/ui/model/HomeChatControllerTest.kt
@@ -554,6 +554,95 @@ class HomeChatViewModelTest {
     }
 
     @Test
+    fun send_clearsExpandedUserActionRowOfPreviousTurn() = runTest {
+        val conversations = FakeHomeConversationStore()
+        val viewModel = HomeChatViewModel(
+            conversations = conversations,
+            runtime = FakeHomeChatRuntime(
+                // 第一轮失败：最后一条 turn 是裸 user message（无 AI 回应），
+                // 此时复制按钮因 isLastTurn 放开；第二轮发起后必须收起
+                stream = {
+                    flowOf(
+                        LlmStreamEvent.RoundStarted,
+                        LlmStreamEvent.Error(message = "boom", code = null),
+                    )
+                },
+            ),
+        )
+
+        viewModel.sendIntent(HomeChatIntent.InputChanged("q1"))
+        runCurrent()
+        viewModel.sendIntent(HomeChatIntent.Send)
+        advanceUntilIdle()
+
+        viewModel.sendIntent(HomeChatIntent.ToggleActionRow(0, ActionSource.User))
+        runCurrent()
+        assertEquals(0L, viewModel.uiStateFlow.value.expandedActionTurnId)
+
+        viewModel.sendIntent(HomeChatIntent.InputChanged("q2"))
+        runCurrent()
+        viewModel.sendIntent(HomeChatIntent.Send)
+        advanceUntilIdle()
+
+        val state = viewModel.uiStateFlow.value
+        assertNull(state.expandedActionTurnId)
+        assertNull(state.expandedActionSource)
+        // 旧回合的错误卡随新回合消失，仅剩两条 user turn
+        assertEquals(2, state.turns.size)
+        assertTrue(state.turns[0].blocks.isEmpty())
+    }
+
+    @Test
+    fun reGenerateAt_clearsErrorBlocksOfOldTurns() = runTest {
+        val conversations = FakeHomeConversationStore()
+        val sourceId = "session-regen-clear"
+        conversations.createConversation(sourceId, "first")
+        conversations.setSnapshot(
+            sourceId,
+            snapshotOf(
+                Message.User(listOf(ContentBlock.Text("first"))),
+            ),
+        )
+        conversations.setLastOpenedConversationId(sourceId)
+        var queryCount = 0
+        val viewModel = HomeChatViewModel(
+            conversations = conversations,
+            runtime = FakeHomeChatRuntime(
+                stream = { _ ->
+                    queryCount++
+                    if (queryCount == 1) {
+                        flowOf(LlmStreamEvent.Error(message = "boom", code = null))
+                    } else {
+                        flowOf(LlmStreamEvent.Completed)
+                    }
+                },
+                historySnapshot = {
+                    listOf(
+                        Message.User(listOf(ContentBlock.Text("first"))),
+                    )
+                },
+            ),
+        )
+        advanceUntilIdle()
+
+        // 第一轮：直接对历史 turn regen，得到一条带 Error 的新 turn
+        viewModel.sendIntent(HomeChatIntent.ReGenerateAt(0))
+        advanceUntilIdle()
+        val failed = viewModel.uiStateFlow.value.turns.last()
+        assertTrue(failed.blocks.filterIsInstance<HomeChatBlock.Error>().isNotEmpty())
+
+        // 第二轮 regen：旧 turn 的 Error 块随新回合发起消失
+        viewModel.sendIntent(HomeChatIntent.ReGenerateAt(0))
+        advanceUntilIdle()
+
+        val state = viewModel.uiStateFlow.value
+        assertTrue(state.turns.dropLast(1).all { turn ->
+            turn.blocks.filterIsInstance<HomeChatBlock.Error>().isEmpty()
+        })
+        assertNull(state.expandedActionTurnId)
+    }
+
+    @Test
     fun newConversation_keepsPersistedConversationButClearsCurrentPointer() = runTest {
         val conversations = FakeHomeConversationStore()
         val viewModel = HomeChatViewModel(


### PR DESCRIPTION
## Changes

### Fix: stuck copy action row after failed turn
- After a failed turn the last turn is a bare user message; tapping it opens the copy action row (allowed via `isLastTurn`). Sending a new message never cleared `expandedActionTurnId/Source`, and since the old turn lost `isLastTurn`, the row could no longer be toggled off — it stayed forever.
- `sendCurrentInput` now clears `expandedActionTurnId/Source` as part of the per-turn transient cleanup, alongside the existing Error/Retrying block clearing.

### Animation
- The user action row's `AnimatedVisibility` gets an explicit symmetric exit (`shrinkVertically() + fadeOut()`), so clearing the state animates the row away instead of popping.

### Thinking icon
- Replace `Icons.Filled.AutoAwesome` with a custom `ic_thinking` drawable (spark glyph), viewport reworked to the glyph bbox at 80% canvas, centered, matching sibling Material icon scale at 13dp.

## Tests
- `send_clearsExpandedUserActionRowOfPreviousTurn`: failed bare turn → expand user action row → send new message; row state cleared, old Error block gone.
- `reGenerateAt_clearsErrorBlocksOfOldTurns`: regen after a failed turn clears Error blocks of old turns.
- Full `HomeChatViewModelTest` suite: 24 tests, 0 failures.
