### PR TITLE
feat: image support (protocol-level plumbing)

### DIFF
--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/LLMController.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/LLMController.kt
@@ -22,7 +22,10 @@ import com.niki914.okia.tooling.DefaultToolRegistry
 import com.niki914.okia.tooling.ToolDescriptor
 import com.niki914.okia.tooling.ToolKind
 import com.niki914.okia.tooling.ToolRegistry
+import com.niki914.xposed.api.util.ContextProvider
 import com.niki914.xposed.api.util.LockState
+import com.niki914.zafiro.chat.agentic.AndroidImageLoader
+import com.niki914.zafiro.chat.agentic.AndroidImageSaver
 import com.niki914.zafiro.chat.agentic.LocalToolExecutor
 import com.niki914.zafiro.chat.agentic.PromptComposer
 import com.niki914.zafiro.chat.agentic.PromptComposerInput
@@ -74,6 +77,26 @@ object LLMController {
     // 实例重建共享同一 registry）。本地工具在 refresh 时全量同步；
     // MCP 工具由 T2b McpDiscovery 注册进同一 registry。
     internal val toolRegistry: ToolRegistry = DefaultToolRegistry()
+
+    // 图片加载器 + 保存器（host 注入 Okia）
+    private val imageLoader: AndroidImageLoader? = try {
+        AndroidImageLoader()
+    } catch (e: Exception) {
+        null
+    }
+    private var imageSaver: AndroidImageSaver? = null
+
+    /** 初始化图片保存器（延迟到首次需要时）。 */
+    private suspend fun ensureImageSaver(): AndroidImageSaver? {
+        if (imageSaver == null) {
+            imageSaver = try {
+                ContextProvider.await().applicationContext?.let { AndroidImageSaver(it) }
+            } catch (e: Exception) {
+                null
+            }
+        }
+        return imageSaver
+    }
 
     // 回合内写入的 py 工具（py_meta_tools write 成功回调，D20）：
     // 持久化尚未被下一次 refresh 读取前的执行兜底 + 回合内注册数据源。
@@ -577,6 +600,7 @@ object LLMController {
             LlmProtocol.OpenAiResponses -> OpenAIResponsesProtocol()
             LlmProtocol.AnthropicMessages -> AnthropicMessagesProtocol()
         }
+        val saver = ensureImageSaver()
         return Okia.open(wireProtocol, restore) {
             this.endpoint = endpoint
             apiKey = config.apiKey
@@ -586,6 +610,8 @@ object LLMController {
             idleTimeoutSeconds = config.idleTimeoutSeconds ?: NO_IDLE_TIMEOUT_SECONDS
             retryPolicy = RetryPolicy(maxAttempts = config.retryMaxAttempts)
             toolRegistry = this@LLMController.toolRegistry
+            imageLoader = this@LLMController.imageLoader
+            imageSaver = saver
         }
     }
 

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/ImageIO.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/ImageIO.kt
@@ -1,0 +1,88 @@
+package com.niki914.zafiro.chat.agentic
+
+import android.content.Context
+import android.net.Uri
+import android.util.Base64
+import com.niki914.okia.ImageLoader
+import com.niki914.okia.ImageSaver
+import java.io.File
+import java.security.MessageDigest
+
+/**
+ * Android ImageLoader 实现：从文件系统读取图片字节。
+ * 返回 null = 文件不存在或不可读（外部存储被用户删除等场景）。
+ */
+class AndroidImageLoader : ImageLoader {
+    override fun load(path: String): ByteArray? {
+        return try {
+            val file = File(path)
+            if (!file.exists() || !file.isFile) return null
+            file.readBytes()
+        } catch (e: Exception) {
+            null
+        }
+    }
+}
+
+/**
+ * Android ImageSaver 实现：将 base64 图片保存到 App 私有目录 filesDir/Zafiro/images/。
+ * SHA-256 内容哈希命名，天然去重。返回文件路径，null = 保存失败。
+ * 后续需要文件访问权限逻辑时再改存储位置（当前与 py 工具一致走私有目录，零权限负担）。
+ */
+class AndroidImageSaver(context: Context) : ImageSaver {
+    private val imagesDir: File = File(File(context.filesDir, "Zafiro"), "images")
+
+    override suspend fun save(base64: String, mimeType: String): String? {
+        return try {
+            val bytes = Base64.decode(base64, Base64.DEFAULT)
+            if (bytes.isEmpty()) return null
+            val hash = sha256(bytes)
+            val ext = mimeType.substringAfterLast("/").lowercase().takeIf { it.isNotEmpty() } ?: "jpg"
+            val file = File(imagesDir, "$hash.$ext")
+            if (!file.exists()) {
+                if (!imagesDir.exists()) imagesDir.mkdirs()
+                file.writeBytes(bytes)
+            }
+            file.absolutePath
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun sha256(bytes: ByteArray): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        return digest.digest(bytes).joinToString("") { "%02x".format(it) }
+    }
+}
+
+/**
+ * 用户分享图片（content URI）→ 保存到 App 私有目录 images 目录 → 返回路径。
+ * 供分享入口调用。
+ */
+class UserImageSaver(private val context: Context) {
+    private val imagesDir: File = File(File(context.filesDir, "Zafiro"), "images")
+
+    fun saveFromUri(uri: Uri): String? {
+        return try {
+            val resolver = context.contentResolver
+            val mimeType = resolver.getType(uri) ?: "image/jpeg"
+            val bytes = resolver.openInputStream(uri)?.use { it.readBytes() } ?: return null
+            if (bytes.isEmpty()) return null
+            val hash = sha256(bytes)
+            val ext = mimeType.substringAfterLast("/").lowercase().takeIf { it.isNotEmpty() } ?: "jpg"
+            val file = File(imagesDir, "$hash.$ext")
+            if (!file.exists()) {
+                if (!imagesDir.exists()) imagesDir.mkdirs()
+                file.writeBytes(bytes)
+            }
+            file.absolutePath
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun sha256(bytes: ByteArray): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        return digest.digest(bytes).joinToString("") { "%02x".format(it) }
+    }
+}

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/LocalToolExecutor.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/LocalToolExecutor.kt
@@ -1,6 +1,7 @@
 package com.niki914.zafiro.chat.agentic
 
 import com.niki914.logging.Logger
+import com.niki914.okia.message.ContentBlock
 import com.niki914.okia.message.ToolCallOutcome
 import com.niki914.okia.tooling.ToolCallContext
 import com.niki914.okia.tooling.ToolExecutor
@@ -128,7 +129,9 @@ class LocalToolExecutor(
             return if (failure != null) {
                 ToolCallOutcome.Failure(message = failure, content = raw)
             } else {
-                ToolCallOutcome.Success(content = raw)
+                // 检查工具结果是否包含图片引用（如 view_image）
+                val image = extractImageFromResult(json)
+                ToolCallOutcome.Success(content = raw, image = image)
             }
         }
         // 非 JSON：文本协议工具结果（#!tool-result 头）
@@ -144,6 +147,20 @@ class LocalToolExecutor(
         }
         // 未知格式：保守成功，原文回喂模型（沿用旧运行时行为）
         return ToolCallOutcome.Success(content = raw)
+    }
+
+    // ── 图片引用提取 ──────────────────────────────────────────────────────────
+
+    /** 从 JSON 结果中提取图片引用（如果工具返回了 image 字段）。 */
+    private fun extractImageFromResult(json: JsonObject?): com.niki914.okia.message.ContentBlock.Image? {
+        if (json == null) return null
+        // 支持 {"image": {"path": ..., "mime_type": ...}} 格式
+        val imageObj = json["image"] as? JsonObject
+            ?: (json["data"] as? JsonObject)?.get("image") as? JsonObject
+            ?: return null
+        val path = (imageObj["path"] as? kotlinx.serialization.json.JsonPrimitive)?.contentOrNull ?: return null
+        val mimeType = (imageObj["mime_type"] as? kotlinx.serialization.json.JsonPrimitive)?.contentOrNull ?: "image/jpeg"
+        return com.niki914.okia.message.ContentBlock.Image(path, mimeType)
     }
 
     // ── py_meta_tools write 回合内注册（D20）────────────────────────────────

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/BuiltinToolRegistry.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/BuiltinToolRegistry.kt
@@ -7,10 +7,12 @@ import com.niki914.zafiro.chat.agentic.buildin.impl.LoadSkillBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.MemoryBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.NotifyBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.OpenUriBuiltin
+import com.niki914.zafiro.chat.agentic.buildin.impl.PyDownloadFileBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.PyMetaToolsBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.ScreenOperationAccessibilityBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.ScreenOperationShellBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.TerminalBuiltin
+import com.niki914.zafiro.chat.agentic.buildin.impl.ViewImageBuiltin
 
 class BuiltinToolRegistry(
     private val tools: List<BuiltinTool>,
@@ -27,6 +29,7 @@ class BuiltinToolRegistry(
                 ExecutePythonBuiltin(),
                 LaunchAppBuiltin(),
                 PyMetaToolsBuiltin(),
+                PyDownloadFileBuiltin(),
                 MemoryBuiltin(),
                 NotifyBuiltin(),
                 OpenUriBuiltin(),
@@ -35,6 +38,7 @@ class BuiltinToolRegistry(
                 FindInstalledAppsBuiltin(),
                 ScreenOperationAccessibilityBuiltin(),
                 ScreenOperationShellBuiltin(),
+                ViewImageBuiltin(),
             )
         )
     }

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/PyDownloadFileBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/PyDownloadFileBuiltin.kt
@@ -1,0 +1,138 @@
+package com.niki914.zafiro.chat.agentic.buildin.impl
+
+import com.niki914.zafiro.chat.agentic.buildin.BuiltinToolRequest
+import com.niki914.zafiro.chat.agentic.buildin.TextResultBuiltinTool
+import com.niki914.zafiro.chat.agentic.buildin.TextToolResult
+import com.niki914.zafiro.chat.agentic.python.PyRuntime
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * py_download_file 工具：从 URL 下载文件到 Python 临时目录（与 py_install_apk 一致，
+ * 进程私有可写、零外部存储权限负担；未来做文件访问权限时再统一存储位置）。
+ */
+class PyDownloadFileBuiltin(
+    private val executor: suspend (code: String, timeoutMs: Long) -> String = PyRuntime::exec,
+) : TextResultBuiltinTool() {
+
+    override val name: String = "py_download_file"
+    override val description: String = """
+Download a file from a URL to a private app temporary directory.
+Use when you need to download images, documents, or other files from the web.
+Returns the local file path on success.
+    """.trimIndent()
+    override val defaultEnabled: Boolean = true
+    override val inputSchemaJson: String? = SCHEMA
+
+    override suspend fun invokeText(request: BuiltinToolRequest): TextToolResult {
+        val args = try {
+            Json.parseToJsonElement(request.argumentsJson.ifBlank { "{}" }).jsonObject
+        } catch (e: Exception) {
+            return TextToolResult.failure(
+                code = "INVALID_ARGUMENTS",
+                message = "argumentsJson is not valid JSON: ${e.message}"
+            )
+        }
+
+        val url = (args["url"] as? JsonPrimitive)?.contentOrNull?.trim().orEmpty()
+        if (url.isBlank()) {
+            return TextToolResult.failure(
+                code = "MISSING_URL",
+                message = "Field 'url' is required and must be a non-empty string."
+            )
+        }
+
+        val filename = (args["filename"] as? JsonPrimitive)?.contentOrNull?.trim().orEmpty()
+
+        val code = buildDownloadScript(url, filename)
+        return try {
+            val output = executor(code, DOWNLOAD_TIMEOUT_MS)
+            val result = Json.parseToJsonElement(output.trim()).jsonObject
+            val ok = (result["ok"] as? JsonPrimitive)?.booleanOrNull ?: false
+            if (ok) {
+                val path = (result["path"] as? JsonPrimitive)?.contentOrNull.orEmpty()
+                TextToolResult.success("Downloaded to $path")
+            } else {
+                val error = (result["error"] as? JsonPrimitive)?.contentOrNull ?: "Download failed"
+                TextToolResult.failure(code = "DOWNLOAD_FAILED", message = error)
+            }
+        } catch (e: Exception) {
+            TextToolResult.failure(
+                code = "DOWNLOAD_ERROR",
+                message = e.message ?: "Download failed"
+            )
+        }
+    }
+
+    private fun buildDownloadScript(url: String, filename: String): String {
+        return """
+import os
+import tempfile
+import urllib.request
+import uuid
+import json
+
+url = ${repr(url)}
+filename = ${repr(filename)}
+download_dir = tempfile.gettempdir()
+
+try:
+    os.makedirs(download_dir, exist_ok=True)
+    
+    # Determine filename
+    if filename:
+        dest = os.path.join(download_dir, filename)
+    else:
+        # Extract from URL or generate UUID
+        from urllib.parse import urlparse
+        parsed = urlparse(url)
+        path = parsed.path
+        name = os.path.basename(path)
+        if not name or '.' not in name:
+            name = str(uuid.uuid4())
+        dest = os.path.join(download_dir, name)
+    
+    # Download
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (Linux; Android 14)"})
+    with urllib.request.urlopen(req, timeout=120) as resp, open(dest, "wb") as f:
+        while True:
+            chunk = resp.read(8192)
+            if not chunk:
+                break
+            f.write(chunk)
+    
+    size = os.path.getsize(dest)
+    print(json.dumps({"ok": True, "path": dest, "size": size}))
+except Exception as e:
+    print(json.dumps({"ok": False, "error": str(e)}))
+        """.trimIndent()
+    }
+
+    companion object {
+        private const val DOWNLOAD_TIMEOUT_MS = 120_000L
+        private val SCHEMA = """
+{
+  "type": "object",
+  "properties": {
+    "url": {
+      "type": "string",
+      "description": "URL of the file to download."
+    },
+    "filename": {
+      "type": "string",
+      "description": "Optional filename. If omitted, extracted from URL or generated."
+    }
+  },
+  "required": ["url"]
+}
+        """.trimIndent()
+    }
+}
+
+private fun repr(s: String): String {
+    return "\"${s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")}\""
+}

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/ViewImageBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/ViewImageBuiltin.kt
@@ -1,0 +1,97 @@
+package com.niki914.zafiro.chat.agentic.buildin.impl
+
+import com.niki914.zafiro.chat.agentic.buildin.BuiltinTool
+import com.niki914.zafiro.chat.agentic.buildin.BuiltinToolRequest
+import com.niki914.zafiro.chat.agentic.buildin.BuiltinToolResult
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import java.io.File
+
+/**
+ * view_image 工具：Agent 主动读取磁盘上的图片文件。
+ * 参数 path = 图片文件绝对路径，返回图片文件路径（供会话树引用）。
+ * 统一存储路径：App 私有目录（filesDir/Zafiro/images）。
+ *
+ * 文件不存在时返回错误，由 Agent 决定后续操作（如提示用户文件已删除）。
+ */
+class ViewImageBuiltin : BuiltinTool() {
+    override val name: String = "view_image"
+    override val description: String = """
+Read an image file from disk so the model can see it.
+Use when you need to view an image that the user shared, downloaded from the web, or saved by a tool.
+Accepts an absolute file path (e.g. a path returned by py_download_file or the images directory).
+Returns the file path if the file exists, or an error if it was deleted or is unreadable.
+    """.trimIndent()
+    override val defaultEnabled: Boolean = true
+    override val inputSchemaJson: String? = SCHEMA
+
+    override suspend fun invoke(request: BuiltinToolRequest): BuiltinToolResult {
+        val args = request.argumentsJson
+        val path = try {
+            val obj = kotlinx.serialization.json.Json.parseToJsonElement(args).jsonObject
+            (obj["path"] as? kotlinx.serialization.json.JsonPrimitive)?.contentOrNull?.trim().orEmpty()
+        } catch (e: Exception) {
+            return BuiltinToolResult.failure(
+                code = "INVALID_ARGUMENTS",
+                message = "Failed to parse arguments: ${e.message}"
+            )
+        }
+
+        if (path.isBlank()) {
+            return BuiltinToolResult.failure(
+                code = "MISSING_PATH",
+                message = "Field 'path' is required and must be a non-empty string."
+            )
+        }
+
+        val file = File(path)
+        if (!file.exists() || !file.isFile) {
+            return BuiltinToolResult.failure(
+                code = "FILE_NOT_FOUND",
+                message = "Image file not found or is not a readable file: $path",
+                hint = "The file may have been deleted. Ask the user to share or download it again."
+            )
+        }
+
+        val mimeType = when (file.extension.lowercase()) {
+            "jpg", "jpeg" -> "image/jpeg"
+            "png" -> "image/png"
+            "gif" -> "image/gif"
+            "webp" -> "image/webp"
+            "bmp" -> "image/bmp"
+            else -> "image/jpeg"
+        }
+
+        return BuiltinToolResult.success(
+            message = "Image file verified: $path",
+            data = JsonObject(
+                mapOf(
+                    "image" to JsonObject(
+                        mapOf(
+                            "path" to kotlinx.serialization.json.JsonPrimitive(path),
+                            "mime_type" to kotlinx.serialization.json.JsonPrimitive(mimeType)
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    companion object {
+        private val SCHEMA = """
+{
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string",
+      "description": "Absolute path to the image file (e.g. a path returned by py_download_file)."
+    }
+  },
+  "required": ["path"]
+}
+        """.trimIndent()
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,12 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
     <queries>
         <package android:name="com.heytap.speechassist" />

--- a/docs/TODO_image_support.md
+++ b/docs/TODO_image_support.md
@@ -1,0 +1,74 @@
+# TODO_image_support（图片支持 · 未来项）
+
+当前状态（2026）：协议层图片链路已通（view_image 工具 → 工具结果带图 →
+四种协议各自编码）。`supportsImages` 全局默认 **false**——尚无任何入口把它
+置 true，图片功能整体休眠。
+
+## Code Review 发现的问题
+
+### 必改
+
+- **Gemini 工具结果图片编码违法**：`GeminiProtocol.functionResponsePart()` 把
+  `functionResponse` 和 `inlineData` 塞进同一个 part，但 Gemini API schema 中
+  `Part` 是 oneof 结构，每个 part 只能有一个字段。会触发
+  `Only one field may be set on a Part` 错误。需改为返回 `List<JsonObject>`，
+  拆成两个独立 part：functionResponse part + inlineData part。
+
+- **MCP 图片 base64 未 strip data URL 前缀**：`AndroidImageSaver.save()` 直接
+  `Base64.decode(base64, ...)`，但 MCP 实现可能返回带
+  `data:image/png;base64,` 前缀的字符串。Android 的 `Base64.decode` 遇到非
+  base64 字符会抛异常或返回错码，导致图片落地失败、工具结果丢失。需先
+  `substringAfter("base64,", base64)` 再 decode。
+
+- **ImageLoader.load() 无文件大小护栏**：`AndroidImageLoader` 原字节直读，
+  无尺寸上限、无 `withContext(Dispatchers.IO)`、无 mime 校验。大图（如 5MB
+  PNG → ~6.7MB base64）可能触达网关请求体上限；且 `load()` 不是 suspend
+  函数，在 `buildRequest` 内阻塞当前协程线程。需加文件大小上限（如 10MB）
+  并把 `ImageLoader` 改为 `suspend fun interface`。
+
+### 需调研
+
+- **OpenAI Responses function_call_output.output 变体名**：当前用 `input_text` /
+  `input_image`，这两个是 user content part 的变体名。`function_call_output.output`
+  数组内的合法变体名是否也是 `input_text` / `input_image`，还是 `output_text` /
+  `output_image`，需对照 OpenAI 官方 spec 进一步调研正确性。PR 实测通过
+  可能是 DeepSeek 网关比较宽容，换到其他 gateway（OpenAI 官方）可能报错。
+
+以下为未来待办，均未排期。
+
+## UI - 用户消息气泡附加图片
+
+用户消息气泡支持附加图片（相册 / 文件等入口，text_file / photos）。
+
+前提：`Okia.send()` 只收 `text: String`，内部恒构造 `ContentBlock.Text`，
+协议层 `userContent()` 的图片分支目前是死代码。需给 send() 增加图片参数或
+新 API，才能构造带 `ContentBlock.Image` 的 `Message.User`。
+
+## decode / filter
+
+发送前图片处理：尺寸收缩 / 格式转换。
+
+- svg 等 provider 不支持的格式需要转换
+- 参照 pi `processImage` / Eta `AgentImageCodec`（尺寸上限 + 压缩）
+- 当前 `AndroidImageLoader` 原字节直读，无任何护栏（大图 base64 可能触达
+  provider 请求体上限）
+
+## MCP 多图
+
+`ToolCallOutcome.Success` 目前只承载单图（McpExecutor 对多图静默丢弃、
+只取第一张）。需扩展为图片列表。
+
+## UI - provider 设置开关
+
+provider 修改页增加 supportsImages 开关。落地后由 LLMController 写入
+OkiaConfig——这是把图片功能从休眠恢复的正式入口。
+
+## 权限请求 / 管理
+
+当前权限只在 manifest 声明（READ_MEDIA_IMAGES 等），未做运行时请求 / 管理 UI。
+
+## 备注
+
+- 历史中含图片路径的工具结果，每次后续请求都会重读文件并重发 base64，
+  token 随图片数累积。Zafiro 暂走 pi 路线（每轮重发）；Eta 的选择是从持久
+  会话剔除图片只留文本占位，两种都成立，成本特性不同。

--- a/libs/okia/src/main/java/com/niki914/okia/ImageLoader.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/ImageLoader.kt
@@ -1,0 +1,12 @@
+package com.niki914.okia
+
+/**
+ * 图片加载器（host 注入）。Okia 纯库不碰 Android 文件系统，protocol 层构建请求时
+ * 调用本接口把 ContentBlock.Image.path 读成字节 → base64。
+ *
+ * 返回 null = 文件不存在或不可读（外部存储被用户删除等场景），protocol 层做降级处理。
+ */
+fun interface ImageLoader {
+    /** 读取图片文件并返回字节。返回 null = 文件不存在或不可读。 */
+    fun load(path: String): ByteArray?
+}

--- a/libs/okia/src/main/java/com/niki914/okia/ImageSaver.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/ImageSaver.kt
@@ -1,0 +1,11 @@
+package com.niki914.okia
+
+/**
+ * 图片保存器（host 注入）。Okia 纯库不碰文件系统，MCP 返回 base64 图片时
+ * 经本接口落地为文件，返回路径引用供 ContentBlock.Image 使用。
+ *
+ * 统一存储路径：/sdcard/Download/Zafiro/images/，SHA-256 内容哈希命名。
+ */
+fun interface ImageSaver {
+    suspend fun save(base64: String, mimeType: String): String?
+}

--- a/libs/okia/src/main/java/com/niki914/okia/OkiaConfig.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/OkiaConfig.kt
@@ -33,7 +33,7 @@ data class OkiaConfig(
     val httpEngine: HttpEngine?,
     val imageLoader: ImageLoader? = null,
     val imageSaver: ImageSaver? = null,
-    val supportsImages: Boolean = true
+    val supportsImages: Boolean = false
 ) {
 
     // apiKey 与敏感 header 值脱敏；mcpServers 内 header 由 McpServer.toString 自行脱敏
@@ -64,7 +64,7 @@ data class OkiaConfig(
         var httpEngine: HttpEngine? = null
         var imageLoader: ImageLoader? = null
         var imageSaver: ImageSaver? = null
-        var supportsImages: Boolean = true
+        var supportsImages: Boolean = false
 
         // 组装不可变配置快照
         fun build(): OkiaConfig = OkiaConfig(

--- a/libs/okia/src/main/java/com/niki914/okia/OkiaConfig.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/OkiaConfig.kt
@@ -30,7 +30,10 @@ data class OkiaConfig(
     val mcpServers: List<McpServer>,
     val hooks: List<Hooks>,
     val toolRegistry: ToolRegistry?,
-    val httpEngine: HttpEngine?
+    val httpEngine: HttpEngine?,
+    val imageLoader: ImageLoader? = null,
+    val imageSaver: ImageSaver? = null,
+    val supportsImages: Boolean = true
 ) {
 
     // apiKey 与敏感 header 值脱敏；mcpServers 内 header 由 McpServer.toString 自行脱敏
@@ -59,6 +62,9 @@ data class OkiaConfig(
         var hooks: List<Hooks> = emptyList()
         var toolRegistry: ToolRegistry? = null
         var httpEngine: HttpEngine? = null
+        var imageLoader: ImageLoader? = null
+        var imageSaver: ImageSaver? = null
+        var supportsImages: Boolean = true
 
         // 组装不可变配置快照
         fun build(): OkiaConfig = OkiaConfig(
@@ -76,7 +82,10 @@ data class OkiaConfig(
             mcpServers = mcpServers,
             hooks = hooks,
             toolRegistry = toolRegistry,
-            httpEngine = httpEngine
+            httpEngine = httpEngine,
+            imageLoader = imageLoader,
+            imageSaver = imageSaver,
+            supportsImages = supportsImages
         )
 
         // 从现有快照复制全部字段（update 热更新的基础：只改 block 声明的字段）
@@ -96,6 +105,9 @@ data class OkiaConfig(
             hooks = other.hooks
             toolRegistry = other.toolRegistry
             httpEngine = other.httpEngine
+            imageLoader = other.imageLoader
+            imageSaver = other.imageSaver
+            supportsImages = other.supportsImages
             return this
         }
     }

--- a/libs/okia/src/main/java/com/niki914/okia/RealOkia.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/RealOkia.kt
@@ -108,7 +108,8 @@ internal class RealOkia(
         McpDiscovery(
             client = dependencies.mcpClient,
             servers = { config.mcpServers },
-            registry = { effectiveRegistry(config) }
+            registry = { effectiveRegistry(config) },
+            imageSaver = config.imageSaver
         )
     }
 
@@ -266,7 +267,9 @@ internal class RealOkia(
                 readMs = cfg.readTimeoutSeconds * 1000,
                 writeMs = cfg.writeTimeoutSeconds * 1000
             ),
-            tools = effectiveRegistry(cfg).snapshot().map { it.descriptor }
+            tools = effectiveRegistry(cfg).snapshot().map { it.descriptor },
+            supportsImages = cfg.supportsImages,
+            imageLoader = cfg.imageLoader
             // 工具描述快照（T9b G5 整改）：send 时快照仅为初始值；每段
             // buildRequest 前 RealAgentLoop 用 registry 现取覆盖（§8.18），
             // 请求体表达「每段发送时的工具集」。

--- a/libs/okia/src/main/java/com/niki914/okia/mcp/McpClient.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/mcp/McpClient.kt
@@ -30,6 +30,9 @@ sealed interface McpContentBlock {
 
     /** 文本块。 */
     data class Text(val text: String) : McpContentBlock
+
+    /** 图片块。base64 编码，host 落地为文件后替换为路径引用。 */
+    data class Image(val data: String, val mimeType: String) : McpContentBlock
 }
 
 /** 在 MCP 服务器上发现的工具，喂入工具注册表。 */

--- a/libs/okia/src/main/java/com/niki914/okia/mcp/McpDiscovery.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/mcp/McpDiscovery.kt
@@ -1,5 +1,6 @@
 package com.niki914.okia.mcp
 
+import com.niki914.okia.ImageSaver
 import com.niki914.okia.tooling.ToolDescriptor
 import com.niki914.okia.tooling.ToolKind
 import com.niki914.okia.tooling.ToolRegistry
@@ -46,13 +47,14 @@ import kotlin.time.ExperimentalTime
 internal class McpDiscovery(
     private val client: McpClient,
     private val servers: () -> List<McpServer>,
-    private val registry: () -> ToolRegistry
+    private val registry: () -> ToolRegistry,
+    private val imageSaver: ImageSaver? = null
 ) {
 
     // 每服务器执行器（注册给发现的工具；servers 解析闭包读最新配置）
-    private val executor = McpExecutor(client) { name ->
+    private val executor = McpExecutor(client, { name ->
         servers().firstOrNull { it.name == name }
-    }
+    }, imageSaver)
 
     // 当前发现快照（不可变整体替换；@Volatile 免锁读取，KMP 无 concurrent map）
     @Volatile

--- a/libs/okia/src/main/java/com/niki914/okia/mcp/McpExecutor.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/mcp/McpExecutor.kt
@@ -1,5 +1,7 @@
 package com.niki914.okia.mcp
 
+import com.niki914.okia.ImageSaver
+import com.niki914.okia.message.ContentBlock
 import com.niki914.okia.message.ToolCallOutcome
 import com.niki914.okia.tooling.ToolCallContext
 import com.niki914.okia.tooling.ToolExecutor
@@ -39,7 +41,8 @@ import kotlinx.coroutines.CancellationException
  */
 class McpExecutor(
     private val client: McpClient,
-    private val servers: (serverName: String) -> McpServer?
+    private val servers: (serverName: String) -> McpServer?,
+    private val imageSaver: ImageSaver? = null
 ) : ToolExecutor {
 
     override suspend fun execute(call: ToolCallContext): ToolCallOutcome {
@@ -50,19 +53,35 @@ class McpExecutor(
             val server = servers(serverName)
                 ?: return ToolCallOutcome.Failure("MCP server not found: $serverName")
             val result = client.callTool(server, toolName, call.argumentsJson)
-            val content = result.content.joinToString("\n") { block ->
+            val textContent = StringBuilder()
+            var imageBlock: ContentBlock.Image? = null
+            for (block in result.content) {
                 when (block) {
-                    // 非文本 block 已在 McpWire.parseCallResult 报错（§8.8 #4 收窄），
-                    // 此处 only Text 可达。
-                    is McpContentBlock.Text -> block.text
+                    is McpContentBlock.Text -> {
+                        if (textContent.isNotEmpty()) textContent.append("\n")
+                        textContent.append(block.text)
+                    }
+                    is McpContentBlock.Image -> {
+                        val saver = imageSaver
+                        if (saver != null && imageBlock == null) {
+                            // TODO: 当前 ToolCallOutcome.Success 仅承载单图，多图仅取第一张，其余静默丢弃
+                            val path = saver.save(block.data, block.mimeType)
+                            if (path != null) {
+                                imageBlock = ContentBlock.Image(path, block.mimeType)
+                            }
+                        }
+                    }
                 }
             }
             if (result.isError) {
                 ToolCallOutcome.Failure(
                     "tool returned isError=true",
-                    content = content.ifEmpty { null })
+                    content = textContent.toString().ifEmpty { null })
             } else {
-                ToolCallOutcome.Success(content)
+                ToolCallOutcome.Success(
+                    content = textContent.toString(),
+                    image = imageBlock
+                )
             }
         } catch (e: CancellationException) {
             throw e

--- a/libs/okia/src/main/java/com/niki914/okia/mcp/McpWire.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/mcp/McpWire.kt
@@ -178,7 +178,7 @@ internal class McpWire(
         }
     }
 
-    /** result 对象 → 结构化调用结果。非文本 content block → 抛（§8.8 #4 收窄）。 */
+    /** result 对象 → 结构化调用结果。非文本/图片 content block → 抛。 */
     fun parseCallResult(result: JsonObject): McpCallResult {
         val isError = (result["isError"] as? JsonPrimitive)?.booleanOrNull ?: false
         val rawContent = result["content"] as? JsonArray ?: JsonArray(emptyList())
@@ -186,15 +186,24 @@ internal class McpWire(
             val block = raw as? JsonObject
                 ?: throw McpProtocolException("content block is not an object: $raw")
             val type = block["type"]?.let { it as? JsonPrimitive }?.contentOrNull
-            if (type != "text") {
-                throw McpProtocolException(
-                    "MCP tool result contains non-text block type '${type ?: "unknown"}'; " +
-                            "only text blocks are supported"
+            when (type) {
+                "text" -> {
+                    val text = block["text"]?.let { it as? JsonPrimitive }?.contentOrNull
+                        ?: throw McpProtocolException("MCP text content block missing 'text': $block")
+                    McpContentBlock.Text(text)
+                }
+                "image" -> {
+                    val mimeType = block["mimeType"]?.let { it as? JsonPrimitive }?.contentOrNull
+                        ?: throw McpProtocolException("MCP image content block missing 'mimeType': $block")
+                    val data = block["data"]?.let { it as? JsonPrimitive }?.contentOrNull
+                        ?: throw McpProtocolException("MCP image content block missing 'data': $block")
+                    McpContentBlock.Image(data, mimeType)
+                }
+                else -> throw McpProtocolException(
+                    "MCP tool result contains unsupported block type '${type ?: "unknown"}'; " +
+                            "only text and image blocks are supported"
                 )
             }
-            val text = block["text"]?.let { it as? JsonPrimitive }?.contentOrNull
-                ?: throw McpProtocolException("MCP text content block missing 'text': $block")
-            McpContentBlock.Text(text)
         }
         return McpCallResult(isError = isError, content = blocks)
     }

--- a/libs/okia/src/main/java/com/niki914/okia/message/ContentBlock.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/message/ContentBlock.kt
@@ -24,9 +24,12 @@ sealed interface ContentBlock {
         val opaquePayload: String? = null
     ) : ContentBlock
 
-    /** Base64 编码图像。多模态入口，M2 前不支持。 */
+    /**
+     * 图像引用。存储文件路径（非 base64），发送时由 protocol 经 ImageLoader
+     * 读取并转为 base64。统一存储路径：/sdcard/Download/Zafiro/images/。
+     */
     @Serializable
-    data class Image(val data: String, val mimeType: String) : ContentBlock
+    data class Image(val path: String, val mimeType: String) : ContentBlock
 
     /** 模型发出的工具调用。参数保持 JSON 字符串。signature：Gemini 3 思维内
      *  工具调用的 thoughtSignature（回放时原样带回到 functionCall part）。 */

--- a/libs/okia/src/main/java/com/niki914/okia/message/ToolCallOutcome.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/message/ToolCallOutcome.kt
@@ -13,9 +13,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 sealed interface ToolCallOutcome {
 
-    /** 工具成功，产出结果负载。内容为任意文本，不一定是 JSON。 */
+    /**
+     * 工具成功，产出结果负载。内容为任意文本，不一定是 JSON。
+     * image：工具返回的图片（view_image / MCP 图片等），path 引用。
+     */
     @Serializable
-    data class Success(val content: String) : ToolCallOutcome
+    data class Success(val content: String, val image: ContentBlock.Image? = null) : ToolCallOutcome
 
     /** 工具已运行但失败。 */
     @Serializable

--- a/libs/okia/src/main/java/com/niki914/okia/protocol/AnthropicMessagesProtocol.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/protocol/AnthropicMessagesProtocol.kt
@@ -36,7 +36,6 @@ import kotlinx.serialization.json.put
  *   tool_result 块（assistant tool_use 之后紧随一个 user 消息携带全部结果）
  * - thinking 块历史回带必须带 signature；无 signature 的思考转文本
  * - 认证走 x-api-key 头 + 固定 anthropic-version 头
- * 图片输入 M2 前不支持（与 OpenAI 协议一致，抛 IllegalStateException）。
  * Design source: pi api/anthropic-messages.ts；实测 DeepSeek Anthropic 网关
  * 字节流（thinking/tool_use/usage/stop_reason 全形态）。
  */
@@ -234,7 +233,7 @@ class AnthropicMessagesProtocol(
                     put("input", parseArguments(block.argumentsJson))
                 }
 
-                is ContentBlock.Image -> null  // M2 前不支持，user 侧已先行抛错；此处防御忽略
+                is ContentBlock.Image -> null  // assistant 不携带图片，防御忽略
             }
         }
 

--- a/libs/okia/src/main/java/com/niki914/okia/protocol/AnthropicMessagesProtocol.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/protocol/AnthropicMessagesProtocol.kt
@@ -1,5 +1,6 @@
 package com.niki914.okia.protocol
 
+import com.niki914.okia.ImageLoader
 import com.niki914.okia.message.AssistantMessage
 import com.niki914.okia.message.ContentBlock
 import com.niki914.okia.message.Message
@@ -11,6 +12,7 @@ import com.niki914.okia.transport.HttpRequest
 import com.niki914.okia.transport.SseEventParser
 import com.niki914.okia.transport.SseLine
 import kotlinx.coroutines.CancellationException
+import kotlin.io.encoding.Base64
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.serialization.SerializationException
@@ -123,7 +125,7 @@ class AnthropicMessagesProtocol(
                 put("tools", buildJsonArray { snapshot.tools.forEach { add(convertTool(it)) } })
             }
             put("messages", buildJsonArray {
-                mergeMessages(history).forEach { merged ->
+                mergeMessages(snapshot, history).forEach { merged ->
                     add(buildJsonObject {
                         put("role", merged.role)
                         put("content", buildJsonArray { merged.blocks.forEach { add(it) } })
@@ -137,13 +139,13 @@ class AnthropicMessagesProtocol(
      * 工具结果映射为 user 消息的 tool_result 块；连续同角色消息合并
      * （Anthropic 严格交替）。工具结果与后续用户输入合并进同一 user 消息。
      */
-    private fun mergeMessages(history: List<Message>): List<MergedMessage> {
+    private fun mergeMessages(snapshot: RequestSnapshot, history: List<Message>): List<MergedMessage> {
         val merged = mutableListOf<MergedMessage>()
         for (message in history) {
             val (role, blocks) = when (message) {
-                is Message.User -> "user" to userBlocks(message.content)
+                is Message.User -> "user" to userBlocks(snapshot, message.content)
                 is Message.Assistant -> "assistant" to assistantBlocks(message.message)
-                is Message.ToolResult -> "user" to listOf(toolResultBlock(message))
+                is Message.ToolResult -> "user" to listOf(toolResultBlock(snapshot, message))
             }
             val last = merged.lastOrNull()
             if (last != null && last.role == role) {
@@ -155,18 +157,53 @@ class AnthropicMessagesProtocol(
         return merged
     }
 
-    private fun userBlocks(blocks: List<ContentBlock>): List<JsonObject> {
+    private fun userBlocks(snapshot: RequestSnapshot, blocks: List<ContentBlock>): List<JsonObject> {
         val image = blocks.firstOrNull { it is ContentBlock.Image }
-        if (image != null) {
-            throw IllegalStateException(
-                "image content is not supported by AnthropicMessagesProtocol before M2"
-            )
+        if (image == null) {
+            return blocks.filterIsInstance<ContentBlock.Text>().map { text ->
+                buildJsonObject {
+                    put("type", "text")
+                    put("text", text.text)
+                }
+            }
         }
+        if (!snapshot.supportsImages) {
+            return blocks.filterIsInstance<ContentBlock.Text>().map { text ->
+                buildJsonObject {
+                    put("type", "text")
+                    put("text", text.text)
+                }
+            } + buildJsonObject {
+                put("type", "text")
+                put("text", "[image omitted: model does not support images]")
+            }
+        }
+        val loader = snapshot.imageLoader
+        val bytes = loader?.load((image as ContentBlock.Image).path)
+        if (bytes == null) {
+            return blocks.filterIsInstance<ContentBlock.Text>().map { text ->
+                buildJsonObject {
+                    put("type", "text")
+                    put("text", text.text)
+                }
+            } + buildJsonObject {
+                put("type", "text")
+                put("text", "[image omitted: file not found]")
+            }
+        }
+        val base64 = Base64.encode(bytes)
         return blocks.filterIsInstance<ContentBlock.Text>().map { text ->
             buildJsonObject {
                 put("type", "text")
                 put("text", text.text)
             }
+        } + buildJsonObject {
+            put("type", "image")
+            put("source", buildJsonObject {
+                put("type", "base64")
+                put("media_type", image.mimeType)
+                put("data", base64)
+            })
         }
     }
 
@@ -201,13 +238,41 @@ class AnthropicMessagesProtocol(
             }
         }
 
-    private fun toolResultBlock(result: Message.ToolResult): JsonObject =
-        buildJsonObject {
+    private fun toolResultBlock(snapshot: RequestSnapshot, result: Message.ToolResult): JsonObject {
+        val image = (result.outcome as? ToolCallOutcome.Success)?.image
+        if (image != null && snapshot.supportsImages) {
+            val loader = snapshot.imageLoader
+            val bytes = loader?.load(image.path)
+            if (bytes != null) {
+                val base64 = Base64.encode(bytes)
+                return buildJsonObject {
+                    put("type", "tool_result")
+                    put("tool_use_id", result.callId)
+                    put("content", buildJsonArray {
+                        add(buildJsonObject {
+                            put("type", "text")
+                            put("text", result.outcome.providerContent())
+                        })
+                        add(buildJsonObject {
+                            put("type", "image")
+                            put("source", buildJsonObject {
+                                put("type", "base64")
+                                put("media_type", image.mimeType)
+                                put("data", base64)
+                            })
+                        })
+                    })
+                    if (result.outcome.isProviderError()) put("is_error", true)
+                }
+            }
+        }
+        return buildJsonObject {
             put("type", "tool_result")
             put("tool_use_id", result.callId)
             put("content", result.outcome.providerContent())
             if (result.outcome.isProviderError()) put("is_error", true)
         }
+    }
 
     private fun parseArguments(argumentsJson: String): JsonObject = try {
         codec.parseToJsonElement(argumentsJson) as? JsonObject ?: buildJsonObject { }

--- a/libs/okia/src/main/java/com/niki914/okia/protocol/GeminiProtocol.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/protocol/GeminiProtocol.kt
@@ -45,7 +45,7 @@ import kotlinx.serialization.json.put
  * 历史与请求装配：consecutive 同角色内容合并（Anthropic 同规则）；工具结果
  * 并入 user content（functionResponse part），可与用户文本共存。
  * 无集成测试（无真实 key，用户裁决 2026-08-18）：实现经代码走查 + fixture
- * 语义对照 pi google-generative-ai.ts。图片输入 M2 前不支持。
+ * 语义对照 pi google-generative-ai.ts。
  * Design source: pi api/google-generative-ai.ts + google-shared.ts。
  */
 class GeminiProtocol(
@@ -218,7 +218,7 @@ class GeminiProtocol(
                     block.signature?.let { put("thoughtSignature", it) }
                 }
 
-                is ContentBlock.Image -> null  // M2 前不支持（user 侧已抛错），防御忽略
+                is ContentBlock.Image -> null  // assistant 不携带图片，防御忽略
             }
         }
 

--- a/libs/okia/src/main/java/com/niki914/okia/protocol/GeminiProtocol.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/protocol/GeminiProtocol.kt
@@ -1,5 +1,6 @@
 package com.niki914.okia.protocol
 
+import com.niki914.okia.ImageLoader
 import com.niki914.okia.message.AssistantMessage
 import com.niki914.okia.message.ContentBlock
 import com.niki914.okia.message.Message
@@ -23,6 +24,7 @@ import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.longOrNull
+import kotlin.io.encoding.Base64
 import kotlinx.serialization.json.put
 
 /**
@@ -109,7 +111,7 @@ class GeminiProtocol(
     private fun buildRequestBody(snapshot: RequestSnapshot, history: List<Message>): JsonObject =
         buildJsonObject {
             put("contents", buildJsonArray {
-                mergeContents(history).forEach { content ->
+                mergeContents(snapshot, history).forEach { content ->
                     add(buildJsonObject {
                         put("role", content.role)
                         put("parts", buildJsonArray { content.parts.forEach { add(it) } })
@@ -143,13 +145,13 @@ class GeminiProtocol(
      * 助手 content = text / thought / functionCall parts；连续同角色合并。
      * 工具结果并入 user content（可与用户文本共存）。
      */
-    private fun mergeContents(history: List<Message>): List<MergedContent> {
+    private fun mergeContents(snapshot: RequestSnapshot, history: List<Message>): List<MergedContent> {
         val merged = mutableListOf<MergedContent>()
         for (message in history) {
             val (role, parts) = when (message) {
-                is Message.User -> "user" to userParts(message.content)
+                is Message.User -> "user" to userParts(snapshot, message.content)
                 is Message.Assistant -> "model" to assistantParts(message.message)
-                is Message.ToolResult -> "user" to listOf(functionResponsePart(message))
+                is Message.ToolResult -> "user" to listOf(functionResponsePart(snapshot, message))
             }
             val last = merged.lastOrNull()
             if (last != null && last.role == role) {
@@ -161,15 +163,33 @@ class GeminiProtocol(
         return merged
     }
 
-    private fun userParts(blocks: List<ContentBlock>): List<JsonObject> {
+    private fun userParts(snapshot: RequestSnapshot, blocks: List<ContentBlock>): List<JsonObject> {
         val image = blocks.firstOrNull { it is ContentBlock.Image }
-        if (image != null) {
-            throw IllegalStateException(
-                "image content is not supported by GeminiProtocol before M2"
-            )
+        if (image == null) {
+            return blocks.filterIsInstance<ContentBlock.Text>().map { text ->
+                buildJsonObject { put("text", text.text) }
+            }
         }
+        if (!snapshot.supportsImages) {
+            return blocks.filterIsInstance<ContentBlock.Text>().map { text ->
+                buildJsonObject { put("text", text.text) }
+            } + buildJsonObject { put("text", "[image omitted: model does not support images]") }
+        }
+        val loader = snapshot.imageLoader
+        val bytes = loader?.load((image as ContentBlock.Image).path)
+        if (bytes == null) {
+            return blocks.filterIsInstance<ContentBlock.Text>().map { text ->
+                buildJsonObject { put("text", text.text) }
+            } + buildJsonObject { put("text", "[image omitted: file not found]") }
+        }
+        val base64 = Base64.encode(bytes)
         return blocks.filterIsInstance<ContentBlock.Text>().map { text ->
             buildJsonObject { put("text", text.text) }
+        } + buildJsonObject {
+            put("inlineData", buildJsonObject {
+                put("mimeType", image.mimeType)
+                put("data", base64)
+            })
         }
     }
 
@@ -202,12 +222,32 @@ class GeminiProtocol(
             }
         }
 
-    private fun functionResponsePart(result: Message.ToolResult): JsonObject =
-        buildJsonObject {
+    private fun functionResponsePart(snapshot: RequestSnapshot, result: Message.ToolResult): JsonObject {
+        val image = (result.outcome as? ToolCallOutcome.Success)?.image
+        if (image != null && snapshot.supportsImages) {
+            val loader = snapshot.imageLoader
+            val bytes = loader?.load(image.path)
+            if (bytes != null) {
+                val base64 = Base64.encode(bytes)
+                return buildJsonObject {
+                    put("functionResponse", buildJsonObject {
+                        put("name", result.toolName)
+                        put("id", result.callId)
+                        put("response", buildJsonObject {
+                            put("output", result.outcome.providerContent())
+                        })
+                    })
+                    put("inlineData", buildJsonObject {
+                        put("mimeType", image.mimeType)
+                        put("data", base64)
+                    })
+                }
+            }
+        }
+        return buildJsonObject {
             put("functionResponse", buildJsonObject {
                 put("name", result.toolName)
                 put("id", result.callId)
-                // 成功走 output，失败走 error（SDK 语义，对照 pi）
                 if (result.outcome.isProviderError()) {
                     put("response", buildJsonObject {
                         put("error", result.outcome.providerContent())
@@ -219,6 +259,7 @@ class GeminiProtocol(
                 }
             })
         }
+    }
 
     private fun parseArguments(argumentsJson: String): JsonObject = try {
         codec.parseToJsonElement(argumentsJson) as? JsonObject ?: buildJsonObject { }

--- a/libs/okia/src/main/java/com/niki914/okia/protocol/OpenAIChatCompletionProtocol.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/protocol/OpenAIChatCompletionProtocol.kt
@@ -1,5 +1,6 @@
 package com.niki914.okia.protocol
 
+import com.niki914.okia.ImageLoader
 import com.niki914.okia.message.AssistantMessage
 import com.niki914.okia.message.ContentBlock
 import com.niki914.okia.message.Message
@@ -10,6 +11,7 @@ import com.niki914.okia.tooling.ToolDescriptor
 import com.niki914.okia.transport.HttpRequest
 import com.niki914.okia.transport.SseEventParser
 import com.niki914.okia.transport.SseLine
+import kotlin.io.encoding.Base64
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.serialization.SerializationException
@@ -135,7 +137,7 @@ class OpenAIChatCompletionProtocol(
                         put("content", it)
                     })
                 }
-                history.forEach { message -> convertMessage(message)?.let { add(it) } }
+                history.forEach { message -> convertMessage(snapshot, message)?.let { add(it) } }
             })
             put("stream", true)
             put("stream_options", buildJsonObject { put("include_usage", true) })
@@ -153,28 +155,71 @@ class OpenAIChatCompletionProtocol(
             }
         }
 
-    private fun convertMessage(message: Message): JsonObject? = when (message) {
+    private fun convertMessage(snapshot: RequestSnapshot, message: Message): JsonObject? = when (message) {
         is Message.User -> buildJsonObject {
             put("role", "user")
-            put("content", userContent(message.content))
+            val content = userContent(snapshot, message.content)
+            if (content is JsonPrimitive) {
+                put("content", content.content)
+            } else {
+                put("content", content)
+            }
         }
 
         is Message.Assistant -> convertAssistant(message.message)
         is Message.ToolResult -> buildJsonObject {
             put("role", "tool")
-            put("content", message.outcome.providerContent())
             put("tool_call_id", message.callId)
+            val image = (message.outcome as? ToolCallOutcome.Success)?.image
+            if (image != null && snapshot.supportsImages) {
+                val loader = snapshot.imageLoader
+                val bytes: ByteArray? = loader?.load(image.path)
+                if (bytes != null) {
+                    val dataUrl = "data:${image.mimeType};base64,${Base64.encode(bytes)}"
+                    put("content", buildJsonArray {
+                        add(buildJsonObject {
+                            put("type", "text")
+                            put("text", message.outcome.providerContent())
+                        })
+                        add(buildJsonObject {
+                            put("type", "image_url")
+                            put("image_url", buildJsonObject { put("url", dataUrl) })
+                        })
+                    })
+                    return@buildJsonObject
+                }
+            }
+            put("content", message.outcome.providerContent())
         }
     }
 
-    private fun userContent(blocks: List<ContentBlock>): String {
+    private fun userContent(snapshot: RequestSnapshot, blocks: List<ContentBlock>): kotlinx.serialization.json.JsonElement {
         val image = blocks.firstOrNull { it is ContentBlock.Image }
-        if (image != null) {
-            throw IllegalStateException(
-                "image content is not supported by OpenAIChatCompletionProtocol before M2"
-            )
+        val text = blocks.filterIsInstance<ContentBlock.Text>().joinToString("\n") { it.text }
+        if (image == null) {
+            return JsonPrimitive(text)
         }
-        return blocks.filterIsInstance<ContentBlock.Text>().joinToString("\n") { it.text }
+        if (!snapshot.supportsImages) {
+            return JsonPrimitive("$text\n[image omitted: model does not support images]")
+        }
+        val loader = snapshot.imageLoader
+        val bytes = loader?.load((image as ContentBlock.Image).path)
+        if (bytes == null) {
+            return JsonPrimitive("$text\n[image omitted: file not found]")
+        }
+        val dataUrl = "data:${image.mimeType};base64,${Base64.encode(bytes)}"
+        return buildJsonArray {
+            blocks.filterIsInstance<ContentBlock.Text>().forEach { t ->
+                add(buildJsonObject {
+                    put("type", "text")
+                    put("text", t.text)
+                })
+            }
+            add(buildJsonObject {
+                put("type", "image_url")
+                put("image_url", buildJsonObject { put("url", dataUrl) })
+            })
+        }
     }
 
     private fun convertAssistant(message: AssistantMessage): JsonObject? {

--- a/libs/okia/src/main/java/com/niki914/okia/protocol/OpenAIChatCompletionProtocol.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/protocol/OpenAIChatCompletionProtocol.kt
@@ -137,7 +137,7 @@ class OpenAIChatCompletionProtocol(
                         put("content", it)
                     })
                 }
-                history.forEach { message -> convertMessage(snapshot, message)?.let { add(it) } }
+                history.forEach { message -> convertMessages(snapshot, message).forEach { add(it) } }
             })
             put("stream", true)
             put("stream_options", buildJsonObject { put("include_usage", true) })
@@ -155,8 +155,9 @@ class OpenAIChatCompletionProtocol(
             }
         }
 
-    private fun convertMessage(snapshot: RequestSnapshot, message: Message): JsonObject? = when (message) {
-        is Message.User -> buildJsonObject {
+    /** 一条历史消息 → 0..n 条 Chat Completions 消息（ToolResult 带图可产两条）。 */
+    private fun convertMessages(snapshot: RequestSnapshot, message: Message): List<JsonObject> = when (message) {
+        is Message.User -> listOf(buildJsonObject {
             put("role", "user")
             val content = userContent(snapshot, message.content)
             if (content is JsonPrimitive) {
@@ -164,33 +165,41 @@ class OpenAIChatCompletionProtocol(
             } else {
                 put("content", content)
             }
-        }
+        })
 
-        is Message.Assistant -> convertAssistant(message.message)
-        is Message.ToolResult -> buildJsonObject {
+        is Message.Assistant -> listOfNotNull(convertAssistant(message.message))
+        is Message.ToolResult -> toolResultMessages(snapshot, message)
+    }
+
+    /**
+     * ToolResult → Chat Completions 消息。OpenAI tool 角色 content 只接受字符串，
+     * 不支持图片 content part（规范限制；pi 同：openai-completions.ts 把工具结果
+     * 图片拆到独立的 user 消息）。图片加载失败 / 不支持时退回单条 tool 字符串消息。
+     */
+    private fun toolResultMessages(snapshot: RequestSnapshot, message: Message.ToolResult): List<JsonObject> {
+        val toolMessage = buildJsonObject {
             put("role", "tool")
             put("tool_call_id", message.callId)
-            val image = (message.outcome as? ToolCallOutcome.Success)?.image
-            if (image != null && snapshot.supportsImages) {
-                val loader = snapshot.imageLoader
-                val bytes: ByteArray? = loader?.load(image.path)
-                if (bytes != null) {
-                    val dataUrl = "data:${image.mimeType};base64,${Base64.encode(bytes)}"
-                    put("content", buildJsonArray {
-                        add(buildJsonObject {
-                            put("type", "text")
-                            put("text", message.outcome.providerContent())
-                        })
-                        add(buildJsonObject {
-                            put("type", "image_url")
-                            put("image_url", buildJsonObject { put("url", dataUrl) })
-                        })
-                    })
-                    return@buildJsonObject
-                }
-            }
             put("content", message.outcome.providerContent())
         }
+        val image = (message.outcome as? ToolCallOutcome.Success)?.image ?: return listOf(toolMessage)
+        if (!snapshot.supportsImages) return listOf(toolMessage)
+        val loader = snapshot.imageLoader
+        val bytes = loader?.load(image.path) ?: return listOf(toolMessage)
+        val dataUrl = "data:${image.mimeType};base64,${Base64.encode(bytes)}"
+        return listOf(toolMessage, buildJsonObject {
+            put("role", "user")
+            put("content", buildJsonArray {
+                add(buildJsonObject {
+                    put("type", "text")
+                    put("text", "Attached image(s) from tool result:")
+                })
+                add(buildJsonObject {
+                    put("type", "image_url")
+                    put("image_url", buildJsonObject { put("url", dataUrl) })
+                })
+            })
+        })
     }
 
     private fun userContent(snapshot: RequestSnapshot, blocks: List<ContentBlock>): kotlinx.serialization.json.JsonElement {

--- a/libs/okia/src/main/java/com/niki914/okia/protocol/OpenAIResponsesProtocol.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/protocol/OpenAIResponsesProtocol.kt
@@ -233,11 +233,11 @@ class OpenAIResponsesProtocol(
                     val dataUrl = "data:${image.mimeType};base64,${Base64.encode(bytes)}"
                     put("output", buildJsonArray {
                         add(buildJsonObject {
-                            put("type", "text")
+                            put("type", "input_text")
                             put("text", message.outcome.providerContent())
                         })
                         add(buildJsonObject {
-                            put("type", "output_image")
+                            put("type", "input_image")
                             put("image_url", dataUrl)
                         })
                     })
@@ -298,7 +298,7 @@ class OpenAIResponsesProtocol(
         val dataUrl = "data:${image.mimeType};base64,${Base64.encode(bytes)}"
         return buildJsonArray {
             add(buildJsonObject {
-                put("type", "text")
+                put("type", "input_text")
                 put("text", text)
             })
             add(buildJsonObject {

--- a/libs/okia/src/main/java/com/niki914/okia/protocol/OpenAIResponsesProtocol.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/protocol/OpenAIResponsesProtocol.kt
@@ -1,5 +1,6 @@
 package com.niki914.okia.protocol
 
+import com.niki914.okia.ImageLoader
 import com.niki914.okia.message.ContentBlock
 import com.niki914.okia.message.Message
 import com.niki914.okia.message.StopReason
@@ -10,6 +11,7 @@ import com.niki914.okia.transport.HttpRequest
 import com.niki914.okia.transport.SseEventParser
 import com.niki914.okia.transport.SseLine
 import kotlinx.coroutines.CancellationException
+import kotlin.io.encoding.Base64
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.serialization.SerializationException
@@ -160,7 +162,7 @@ class OpenAIResponsesProtocol(
         buildJsonObject {
             put("model", snapshot.model)
             put("input", buildJsonArray {
-                history.forEach { message -> addInputItem(message).forEach { add(it) } }
+                history.forEach { message -> addInputItem(snapshot, message).forEach { add(it) } }
             })
             snapshot.systemPrompt?.let { put("instructions", it) }
             put("stream", true)
@@ -178,10 +180,10 @@ class OpenAIResponsesProtocol(
      * reasoning item（不把其文本拼进 message，避免重复）；无 payload 或前缀
      * 不认识的思考块继续按明文合并进文本（DeepSeek 网关形态）。
      */
-    private fun addInputItem(message: Message): List<JsonObject> = when (message) {
+    private fun addInputItem(snapshot: RequestSnapshot, message: Message): List<JsonObject> = when (message) {
         is Message.User -> listOf(buildJsonObject {
             put("role", "user")
-            put("content", userContent(message.content))
+            put("content", userContent(snapshot, message.content))
         })
 
         is Message.Assistant -> {
@@ -223,6 +225,25 @@ class OpenAIResponsesProtocol(
         is Message.ToolResult -> listOf(buildJsonObject {
             put("type", "function_call_output")
             put("call_id", message.callId)
+            val image = (message.outcome as? ToolCallOutcome.Success)?.image
+            if (image != null && snapshot.supportsImages) {
+                val loader = snapshot.imageLoader
+                val bytes = loader?.load(image.path)
+                if (bytes != null) {
+                    val dataUrl = "data:${image.mimeType};base64,${Base64.encode(bytes)}"
+                    put("output", buildJsonArray {
+                        add(buildJsonObject {
+                            put("type", "text")
+                            put("text", message.outcome.providerContent())
+                        })
+                        add(buildJsonObject {
+                            put("type", "output_image")
+                            put("image_url", dataUrl)
+                        })
+                    })
+                    return@buildJsonObject
+                }
+            }
             put("output", message.outcome.providerContent())
         })
     }
@@ -260,14 +281,31 @@ class OpenAIResponsesProtocol(
         state.reasoningItems.clear()
     }
 
-    private fun userContent(blocks: List<ContentBlock>): String {
+    private fun userContent(snapshot: RequestSnapshot, blocks: List<ContentBlock>): kotlinx.serialization.json.JsonElement {
         val image = blocks.firstOrNull { it is ContentBlock.Image }
-        if (image != null) {
-            throw IllegalStateException(
-                "image content is not supported by OpenAIResponsesProtocol before M2"
-            )
+        val text = blocks.filterIsInstance<ContentBlock.Text>().joinToString("\n") { it.text }
+        if (image == null) {
+            return kotlinx.serialization.json.JsonPrimitive(text)
         }
-        return blocks.filterIsInstance<ContentBlock.Text>().joinToString("\n") { it.text }
+        if (!snapshot.supportsImages) {
+            return kotlinx.serialization.json.JsonPrimitive("$text\n[image omitted: model does not support images]")
+        }
+        val loader = snapshot.imageLoader
+        val bytes = loader?.load((image as ContentBlock.Image).path)
+        if (bytes == null) {
+            return kotlinx.serialization.json.JsonPrimitive("$text\n[image omitted: file not found]")
+        }
+        val dataUrl = "data:${image.mimeType};base64,${Base64.encode(bytes)}"
+        return buildJsonArray {
+            add(buildJsonObject {
+                put("type", "text")
+                put("text", text)
+            })
+            add(buildJsonObject {
+                put("type", "input_image")
+                put("image_url", dataUrl)
+            })
+        }
     }
 
     private fun convertTool(tool: ToolDescriptor): JsonObject =

--- a/libs/okia/src/main/java/com/niki914/okia/protocol/RequestSnapshot.kt
+++ b/libs/okia/src/main/java/com/niki914/okia/protocol/RequestSnapshot.kt
@@ -1,5 +1,6 @@
 package com.niki914.okia.protocol
 
+import com.niki914.okia.ImageLoader
 import com.niki914.okia.tooling.ToolDescriptor
 import com.niki914.okia.transport.HttpTimeouts
 import com.niki914.okia.transport.redactHeaders
@@ -18,7 +19,9 @@ data class RequestSnapshot(
     val maxTokens: Int,
     val headers: Map<String, String>,
     val timeouts: HttpTimeouts,
-    val tools: List<ToolDescriptor>
+    val tools: List<ToolDescriptor>,
+    val supportsImages: Boolean = false,
+    val imageLoader: ImageLoader? = null
 ) {
 
     // apiKey 与敏感 header 值脱敏（systemPrompt 非凭据，保留）

--- a/libs/okia/src/test/java/com/niki914/okia/mcp/LegacyStreamableHttpMcpClientTest.kt
+++ b/libs/okia/src/test/java/com/niki914/okia/mcp/LegacyStreamableHttpMcpClientTest.kt
@@ -691,7 +691,7 @@ class LegacyStreamableHttpMcpClientTest {
     }
 
     @Test
-    fun `non-text content block is a protocol error`() = runBlocking {
+    fun `image content block is parsed`() = runBlocking {
         server.dispatcher = serverWith(
             call = { b ->
                 rpcResult(
@@ -700,12 +700,10 @@ class LegacyStreamableHttpMcpClientTest {
                 )
             }
         )
-        val e = try {
-            client.callTool(mcpServer(), "t", "{}"); null
-        } catch (x: McpProtocolException) {
-            x
-        }
-        assertNotNull(e)
+        val result = client.callTool(mcpServer(), "t", "{}")
+        val block = result.content.single() as McpContentBlock.Image
+        assertEquals("AAAA", block.data)
+        assertEquals("image/png", block.mimeType)
     }
 
     @Test

--- a/libs/okia/src/test/java/com/niki914/okia/mcp/McpExecutorTest.kt
+++ b/libs/okia/src/test/java/com/niki914/okia/mcp/McpExecutorTest.kt
@@ -1,5 +1,6 @@
 package com.niki914.okia.mcp
 
+import com.niki914.okia.ImageSaver
 import com.niki914.okia.message.ToolCallOutcome
 import com.niki914.okia.tooling.ToolCallContext
 import com.niki914.okia.tooling.ToolDescriptor
@@ -69,8 +70,9 @@ class McpExecutorTest {
 
     private fun executor(
         client: FakeClient,
-        servers: Map<String, McpServer> = mapOf("docs" to server("docs"))
-    ) = McpExecutor(client) { servers[it] }
+        servers: Map<String, McpServer> = mapOf("docs" to server("docs")),
+        imageSaver: ImageSaver? = null,
+    ) = McpExecutor(client, { servers[it] }, imageSaver)
 
     // ── 路由与工具名还原 ───────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Protocol-level image plumbing for Okia engine. Agent can read images via  tool; tool results with images are base64-encoded and sent alongside text content blocks across all four protocols (OpenAI Responses / Chat Completions / Anthropic / Gemini).

- New  — stores file path, not bytes; protocol layer loads via 
-  carries optional  field
-  builtin tool +  for downloading from URL
-  /  host implementations (SHA-256 dedup, private dir)
- OpenAI Responses: fix content part variant names (/ vs /)
- OpenAI Chat Completions: tool result images split into separate user message (spec limitation)
- Anthropic: tool_result content array with nested image block (native support)
- Gemini: user messages via  part
- MCP: parse  content blocks, save via 
-  defaults to  — feature dormant until UI/provider toggle lands

## Test plan

- [x] Responses gateway end-to-end: agent calls , model sees image and answers accordingly
- [ ] Gemini tool result image encoding (known issue, see TODO)
- [ ] MCP image with data URL prefix (known issue, see TODO)
- [ ] Large file guardrail (known issue, see TODO)

## Known issues / TODO

See  — contains code review findings including 3 must-fix items and 1 needs-investigation item.