### PR TITLE
feat: Prompt 整页编辑页 + fix: 工具块后文本丢失

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ packing/
 /.as-run/app.run.xml
 /RELEASING.md
 media/
+.pi/

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/LlmStreamEvent.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/LlmStreamEvent.kt
@@ -8,6 +8,8 @@ sealed interface LlmStreamEvent {
         val delta: String,
         val fullText: String,
         val charsPerSecond: Float? = null,
+        /** 段起点：fullText 为新文本段坐标（从头累计），消费端据此重置段内状态（节流器等）。 */
+        val isSegmentStart: Boolean = false,
     ) : LlmStreamEvent
 
     /** 思考块开始/进行中：id 为回合内由 Mapper 分配的单调块标识（OKIA index 跨轮复用，不可作身份），text 为当前全量。 */

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/stream/LlmStreamEventMapper.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/stream/LlmStreamEventMapper.kt
@@ -53,7 +53,8 @@ object LlmStreamEventMapper {
                 LlmStreamEvent.RoundStarted
             }
 
-            // 文本块开始：partial 含第一个 delta（OKIA 不单发），以全量作 delta
+            // 文本块开始：partial 含第一个 delta（OKIA 不单发），以全量作 delta。
+            // isSegmentStart = true：工具块等边界后 fullText 从新坐标开始，消费端据此重置段内状态。
             is TurnEvent.TextStarted -> {
                 val fullText = event.partial.textContent()
                 accumulatedText = fullText
@@ -61,6 +62,7 @@ object LlmStreamEventMapper {
                     delta = fullText,
                     fullText = fullText,
                     charsPerSecond = charsPerSecond(fullText, startedAtMs),
+                    isSegmentStart = true,
                 )
             }
 

--- a/agent-runtime/src/test/java/com/niki914/zafiro/chat/agentic/stream/LlmStreamEventMapperTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/zafiro/chat/agentic/stream/LlmStreamEventMapperTest.kt
@@ -10,6 +10,7 @@ import com.niki914.zafiro.chat.LlmErrorCode
 import com.niki914.zafiro.chat.LlmStreamEvent
 import com.niki914.zafiro.chat.util.SilentLoggerRule
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -77,6 +78,22 @@ class LlmStreamEventMapperTest {
         // 事件序列 delta 累积 == fullText：UI appendText 逐 delta 追加即得完整结果
         val accumulated = started.delta + next.delta
         assertEquals(next.fullText, accumulated)
+    }
+
+    @Test
+    fun `TextStarted marks segment start for downstream pacer reset`() {
+        val result = LlmStreamEventMapper.map(
+            TurnEvent.TextStarted(0, AssistantMessage(listOf(ContentBlock.Text("hi")))),
+            0L,
+                    ) as LlmStreamEvent.TextDelta
+        assertTrue(result.isSegmentStart)
+
+        // 后续 Delta 非段起点
+        val next = LlmStreamEventMapper.map(
+            TurnEvent.TextDelta(0, "!", AssistantMessage(listOf(ContentBlock.Text("hi!")))),
+            0L,
+                    ) as LlmStreamEvent.TextDelta
+        assertFalse(next.isSegmentStart)
     }
 
     @Test

--- a/app/src/main/java/com/niki914/zafiro/app/ui/ZafiroPageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/ZafiroPageContent.kt
@@ -15,6 +15,7 @@ import com.niki914.zafiro.app.ui.nav.ExecutionRuleDetailPage
 import com.niki914.zafiro.app.ui.nav.HomePage
 import com.niki914.zafiro.app.ui.nav.McpServerDetailPage
 import com.niki914.zafiro.app.ui.nav.ProviderPickPage
+import com.niki914.zafiro.app.ui.nav.PromptEditPage
 import com.niki914.zafiro.app.ui.nav.SavedConfigDetailPage
 import com.niki914.zafiro.app.ui.nav.SettingsDetailPage
 import com.niki914.zafiro.app.ui.nav.SettingsHomePage
@@ -32,6 +33,7 @@ import com.niki914.zafiro.app.ui.route.ExecutionRuleDetailRoute
 import com.niki914.zafiro.app.ui.route.HomePageRoute
 import com.niki914.zafiro.app.ui.route.McpServerDetailRoute
 import com.niki914.zafiro.app.ui.route.ProviderPickPageRoute
+import com.niki914.zafiro.app.ui.route.PromptEditRoute
 import com.niki914.zafiro.app.ui.route.SavedConfigDetailRoute
 import com.niki914.zafiro.app.ui.route.SettingsDetailPageRoute
 import com.niki914.zafiro.app.ui.route.SettingsHomePageRoute
@@ -116,6 +118,10 @@ fun ZafiroPageContent(
         is SettingsDetailPage -> SettingsDetailPageRoute(
             page = page,
             onPush = onPush,
+            onBack = onPop,
+        )
+
+        PromptEditPage -> PromptEditRoute(
             onBack = onPop,
         )
 

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/ConfigureEditableField.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/ConfigureEditableField.kt
@@ -5,6 +5,5 @@ enum class ConfigureEditableField {
     Endpoint,
     Model,
     ApiKey,
-    Prompt,
     Proxy,
 }

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/FullScreenContentEditor.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/FullScreenContentEditor.kt
@@ -1,0 +1,88 @@
+package com.niki914.zafiro.app.ui.content
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.niki914.uikit.infra.component.PageDescriptionText
+import com.niki914.uikit.infra.component.SettingsDetailPageDefaults
+import com.niki914.uikit.infra.component.TintLiquidButton
+import com.niki914.uikit.infra.liquidScreenTopPadding
+
+/**
+ * 整页内容编辑器骨架（infra）：描述文案 + 全页 TextField + 底部保存按钮 + 内联错误。
+ * 从 SkillDetailContent 提取；Prompt 编辑页与 Skill 详情页共用。
+ * 顶层 chrome（未保存确认、删除确认）仍由调用方经 [EditableSettingsDetailChrome] 提供。
+ */
+@Composable
+internal fun FullScreenContentEditor(
+    description: String,
+    value: String,
+    enabled: Boolean,
+    onValueChange: (String) -> Unit,
+    actionText: String,
+    onActionClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    actionLoading: Boolean = false,
+    inlineErrorText: String? = null,
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = SettingsDetailPageDefaults.HorizontalPadding)
+                .padding(
+                    top = liquidScreenTopPadding(SettingsDetailPageDefaults.VerticalPadding),
+                    bottom = SettingsDetailPageDefaults.VerticalPadding +
+                            SettingsDetailPageDefaults.RootVerticalSpacing +
+                            SettingsDetailPageDefaults.ActionButtonReservedHeight,
+                ),
+            verticalArrangement = Arrangement.spacedBy(
+                SettingsDetailPageDefaults.ContentVerticalSpacing,
+            ),
+        ) {
+            PageDescriptionText(text = description)
+            TextField(
+                value = value,
+                onValueChange = onValueChange,
+                enabled = enabled,
+                textStyle = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+            )
+            inlineErrorText?.let { errorText ->
+                Text(
+                    text = errorText,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(
+                        horizontal = SettingsDetailPageDefaults.InlineErrorHorizontalPadding,
+                    ),
+                )
+            }
+        }
+
+        TintLiquidButton(
+            text = actionText,
+            enabled = enabled,
+            isLoading = actionLoading,
+            onClick = onActionClick,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(
+                    start = SettingsDetailPageDefaults.HorizontalPadding,
+                    end = SettingsDetailPageDefaults.HorizontalPadding,
+                    bottom = SettingsDetailPageDefaults.VerticalPadding,
+                ),
+        )
+    }
+}

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/ModelConfigSettingsContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/ModelConfigSettingsContent.kt
@@ -7,39 +7,36 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.stringResource
 import com.niki914.uikit.infra.ConfirmationLiquidDialog
-import com.niki914.uikit.infra.component.SettingExpandableTextItem
 import com.niki914.uikit.infra.component.SettingsGroupCard
 import com.niki914.uikit.infra.component.SettingsListPageContent
+import com.niki914.uikit.infra.component.SettingNavigationItem
 import com.niki914.uikit.infra.nav.pageViewModel
 import com.niki914.zafiro.app.R
 import com.niki914.zafiro.app.ui.model.ConfigureIntent
 import com.niki914.zafiro.app.ui.model.ConfigureScene
 import com.niki914.zafiro.app.ui.model.ConfigureViewModel
 import com.niki914.zafiro.app.ui.nav.TopBarActionSpec
-import kotlinx.coroutines.delay
 
 /**
- * Model Configuration 一级页：System Prompt（防抖自动保存）+ Saved Configuration 列表。
- * 编辑/新建走 SavedConfigDetailPage 二级页。
+ * Model Configuration 一级页：System Prompt 卡片（点击进整页编辑）+ Saved Configuration 列表。
+ * 编辑/新建走 SavedConfigDetailPage 二级页，Prompt 编辑走 PromptEditPage 二级页。
  */
 @Composable
 fun ModelConfigSettingsContent(
     onBack: () -> Unit,
     onOpenProviderPick: () -> Unit,
     onOpenConfigDetail: (configId: String, configName: String) -> Unit,
+    onOpenPromptEdit: () -> Unit,
 ) {
     val viewModel = pageViewModel<ConfigureViewModel>(
         key = "settings-configure",
     )
     val uiState by viewModel.uiStateFlow.collectAsState()
     var pendingDeleteConfigId by rememberSaveable { mutableStateOf<String?>(null) }
-    // 首次加载 document.prompt 时不触发自动保存
-    var promptLoadSettled by remember { mutableStateOf(false) }
 
     LaunchedEffect(viewModel) {
         viewModel.sendIntent(
@@ -47,16 +44,6 @@ fun ModelConfigSettingsContent(
                 scene = ConfigureScene.SettingsEdit,
             ),
         )
-    }
-
-    // prompt 防抖自动保存：停止输入 500ms 后持久化
-    LaunchedEffect(uiState.promptInput) {
-        if (!promptLoadSettled) {
-            promptLoadSettled = true
-            return@LaunchedEffect
-        }
-        delay(PROMPT_AUTO_SAVE_DEBOUNCE_MILLIS)
-        viewModel.sendIntent(ConfigureIntent.SavePrompt)
     }
 
     EditableSettingsDetailChrome(
@@ -71,19 +58,10 @@ fun ModelConfigSettingsContent(
     ) {
         SettingsListPageContent {
             SettingsGroupCard {
-                var promptExpanded by rememberSaveable { mutableStateOf(false) }
-                SettingExpandableTextItem(
+                SettingNavigationItem(
                     title = stringResource(R.string.ui_settings_configure_prompt_label),
-                    value = uiState.promptInput,
-                    onValueChange = { value ->
-                        viewModel.sendIntent(ConfigureIntent.UpdatePrompt(value))
-                    },
-                    placeholder = stringResource(R.string.ui_settings_configure_prompt_placeholder),
-                    description = null,
-                    minLines = 3,
-                    maxLines = 8,
-                    expanded = promptExpanded,
-                    onExpandedChange = { promptExpanded = it },
+                    summary = null,
+                    onClick = onOpenPromptEdit,
                 )
             }
 
@@ -123,5 +101,3 @@ fun ModelConfigSettingsContent(
         },
     )
 }
-
-private const val PROMPT_AUTO_SAVE_DEBOUNCE_MILLIS = 500L

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/PromptEditContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/PromptEditContent.kt
@@ -1,0 +1,62 @@
+package com.niki914.zafiro.app.ui.content
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.res.stringResource
+import com.niki914.uikit.infra.nav.pageViewModel
+import com.niki914.zafiro.app.R
+import com.niki914.zafiro.app.ui.model.PromptEditEffect
+import com.niki914.zafiro.app.ui.model.PromptEditIntent
+import com.niki914.zafiro.app.ui.model.PromptEditViewModel
+import com.niki914.zafiro.app.ui.model.hasUnsavedChanges
+
+/**
+ * System Prompt 整页编辑页：卡片点击进入，整页编辑 + 显式保存。
+ * 骨架复用 [FullScreenContentEditor]（与 Skill 详情页同款）。
+ */
+@Composable
+fun PromptEditContent(
+    onBack: () -> Unit,
+) {
+    val viewModel = pageViewModel<PromptEditViewModel>()
+    val uiState by viewModel.uiStateFlow.collectAsState()
+
+    EditableSettingsDetailChrome(
+        isCreating = false,
+        hasUnsavedChanges = { uiState.hasUnsavedChanges },
+        onDiscardChanges = onBack,
+    ) {
+        FullScreenContentEditor(
+            description = stringResource(R.string.prompt_editor_description),
+            value = uiState.content,
+            enabled = !uiState.isLoading && !uiState.loadError && !uiState.isSaving,
+            onValueChange = { value ->
+                viewModel.sendIntent(PromptEditIntent.ContentChanged(value))
+            },
+            actionText = stringResource(R.string.skill_save_action),
+            onActionClick = {
+                viewModel.sendIntent(PromptEditIntent.Save)
+            },
+            actionLoading = uiState.isSaving,
+            inlineErrorText = if (uiState.loadError) {
+                stringResource(R.string.prompt_error_load_failed)
+            } else {
+                null
+            },
+        )
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.sendIntent(PromptEditIntent.Load)
+    }
+
+    LaunchedEffect(viewModel) {
+        viewModel.uiEffect.collect { effect ->
+            when (effect) {
+                PromptEditEffect.Exit -> onBack()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/SettingsDetailPageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/SettingsDetailPageContent.kt
@@ -9,6 +9,7 @@ import com.niki914.zafiro.app.ui.model.SettingsViewModel
 import com.niki914.zafiro.app.ui.nav.BuiltinToolGroupDetailPage
 import com.niki914.zafiro.app.ui.nav.ExecutionRuleDetailPage
 import com.niki914.zafiro.app.ui.nav.McpServerDetailPage
+import com.niki914.zafiro.app.ui.nav.PromptEditPage
 import com.niki914.zafiro.app.ui.nav.SavedConfigDetailPage
 import com.niki914.zafiro.app.ui.nav.SettingsProviderPickPage
 import com.niki914.zafiro.app.ui.nav.SkillDetailPage
@@ -37,6 +38,9 @@ fun SettingsDetailPageContent(
             },
             onOpenConfigDetail = { configId, configName ->
                 onPush(SavedConfigDetailPage(configId = configId, configName = configName))
+            },
+            onOpenPromptEdit = {
+                onPush(PromptEditPage)
             },
         )
         return

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/SkillDetailContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/SkillDetailContent.kt
@@ -1,26 +1,11 @@
 package com.niki914.zafiro.app.ui.content
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.niki914.uikit.infra.ConfirmationLiquidDialog
-import com.niki914.uikit.infra.component.PageDescriptionText
-import com.niki914.uikit.infra.component.SettingsDetailPageDefaults
-import com.niki914.uikit.infra.component.TintLiquidButton
-import com.niki914.uikit.infra.liquidScreenTopPadding
 import com.niki914.uikit.infra.nav.pageViewModel
 import com.niki914.zafiro.app.R
 import com.niki914.zafiro.app.ui.model.SkillDeleteConfirmationState
@@ -105,74 +90,15 @@ private fun SkillDetailContentBody(
     val detailLoaded = uiState.formState.skillId.isNotBlank() &&
             uiState.inlineError !is SkillInlineError.LoadFailed
 
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = SettingsDetailPageDefaults.HorizontalPadding)
-                .padding(
-                    top = liquidScreenTopPadding(SettingsDetailPageDefaults.VerticalPadding),
-                    bottom = SettingsDetailPageDefaults.VerticalPadding +
-                            SettingsDetailPageDefaults.RootVerticalSpacing +
-                            SettingsDetailPageDefaults.ActionButtonReservedHeight,
-                ),
-            verticalArrangement = Arrangement.spacedBy(
-                SettingsDetailPageDefaults.ContentVerticalSpacing,
-            ),
-        ) {
-            PageDescriptionText(text = stringResource(R.string.skill_editor_description))
-            SkillContentEditor(
-                value = uiState.formState.content,
-                enabled = detailLoaded && !uiState.isSaving && !uiState.isLoading,
-                onValueChange = onContentChange,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f),
-            )
-            skillInlineErrorText(uiState.inlineError)?.let { errorText ->
-                Text(
-                    text = errorText,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error,
-                    modifier = Modifier.padding(
-                        horizontal = SettingsDetailPageDefaults.InlineErrorHorizontalPadding,
-                    ),
-                )
-            }
-        }
-
-        TintLiquidButton(
-            text = stringResource(R.string.skill_save_action),
-            enabled = detailLoaded && !uiState.isSaving && !uiState.isLoading,
-            isLoading = uiState.isSaving,
-            onClick = onSave,
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .padding(
-                    start = SettingsDetailPageDefaults.HorizontalPadding,
-                    end = SettingsDetailPageDefaults.HorizontalPadding,
-                    bottom = SettingsDetailPageDefaults.VerticalPadding,
-                ),
-        )
-    }
-}
-
-@Composable
-private fun SkillContentEditor(
-    value: String,
-    enabled: Boolean,
-    onValueChange: (String) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    TextField(
-        value = value,
-        onValueChange = onValueChange,
-        enabled = enabled,
-        textStyle = MaterialTheme.typography.bodyMedium,
-        modifier = modifier,
+    FullScreenContentEditor(
+        description = stringResource(R.string.skill_editor_description),
+        value = uiState.formState.content,
+        enabled = detailLoaded && !uiState.isSaving && !uiState.isLoading,
+        onValueChange = onContentChange,
+        actionText = stringResource(R.string.skill_save_action),
+        onActionClick = onSave,
+        actionLoading = uiState.isSaving,
+        inlineErrorText = skillInlineErrorText(uiState.inlineError),
     )
 }
 

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/ConfigureState.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/ConfigureState.kt
@@ -46,8 +46,6 @@ data class ConfigureUiState(
     @param:StringRes val endpointErrorResId: Int? = null,
     @param:StringRes val modelErrorResId: Int? = null,
     @param:StringRes val apiKeyErrorResId: Int? = null,
-    /** 全局 system prompt（页面级，不随 saved config 切换）。 */
-    val promptInput: String = "",
     val proxyInput: String = "",
     @param:StringRes val proxyErrorResId: Int? = null,
     val isSaving: Boolean = false,
@@ -67,7 +65,6 @@ data class ConfigureSnapshot(
     val apiKey: String,
     val protocolWireId: String,
     val proxy: String,
-    val prompt: String,
 )
 
 val ConfigureUiState.hasUnsavedChanges: Boolean
@@ -100,10 +97,6 @@ sealed interface ConfigureIntent {
     data class UpdateModel(val value: String) : ConfigureIntent
     data class UpdateApiKey(val value: String) : ConfigureIntent
     data class SelectProtocol(val wireId: String) : ConfigureIntent
-    data class UpdatePrompt(val value: String) : ConfigureIntent
-
-    /** 仅持久化全局 prompt（列表页防抖自动保存）。 */
-    data object SavePrompt : ConfigureIntent
     data class UpdateProxy(val value: String) : ConfigureIntent
     data object ToggleApiKeyVisibility : ConfigureIntent
     data class ActivateConfig(val configId: String) : ConfigureIntent
@@ -146,7 +139,6 @@ internal data class ConfigureViewModelDependencies(
     val upsertConfig: suspend (SavedLlmConfig) -> String?,
     val deleteConfig: suspend (String) -> Unit,
     val setActiveConfig: suspend (String) -> Unit,
-    val saveGlobalPrompt: suspend (String) -> Unit,
 ) {
     companion object {
         val Default = ConfigureViewModelDependencies(
@@ -154,7 +146,6 @@ internal data class ConfigureViewModelDependencies(
             upsertConfig = { XRepo.llmConfigs.upsert(it) },
             deleteConfig = { XRepo.llmConfigs.delete(it) },
             setActiveConfig = { XRepo.llmConfigs.setActive(it) },
-            saveGlobalPrompt = { XRepo.llmConfigs.savePrompt(it) },
         )
     }
 }
@@ -195,10 +186,6 @@ class ConfigureViewModel internal constructor(
 
             is ConfigureIntent.SelectProtocol -> handleProtocolSwitch(intent.wireId)
 
-            is ConfigureIntent.UpdatePrompt -> updateState {
-                copy(promptInput = intent.value)
-            }
-
             is ConfigureIntent.UpdateProxy -> updateState {
                 copy(proxyInput = intent.value, proxyErrorResId = null, inlineError = null)
             }
@@ -210,7 +197,6 @@ class ConfigureViewModel internal constructor(
             is ConfigureIntent.ActivateConfig -> activateConfig(intent.configId)
             is ConfigureIntent.DeleteConfig -> deleteConfig(intent.configId)
             ConfigureIntent.Save -> handleSave()
-            ConfigureIntent.SavePrompt -> savePromptOnly()
             ConfigureIntent.ConfirmEndpointMismatch -> confirmEndpointMismatch()
             ConfigureIntent.CancelEndpointMismatch -> cancelEndpointMismatch()
         }
@@ -283,7 +269,6 @@ class ConfigureViewModel internal constructor(
                 endpointErrorResId = null,
                 modelErrorResId = null,
                 apiKeyErrorResId = null,
-                promptInput = document.prompt,
                 proxyInput = "",
                 proxyErrorResId = null,
                 isSaving = false,
@@ -315,7 +300,6 @@ class ConfigureViewModel internal constructor(
                 endpointErrorResId = null,
                 modelErrorResId = null,
                 apiKeyErrorResId = null,
-                promptInput = document.prompt,
                 proxyInput = "",
                 proxyErrorResId = null,
                 isSaving = false,
@@ -354,7 +338,6 @@ class ConfigureViewModel internal constructor(
                 endpointErrorResId = null,
                 modelErrorResId = null,
                 apiKeyErrorResId = null,
-                promptInput = document.prompt,
                 proxyInput = target.proxy,
                 proxyErrorResId = null,
                 isSaving = false,
@@ -393,14 +376,6 @@ class ConfigureViewModel internal constructor(
                 },
             )
         }
-    }
-
-    private suspend fun savePromptOnly() {
-        runCatching { dependencies.saveGlobalPrompt(currentState.promptInput) }
-            .onFailure { throwable ->
-                if (throwable is CancellationException) throw throwable
-                Logger.w(LOG_TAG, "save prompt failed reason=${throwable.message}")
-            }
     }
 
     private suspend fun deleteConfig(configId: String) {
@@ -653,7 +628,6 @@ private fun ConfigureUiState.toSettingsSnapshot(): ConfigureSnapshot {
         apiKey = apiKeyInput,
         protocolWireId = protocolWireId,
         proxy = proxyInput.trim(),
-        prompt = promptInput,
     )
 }
 

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/HomeChatState.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/HomeChatState.kt
@@ -436,6 +436,15 @@ class HomeChatViewModel internal constructor(
      */
     private suspend fun paceTextDelta(turnId: Long, event: LlmStreamEvent.TextDelta) {
         val fullText = event.fullText
+        if (event.isSegmentStart) {
+            // 段边界（工具块等之后的新文本段）：fullText 从新坐标开始，节流器同步归零。
+            // 不重置则新段长度 ≤ 已放出字符数时 pace 直接 return，整段被静默丢弃。
+            Logger.d(
+                LOG_TAG,
+                "pace segment reset turnId=$turnId fullTextLen=${fullText.length} released=${textPacer.released}"
+            )
+            textPacer.reset()
+        }
         try {
             textPacer.pace(fullText.length) { from, to ->
                 applyEvent(

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/PromptEditState.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/PromptEditState.kt
@@ -1,0 +1,104 @@
+package com.niki914.zafiro.app.ui.model
+
+import androidx.annotation.StringRes
+import com.niki914.logging.Logger
+import com.niki914.uikit.base.ComposeMVIViewModel
+import com.niki914.zafiro.app.R
+import com.niki914.zafiro.repo.XRepo
+import kotlinx.coroutines.CancellationException
+
+/**
+ * System Prompt 整页编辑（MVI）。
+ *
+ * Prompt 为全局一份的行为层配置，独立于 Saved Configuration 持久化
+ * （[XRepo.llmConfigs] 的 prompt()/savePrompt()）。卡片点击跳入本页，
+ * 整页编辑 + 显式保存，替代原列表页内联展开 + 防抖自动保存。
+ */
+data class PromptEditUiState(
+    /** 编辑中内容。 */
+    val content: String = "",
+    /** 进入页面时的内容，用于未保存变更判断。 */
+    val initialContent: String = "",
+    val isLoading: Boolean = true,
+    val isSaving: Boolean = false,
+    /** 读失败时展示的内联错误；null = 正常。 */
+    val loadError: Boolean = false,
+)
+
+val PromptEditUiState.hasUnsavedChanges: Boolean
+    get() = !isLoading && content != initialContent
+
+sealed interface PromptEditIntent {
+    data object Load : PromptEditIntent
+    data class ContentChanged(val value: String) : PromptEditIntent
+    data object Save : PromptEditIntent
+}
+
+sealed interface PromptEditEffect {
+    data object Exit : PromptEditEffect
+}
+
+class PromptEditViewModel : ComposeMVIViewModel<
+        PromptEditIntent,
+        PromptEditUiState,
+        PromptEditEffect,
+        >() {
+
+    private companion object {
+        private const val LOG_TAG = "niki914_nexus_PromptEditViewModel"
+    }
+
+    override fun initUiState(): PromptEditUiState = PromptEditUiState()
+
+    override suspend fun handleIntent(intent: PromptEditIntent) {
+        when (intent) {
+            PromptEditIntent.Load -> load()
+            is PromptEditIntent.ContentChanged -> updateState {
+                copy(content = intent.value, loadError = false)
+            }
+
+            PromptEditIntent.Save -> save()
+        }
+    }
+
+    private suspend fun load() {
+        updateState { copy(isLoading = true, loadError = false) }
+        try {
+            val prompt = XRepo.llmConfigs.prompt()
+            Logger.d(LOG_TAG, "load succeeded length=${prompt.length}")
+            updateState {
+                copy(
+                    content = prompt,
+                    initialContent = prompt,
+                    isLoading = false,
+                    loadError = false,
+                )
+            }
+            // prompt 不存在视为空内容可编辑，不报错；读 store 失败才视为 loadError
+        } catch (throwable: Throwable) {
+            if (throwable is CancellationException) throw throwable
+            Logger.w(LOG_TAG, "load failed reason=${throwable.message}")
+            updateState { copy(isLoading = false, loadError = true) }
+        }
+    }
+
+    private suspend fun save() {
+        if (currentState.isSaving) return
+        updateState { copy(isSaving = true) }
+        try {
+            XRepo.llmConfigs.savePrompt(currentState.content)
+            Logger.i(LOG_TAG, "save succeeded length=${currentState.content.length}")
+            updateState {
+                copy(
+                    initialContent = currentState.content,
+                    isSaving = false,
+                )
+            }
+            sendEffect(PromptEditEffect.Exit)
+        } catch (throwable: Throwable) {
+            if (throwable is CancellationException) throw throwable
+            Logger.w(LOG_TAG, "save failed reason=${throwable.message}")
+            updateState { copy(isSaving = false) }
+        }
+    }
+}

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/TextPacer.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/TextPacer.kt
@@ -25,7 +25,17 @@ internal class TextPacer(
      * （参数 = 本帧放出区间 [from, to)），调用方据此从 fullText 切增量。
      */
     internal suspend fun pace(targetChars: Int, onRelease: suspend (Int, Int) -> Unit) {
-        if (targetChars <= released) return
+        // ponytail: 诊断日志，复现确认后随修复验证删除，不进 commit
+        if (targetChars <= released) {
+            if (targetChars < released) {
+                android.util.Log.w(
+                    "TextPacer",
+                    "drop branch hit: targetChars=$targetChars released=$released " +
+                            "(segment shorter than released coords, content would be lost)"
+                )
+            }
+            return
+        }
         var firstFrame = lastFrameMs == 0L
         while (released < targetChars) {
             val now = System.currentTimeMillis()

--- a/app/src/main/java/com/niki914/zafiro/app/ui/nav/ZafiroPages.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/nav/ZafiroPages.kt
@@ -202,6 +202,14 @@ data class TakeoverRuleDetailPage(
         if (isCreating) null else TopBarActionSpec(Icons.Default.Delete)
 }
 
+data object PromptEditPage : ZafiroPage {
+    override val routeKey: String = "prompt-edit"
+    override val titleSpec: PageTitleSpec = ResTitle(R.string.ui_settings_configure_prompt_label)
+    override val leftAction: TopBarActionSpec =
+        TopBarActionSpec(Icons.AutoMirrored.Filled.ArrowBack)
+    override val rightAction: TopBarActionSpec? = null
+}
+
 data object CustomPyToolsPage : ZafiroPage {
     override val routeKey: String = "custom-py-tools"
     override val titleSpec: PageTitleSpec = ResTitle(R.string.custom_py_tool_page_title)

--- a/app/src/main/java/com/niki914/zafiro/app/ui/route/PromptEditRoute.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/route/PromptEditRoute.kt
@@ -1,0 +1,13 @@
+package com.niki914.zafiro.app.ui.route
+
+import androidx.compose.runtime.Composable
+import com.niki914.zafiro.app.ui.content.PromptEditContent
+
+@Composable
+internal fun PromptEditRoute(
+    onBack: () -> Unit,
+) {
+    PromptEditContent(
+        onBack = onBack,
+    )
+}

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -140,6 +140,8 @@
     <string name="ui_settings_configure_save">儲存設定</string>
     <string name="ui_settings_configure_prompt_label">提示詞</string>
     <string name="ui_settings_configure_prompt_placeholder">你希望助理怎樣做？</string>
+    <string name="prompt_editor_description">編輯 System Prompt。儲存後，變更會在下一次對話時生效。</string>
+    <string name="prompt_error_load_failed">讀取提示詞失敗，請返回重試。</string>
     <string name="ui_settings_configure_proxy_label">代理</string>
     <string name="ui_settings_configure_proxy_placeholder">例如：http://127.0.0.1:7890</string>
     <string name="ui_settings_configure_error_required">必填欄位不能為空</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -141,6 +141,8 @@
     <string name="ui_settings_configure_save">Save Configuration</string>
     <string name="ui_settings_configure_prompt_label">Prompt</string>
     <string name="ui_settings_configure_prompt_placeholder">What should your assistant do?</string>
+    <string name="prompt_editor_description">Edit the System Prompt. Saved changes apply in the next conversation.</string>
+    <string name="prompt_error_load_failed">Failed to load the prompt. Go back and retry.</string>
     <string name="ui_settings_configure_proxy_label">Proxy</string>
     <string name="ui_settings_configure_proxy_placeholder">For example: http://127.0.0.1:7890</string>
     <string name="ui_settings_configure_error_required">This field cannot be empty</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -141,6 +141,8 @@
     <string name="ui_settings_configure_save">Guardar configuración</string>
     <string name="ui_settings_configure_prompt_label">Prompt del sistema</string>
     <string name="ui_settings_configure_prompt_placeholder">¿Cómo debería comportarse el asistente?</string>
+    <string name="prompt_editor_description">Edita el System Prompt. Los cambios se aplicarán en la siguiente conversación tras guardar.</string>
+    <string name="prompt_error_load_failed">No se pudo cargar el prompt. Vuelve atrás e inténtalo de nuevo.</string>
     <string name="ui_settings_configure_proxy_label">Proxy</string>
     <string name="ui_settings_configure_proxy_placeholder">Ejemplo: http://127.0.0.1:7890</string>
     <string name="ui_settings_configure_error_required">Los campos obligatorios no pueden estar vacíos</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -140,6 +140,8 @@
     <string name="ui_settings_configure_save">設定を保存</string>
     <string name="ui_settings_configure_prompt_label">プロンプト</string>
     <string name="ui_settings_configure_prompt_placeholder">アシスタントにどのような振る舞いをさせますか？</string>
+    <string name="prompt_editor_description">システムプロンプトを編集します。保存された変更は次回の会話から反映されます。</string>
+    <string name="prompt_error_load_failed">プロンプトの読み込みに失敗しました。戻って再試行してください。</string>
     <string name="ui_settings_configure_proxy_label">プロキシ</string>
     <string name="ui_settings_configure_proxy_placeholder">例：http://127.0.0.1:7890</string>
     <string name="ui_settings_configure_error_required">必須項目を入力してください</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,6 +140,8 @@
     <string name="ui_settings_configure_save">保存配置</string>
     <string name="ui_settings_configure_prompt_label">提示词</string>
     <string name="ui_settings_configure_prompt_placeholder">你的助手应该怎么做？</string>
+    <string name="prompt_editor_description">编辑 System Prompt。保存后，变更会在下次对话生效。</string>
+    <string name="prompt_error_load_failed">读取提示词失败，请返回重试。</string>
     <string name="ui_settings_configure_proxy_label">代理</string>
     <string name="ui_settings_configure_proxy_placeholder">例如：http://127.0.0.1:7890</string>
     <string name="ui_settings_configure_error_required">必填项不能为空</string>

--- a/app/src/test/java/com/niki914/zafiro/app/ui/model/ConfigureViewModelTest.kt
+++ b/app/src/test/java/com/niki914/zafiro/app/ui/model/ConfigureViewModelTest.kt
@@ -27,13 +27,12 @@ class ConfigureViewModelTest {
     val mainDispatcherRule =
         MainDispatcherRule()
 
-    /** 记录式依赖：upsert/delete/setActive/savePrompt 全部落到内存 document。 */
+    /** 记录式依赖：upsert/delete/setActive 全部落到内存 document。 */
     private class RecordingDeps {
         var document = LlmConfigsDocument()
         val upserted = mutableListOf<SavedLlmConfig>()
         val deletedIds = mutableListOf<String>()
         val activatedIds = mutableListOf<String>()
-        val savedPrompts = mutableListOf<String>()
 
         fun toDependencies(): ConfigureViewModelDependencies =
             ConfigureViewModelDependencies(
@@ -67,10 +66,6 @@ class ConfigureViewModelTest {
                     activatedIds += id
                     document = document.copy(activeId = id)
                 },
-                saveGlobalPrompt = { prompt ->
-                    savedPrompts += prompt
-                    document = document.copy(prompt = prompt)
-                },
             )
     }
 
@@ -89,7 +84,7 @@ class ConfigureViewModelTest {
     )
 
     @Test
-    fun initializeSettingsEdit_loadsActiveConfigAndGlobalPrompt() = runTest {
+    fun initializeSettingsEdit_loadsActiveConfig() = runTest {
         val deps = RecordingDeps()
         deps.document = LlmConfigsDocument(
             activeId = "cfg-a",
@@ -104,7 +99,6 @@ class ConfigureViewModelTest {
         val state = viewModel.uiStateFlow.value
         assertEquals(ConfigureScene.SettingsEdit, state.scene)
         assertEquals("cfg-a", state.editingConfigId)
-        assertEquals("global", state.promptInput)
         assertEquals("deepseek-v4-pro", state.modelInput)
         assertEquals(LlmProtocol.OpenAiResponses.wireId, state.protocolWireId)
         assertTrue(state.savedConfigs.first().isActive)
@@ -128,7 +122,7 @@ class ConfigureViewModelTest {
     }
 
     @Test
-    fun saveOnNewConfig_activatesIt_promptSavedViaSeparateIntent() = runTest {
+    fun saveOnNewConfig_activatesIt() = runTest {
         val deps = RecordingDeps()
         val viewModel = ConfigureViewModel(deps.toDependencies())
         viewModel.sendIntent(ConfigureIntent.Initialize(ConfigureScene.SettingsNew))
@@ -136,7 +130,6 @@ class ConfigureViewModelTest {
         val effectDeferred = async { viewModel.uiEffect.first() }
 
         viewModel.sendIntent(ConfigureIntent.UpdateName("主力"))
-        viewModel.sendIntent(ConfigureIntent.UpdatePrompt("你是一个测试助手。"))
         viewModel.sendIntent(ConfigureIntent.UpdateModel("gpt-5"))
         viewModel.sendIntent(ConfigureIntent.UpdateApiKey("sk"))
         viewModel.sendIntent(ConfigureIntent.Save)
@@ -144,10 +137,6 @@ class ConfigureViewModelTest {
 
         assertEquals(1, deps.upserted.size)
         assertTrue(deps.upserted.first().id.isNotBlank())
-        assertTrue(deps.savedPrompts.isEmpty())
-        viewModel.sendIntent(ConfigureIntent.SavePrompt)
-        advanceUntilIdle()
-        assertEquals("你是一个测试助手。", deps.savedPrompts.single())
         assertTrue(deps.activatedIds.isEmpty())
         assertEquals(deps.upserted.first().id, viewModel.uiStateFlow.value.activeConfigId)
         assertEquals(ConfigureEffect.SettingsSaveSucceeded, effectDeferred.await())
@@ -234,7 +223,7 @@ class ConfigureViewModelTest {
     }
 
     @Test
-    fun editingPrompt_marksDirty() = runTest {
+    fun editingName_marksDirty() = runTest {
         val deps = RecordingDeps()
         deps.document = LlmConfigsDocument(
             activeId = "cfg-a",
@@ -244,7 +233,7 @@ class ConfigureViewModelTest {
         viewModel.sendIntent(ConfigureIntent.Initialize(ConfigureScene.SettingsEdit))
         advanceUntilIdle()
 
-        viewModel.sendIntent(ConfigureIntent.UpdatePrompt("new prompt"))
+        viewModel.sendIntent(ConfigureIntent.UpdateName("new name"))
         advanceUntilIdle()
         assertTrue(viewModel.uiStateFlow.value.hasUnsavedChanges)
     }

--- a/app/src/test/java/com/niki914/zafiro/app/ui/model/HomeChatControllerTest.kt
+++ b/app/src/test/java/com/niki914/zafiro/app/ui/model/HomeChatControllerTest.kt
@@ -878,6 +878,59 @@ class HomeChatViewModelTest {
     }
 
     @Test
+    fun send_textAfterToolBlock_isNotDroppedByPacer() = runTest {
+        // 回归：工具块后新文本段 fullText 从新坐标开始，若不重置节流器，
+        // 段长 ≤ 已放出字符数时整段被静默丢弃（trunk loss after tool blocks）
+        val longText = "a".repeat(600)
+        val conversations = FakeHomeConversationStore()
+        val viewModel = HomeChatViewModel(
+            conversations = conversations,
+            runtime = FakeHomeChatRuntime(
+                stream = {
+                    flow {
+                        emit(LlmStreamEvent.RoundStarted)
+                        // 第一段：长文本，pacer 放出后 released 坐标远大于下一段
+                        emit(
+                            LlmStreamEvent.TextDelta(
+                                delta = longText,
+                                fullText = longText,
+                                isSegmentStart = true,
+                            )
+                        )
+                        emit(
+                            LlmStreamEvent.ToolRunning(
+                                ToolCallStatus(callId = "t1", name = "tool")
+                            )
+                        )
+                        emit(
+                            LlmStreamEvent.ToolSucceeded(
+                                ToolCallStatus(callId = "t1", name = "tool")
+                            )
+                        )
+                        // 工具后新文本段：短坐标（isSegmentStart = true）
+                        emit(
+                            LlmStreamEvent.TextDelta(
+                                delta = "after tool",
+                                fullText = "after tool",
+                                isSegmentStart = true,
+                            )
+                        )
+                        emit(LlmStreamEvent.Completed)
+                    }
+                },
+            ),
+        )
+        viewModel.sendIntent(HomeChatIntent.InputChanged("q"))
+        runCurrent()
+        viewModel.sendIntent(HomeChatIntent.Send)
+        advanceUntilIdle()
+
+        val turn = viewModel.uiStateFlow.value.turns.single()
+        val texts = turn.blocks.filterIsInstance<HomeChatBlock.Text>().map { it.text }
+        assertEquals(listOf(longText, "after tool"), texts)
+    }
+
+    @Test
     fun thinking_autoExpandsWhileActive_manualCollapseSurvivesEchoEndKeepsState() = runTest {
         val conversations = FakeHomeConversationStore()
         val viewModel = HomeChatViewModel(


### PR DESCRIPTION
## 改动

### fix: 工具块后文本段被 TextPacer 静默丢弃（trunk loss after tool blocks）

- 根因：工具块后新文本段的 `fullText` 从头累计，而 `TextPacer.released` 仍保留上一段坐标；段长 ≤ 已放出字符数时 `pace()` 直接 return，整段不渲染
- 修复：`LlmStreamEvent.TextDelta` 新增 `isSegmentStart`（Mapper 在 `TextStarted` 置位），Home 聊天页在段起点重置节流器
- `TextPacer` 丢弃分支保留诊断日志（logcat tag `TextPacer`），已在真机确认：日志捕获到 `fullTextLen=3, released=165` 的原 bug 场景且修复后内容完整
- 回归测试：`send_textAfterToolBlock_isNotDroppedByPacer`（长文本 → 工具 → 短文本段，断言后段到达）；Mapper 段起点标记测试

### feat: System Prompt 整页编辑页

- 从 SkillDetailContent 抽出 `FullScreenContentEditor` 整页编辑器基建（描述 + 全页 TextField + 底部保存 + 内联错误），Skill 页改为消费
- 新增 `PromptEditPage`：卡片点击进入、整页编辑 + 显式保存，替代列表页内联展开 + 500ms 防抖自动保存
- `ConfigureViewModel` 移除 `promptInput`/`UpdatePrompt`/`SavePrompt`（prompt 编辑不再经过它），`ConfigureSnapshot.prompt` 一并删除

## 验证

- `:app` `:agent-runtime` 编译通过
- ConfigureViewModelTest / HomeChatViewModelTest / LlmStreamEventMapperTest 全部通过