### PR TITLE
feat: 后台工具权限 overlay 弹窗

### DIFF
--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/LLMController.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/LLMController.kt
@@ -328,10 +328,7 @@ object LLMController {
 
     fun stream(
         query: String,
-        fromUserInterface: Boolean = false,
     ): Flow<LlmStreamEvent> = channelFlow {
-        // 确认型执行规则按来源区分：UI 直连可弹窗；宿主路径默认拒绝（英文错误回给 Agent）
-        ToolPermissionCoordinator.canRequestUserConfirmation = fromUserInterface
         try {
             val state = try {
                 refresh()

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/shell/ToolPermissionCoordinator.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/shell/ToolPermissionCoordinator.kt
@@ -1,9 +1,6 @@
 package com.niki914.zafiro.chat.agentic.shell
 
 import com.niki914.logging.Logger
-import com.niki914.zafiro.chat.agentic.shell.ToolPermissionCoordinator.canRequestUserConfirmation
-import com.niki914.zafiro.chat.agentic.shell.ToolPermissionCoordinator.pendingConfirmation
-import com.niki914.zafiro.chat.agentic.shell.ToolPermissionCoordinator.respond
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -17,22 +14,28 @@ data class ToolPermissionRequest(
     val matchedRuleName: String,
 )
 
-/** 确认请求终态：允许 / 用户拒绝 / 无确认渠道（宿主路径）拒绝。 */
+/** 确认请求终态：允许 / 用户拒绝 / 无确认渠道拒绝。 */
 enum class ToolPermissionResponse { ALLOWED, DENIED_BY_USER, DENIED_UNAVAILABLE }
 
 /**
  * CONFIRM 型执行规则的用户确认协调器。
- * - LLMController.stream 按来源设置 [canRequestUserConfirmation]：
- *   UI 直连 = true；宿主 Binder = false（默认拒绝，Agent 收到英文错误）。
- * - UI collect [pendingConfirmation] 渲染对话框，[respond] 解除挂起；
- *   永不超时（用户明确决策，PRD §3）。
- * - LLMController 单活跃回合，confirm/respond 无并发竞争。
+ *
+ * 路由策略（按优先级）：
+ * - 应用前台 → Compose 对话框（[pendingConfirmation] StateFlow → HomePageContent 渲染）
+ * - 应用后台 + [backgroundConfirmationHandler] 已设置 → 后台弹窗（overlay）
+ * - 否则 → DENIED_UNAVAILABLE
+ *
+ * 永不超时（用户明确决策，PRD §3）。
  */
 object ToolPermissionCoordinator {
     private const val LOG_TAG = "niki914_nexus_ToolPermission"
 
+    /** 应用 UI 是否可见（MainActivity 前台）。由 App 端 onResume/onPause 写入。 */
     @Volatile
-    var canRequestUserConfirmation: Boolean = false
+    var isUiResumed: Boolean = false
+
+    /** 后台确认处理器（overlay 弹窗）。null = 无后台确认能力，静默拒绝。 */
+    var backgroundConfirmationHandler: (suspend (ToolPermissionRequest) -> ToolPermissionResponse)? = null
 
     private val pendingFlow = MutableStateFlow<ToolPermissionRequest?>(null)
 
@@ -42,11 +45,22 @@ object ToolPermissionCoordinator {
     private var deferred: CompletableDeferred<ToolPermissionResponse>? = null
 
     suspend fun confirm(request: ToolPermissionRequest): ToolPermissionResponse {
-        if (!canRequestUserConfirmation) {
-            Logger.i(LOG_TAG, "confirm denied source=host id=${request.id}")
-            return ToolPermissionResponse.DENIED_UNAVAILABLE
+        Logger.i(
+            LOG_TAG,
+            "confirm id=${request.id} tool=${request.toolName} uiResumed=$isUiResumed handler=${backgroundConfirmationHandler != null}",
+        )
+        if (isUiResumed) {
+            return showInAppDialog(request)
         }
-        Logger.i(LOG_TAG, "confirm requested id=${request.id} tool=${request.toolName}")
+        val handler = backgroundConfirmationHandler
+        if (handler != null) {
+            return handler(request)
+        }
+        Logger.i(LOG_TAG, "confirm denied unavailable id=${request.id}")
+        return ToolPermissionResponse.DENIED_UNAVAILABLE
+    }
+
+    private suspend fun showInAppDialog(request: ToolPermissionRequest): ToolPermissionResponse {
         pendingFlow.value = request
         val waiter = CompletableDeferred<ToolPermissionResponse>()
         deferred = waiter

--- a/agent-runtime/src/test/java/com/niki914/zafiro/chat/ShellCommandSafetyPolicyTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/zafiro/chat/ShellCommandSafetyPolicyTest.kt
@@ -148,14 +148,14 @@ class ShellCommandSafetyPolicyTest {
                 executionRules = listOf(dangerousRule(enabledMode = ExecutionRuleEnabledMode.CONFIRM))
             )
         )
-        ToolPermissionCoordinator.canRequestUserConfirmation = false
+        ToolPermissionCoordinator.isUiResumed = false
+        ToolPermissionCoordinator.backgroundConfirmationHandler = null
 
         val decision = ShellCommandSafetyPolicy()
             .evaluate("rm -rf /data/local/tmp/cache", toolName = "terminal")
 
         assertFalse(decision.allowed)
         assertEquals("CONFIRM_UNAVAILABLE", decision.code)
-        assertTrue(decision.reason.contains("cannot request permission"))
     }
 
     @Test
@@ -165,7 +165,7 @@ class ShellCommandSafetyPolicyTest {
                 executionRules = listOf(dangerousRule(enabledMode = ExecutionRuleEnabledMode.CONFIRM))
             )
         )
-        ToolPermissionCoordinator.canRequestUserConfirmation = true
+        ToolPermissionCoordinator.isUiResumed = true
 
         val evaluation = async {
             ShellCommandSafetyPolicy().evaluate(
@@ -197,7 +197,7 @@ class ShellCommandSafetyPolicyTest {
                 )
             )
         )
-        ToolPermissionCoordinator.canRequestUserConfirmation = true
+        ToolPermissionCoordinator.isUiResumed = true
 
         val evaluation = async {
             ShellCommandSafetyPolicy().evaluate(
@@ -221,7 +221,8 @@ class ShellCommandSafetyPolicyTest {
 
     @After
     fun resetToolPermissionCoordinator() {
-        ToolPermissionCoordinator.canRequestUserConfirmation = false
+        ToolPermissionCoordinator.isUiResumed = false
+        ToolPermissionCoordinator.backgroundConfirmationHandler = null
     }
 
     private fun dangerousRule(

--- a/app/src/main/java/com/niki914/zafiro/app/App.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/App.kt
@@ -2,13 +2,19 @@ package com.niki914.zafiro.app
 
 import android.app.ActivityManager
 import android.app.Application
+import android.content.Context
+import android.provider.Settings
 import androidx.appcompat.app.AppCompatDelegate
 import com.google.android.material.color.DynamicColors
 import com.niki914.logging.Logger
 import com.niki914.xposed.api.util.ContextProvider
 import com.niki914.zafiro.app.conversation.ConversationPersister
 import com.niki914.zafiro.app.conversation.ConversationRepo
+import com.niki914.zafiro.app.overlay.ToolPermissionOverlay
 import com.niki914.zafiro.chat.agentic.python.PyRuntime
+import com.niki914.zafiro.chat.agentic.shell.ToolPermissionCoordinator
+import com.niki914.zafiro.chat.agentic.shell.ToolPermissionRequest
+import com.niki914.zafiro.chat.agentic.shell.ToolPermissionResponse
 import com.niki914.zafiro.repo.UpdateCheckHolder
 import com.niki914.zafiro.repo.XRepo
 import com.niki914.zafiro.runtime.createAppRuntimeBridge
@@ -53,6 +59,43 @@ class App : Application() {
         applicationScope.launch {
             PyRuntime.warmUp()
         }
+
+        ToolPermissionCoordinator.backgroundConfirmationHandler = { request ->
+            handleBackgroundConfirmation(this, request)
+        }
+    }
+
+    private suspend fun handleBackgroundConfirmation(
+        context: Context,
+        request: ToolPermissionRequest,
+    ): ToolPermissionResponse {
+        if (!Settings.canDrawOverlays(context)) {
+            if (!grantOverlayPermissionViaRoot(context)) {
+                return ToolPermissionResponse.DENIED_UNAVAILABLE
+            }
+        }
+        // 窗口加不上（权限被收回等）≠ 用户拒绝：失败走 DENIED_UNAVAILABLE
+        val allowed = try {
+            ToolPermissionOverlay.show(context, request)
+        } catch (_: Throwable) {
+            return ToolPermissionResponse.DENIED_UNAVAILABLE
+        }
+        return if (allowed) {
+            ToolPermissionResponse.ALLOWED
+        } else {
+            ToolPermissionResponse.DENIED_BY_USER
+        }
+    }
+
+    private fun grantOverlayPermissionViaRoot(context: Context): Boolean {
+        return try {
+            val proc = Runtime.getRuntime().exec(
+                arrayOf("su", "-c", "appops set ${context.packageName} SYSTEM_ALERT_WINDOW allow")
+            )
+            proc.waitFor(5, java.util.concurrent.TimeUnit.SECONDS) && proc.exitValue() == 0
+        } catch (_: Exception) {
+            false
+        } && Settings.canDrawOverlays(context)
     }
 
     private fun isPythonWorkerProcess(): Boolean {
@@ -62,4 +105,5 @@ class App : Application() {
         ActivityManager.getMyMemoryState(info)
         return info.processName == "$packageName:python"
     }
+
 }

--- a/app/src/main/java/com/niki914/zafiro/app/MainActivity.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.core.os.LocaleListCompat
 import com.niki914.zafiro.app.ui.ZafiroApp
 import com.niki914.zafiro.app.ui.model.AppLaunchDecision
 import com.niki914.zafiro.app.ui.model.ThemeController
+import com.niki914.zafiro.chat.agentic.shell.ToolPermissionCoordinator
 import kotlinx.coroutines.runBlocking
 
 // tag:niki914 | tag:nexus-x-log | message:niki914 | message:nexus-x-log
@@ -55,16 +56,18 @@ class MainActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         isResumed = true
+        ToolPermissionCoordinator.isUiResumed = true
     }
 
     override fun onPause() {
         super.onPause()
         isResumed = false
+        ToolPermissionCoordinator.isUiResumed = false
     }
 
     companion object {
 
-        /** 前后台标记：确认请求在后台时改为发通知（纯通知，无决策入口）。 */
+        /** 前后台标记：确认请求在后台时尝试 overlay 弹窗，无权限则静默拒绝。 */
         @Volatile
         var isResumed: Boolean = false
             private set

--- a/app/src/main/java/com/niki914/zafiro/app/overlay/ToolPermissionOverlay.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/overlay/ToolPermissionOverlay.kt
@@ -1,0 +1,355 @@
+package com.niki914.zafiro.app.overlay
+
+import android.content.Context
+import android.content.res.Configuration
+import android.graphics.Color
+import android.graphics.PixelFormat
+import android.graphics.Typeface
+import android.graphics.drawable.GradientDrawable
+import android.os.Build
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
+import android.widget.FrameLayout
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import com.niki914.logging.Logger
+import com.niki914.zafiro.app.R
+import com.niki914.zafiro.chat.agentic.shell.ToolPermissionRequest
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * 后台工具权限确认弹窗。
+ *
+ * 应用不在前台时，Compose 对话框不可见，此时通过 TYPE_APPLICATION_OVERLAY
+ * 窗口渲染确认界面。窗口管理与 root 授权复用 [PointerOverlay] 的既有模式。
+ *
+ * 布局像素级复刻 Shizuku 的 RequestPermissionActivity（confirmation_dialog.xml
+ * + GrantPermissionsButtons 样式）：居中图标 24dp → 居中标题 20sp → 全宽纵向
+ * 堆叠按钮（允许在上、拒绝在下，56dp 高，2dp 缝，圆角 12/4 内收）。内容
+ * （文案与 icon）沿用本应用既有资源。
+ */
+object ToolPermissionOverlay {
+
+    private const val TAG = "niki914_nexus_ToolPermOverlay"
+
+    // ---- Shizuku confirmation_dialog.xml / GrantPermissionsButtons 对应值 ----
+    private const val CARD_MAX_WIDTH_DP = 320      // M3 对话框宽度
+    private const val CARD_SIDE_MARGIN_DP = 36f    // 小屏兜底边距
+    private const val CARD_CORNER_DP = 28f         // M3 dialog corner radius
+    private const val ROOT_PAD_TOP_DP = 24f        // 根容器上下 padding
+    private const val ROOT_PAD_BOTTOM_DP = 24f
+    private const val ICON_SIZE_DP = 24            // 图标 24dp 居中
+    private const val TITLE_PAD_H_DP = 24f         // 标题左右 padding
+    private const val TITLE_PAD_TOP_DP = 16f
+    private const val TITLE_PAD_BOTTOM_DP = 24f
+    private const val TITLE_TEXT_SIZE_SP = 20f     // Shizuku 标题 20sp
+    private const val BUTTON_MIN_HEIGHT_DP = 56    // GrantPermissionsButtons
+    private const val BUTTON_PAD_DP = 16f          //   padding 16dp
+    private const val BUTTON_MARGIN_H_DP = 24f     //   左右 margin 24dp
+    private const val BUTTON_GAP_DP = 2f           //   两按钮间 2dp 缝
+    private const val BUTTON_TEXT_SIZE_SP = 14f    //   textSize 14sp
+    private const val BUTTON_CORNER_OUT_DP = 12f   // 外侧圆角 12dp
+    private const val BUTTON_CORNER_IN_DP = 4f     // 内侧圆角 4dp
+    private const val DIM_ALPHA = 153              // dialog backgroundDim 相当值
+
+    // ---- M3 baseline 色板（overlay 无 Compose 主题，取 Shizuku 同款默认紫） ----
+    private const val PRIMARY_CONTAINER = 0xFFEADDFF.toInt()
+    private const val ON_PRIMARY_CONTAINER = 0xFF21005D.toInt()
+    private const val SURFACE_LIGHT = 0xFFFEF7FF.toInt()   // M3 dialog surface
+    private const val SURFACE_DARK = 0xFF141218.toInt()
+    private const val SURFACE_CONTAINER_HIGHEST_LIGHT = 0xFFE6E0E9.toInt()
+    private const val ON_SURFACE_LIGHT = 0xFF1D1B20.toInt()
+    private const val ON_SURFACE_VARIANT_LIGHT = 0xFF49454F.toInt()
+    private const val SURFACE_CONTAINER_HIGHEST_DARK = 0xFF35363F.toInt()
+    private const val ON_SURFACE_DARK = 0xFFE6E1E5.toInt()
+    private const val ON_SURFACE_VARIANT_DARK = 0xFFCAC4D0.toInt()
+    private const val ERROR_LIGHT = 0xFFB3261E.toInt()
+    private const val ERROR_DARK = 0xFFF2B8B5.toInt()
+
+    private var wm: WindowManager? = null
+    private var currentView: View? = null
+    private var currentDeferred: CompletableDeferred<Boolean>? = null
+
+    suspend fun show(context: Context, request: ToolPermissionRequest): Boolean =
+        withContext(Dispatchers.Main) {
+            // 已有窗口在显示时并入等待，禁止叠两层（双重黑幕的来源）
+            val existing = currentDeferred
+            if (existing != null && existing.isActive) {
+                return@withContext existing.await()
+            }
+
+            val deferred = CompletableDeferred<Boolean>()
+            currentDeferred = deferred
+            wm = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+
+            val view = buildRoot(context, request) { allowed ->
+                currentDeferred?.let { if (it.isActive) it.complete(allowed) }
+            }
+            currentView = view
+
+            val lp = WindowManager.LayoutParams(
+                WindowManager.LayoutParams.MATCH_PARENT,
+                WindowManager.LayoutParams.MATCH_PARENT,
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+                    WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+                else
+                    WindowManager.LayoutParams.TYPE_PHONE,
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                        WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+                PixelFormat.TRANSLUCENT,
+            )
+            lp.gravity = Gravity.TOP or Gravity.START
+
+            try {
+                wm?.addView(view, lp)
+                deferred.await()
+            } finally {
+                dismiss()
+            }
+        }
+
+    fun dismiss() {
+        val view = currentView
+        val w = wm
+        if (view != null && w != null) {
+            try {
+                w.removeViewImmediate(view)
+            } catch (e: Exception) {
+                Logger.w(TAG, "overlay removeView failed", e)
+            }
+        }
+        currentView = null
+        wm = null
+        currentDeferred = null
+    }
+
+    // ============================================================
+    // 布局：Shizuku confirmation_dialog.xml 结构
+    // ============================================================
+
+    private fun buildRoot(
+        context: Context,
+        request: ToolPermissionRequest,
+        onDecision: (Boolean) -> Unit,
+    ): View {
+        val density = context.resources.displayMetrics.density
+        val root = FrameLayout(context).apply {
+            setBackgroundColor(Color.argb(DIM_ALPHA, 0, 0, 0))
+            isClickable = true
+            setOnClickListener { onDecision(false) }
+        }
+
+        val card = buildCard(context, density, request, onDecision)
+        val cardLp = FrameLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+        ).apply {
+            gravity = Gravity.CENTER
+            width = minOf(
+                (CARD_MAX_WIDTH_DP * density).toInt(),
+                context.resources.displayMetrics.widthPixels -
+                        (2 * CARD_SIDE_MARGIN_DP * density).toInt(),
+            )
+        }
+        root.addView(card, cardLp)
+        return root
+    }
+
+    private fun buildCard(
+        context: Context,
+        density: Float,
+        request: ToolPermissionRequest,
+        onDecision: (Boolean) -> Unit,
+    ): LinearLayout {
+        val isNight = (context.resources.configuration.uiMode and
+                Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
+        val surface = if (isNight) SURFACE_DARK else SURFACE_LIGHT
+        val onSurface = if (isNight) ON_SURFACE_DARK else ON_SURFACE_LIGHT
+        val onSurfaceVariant = if (isNight) ON_SURFACE_VARIANT_DARK else ON_SURFACE_VARIANT_LIGHT
+        val commandBg = if (isNight) SURFACE_CONTAINER_HIGHEST_DARK else SURFACE_CONTAINER_HIGHEST_LIGHT
+        val ruleColor = if (isNight) ERROR_DARK else ERROR_LIGHT
+
+        return LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+            // 卡片背景：M3 dialog surface + 28dp 圆角（缺它文字直接浮在黑幕上）
+            background = GradientDrawable().apply {
+                setColor(surface)
+                cornerRadius = CARD_CORNER_DP * density
+            }
+            isClickable = true // 消费点击，防止穿透到 dim 层
+            // 根容器 paddingTop/Bottom 24dp（confirmation_dialog.xml）
+            setPadding(0, (ROOT_PAD_TOP_DP * density).toInt(), 0, (ROOT_PAD_BOTTOM_DP * density).toInt())
+
+            // 图标 24dp 居中（内容用应用自己的 icon）
+            addView(ImageView(context).apply {
+                setImageResource(R.mipmap.ic_launcher)
+                importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+                val size = (ICON_SIZE_DP * density).toInt()
+                layoutParams = LinearLayout.LayoutParams(size, size).apply {
+                    gravity = Gravity.CENTER_HORIZONTAL
+                }
+            })
+
+            // 标题 20sp 居中，padding 24/16/24/24（confirmation_dialog.xml）
+            addView(TextView(context).apply {
+                text = context.getString(R.string.tool_permission_dialog_title)
+                setTextColor(onSurface)
+                textSize = TITLE_TEXT_SIZE_SP
+                gravity = Gravity.CENTER
+                setPadding(
+                    (TITLE_PAD_H_DP * density).toInt(),
+                    (TITLE_PAD_TOP_DP * density).toInt(),
+                    (TITLE_PAD_H_DP * density).toInt(),
+                    (TITLE_PAD_BOTTOM_DP * density).toInt(),
+                )
+            })
+
+            // 工具介绍（带应用名）
+            addView(introText(context, request, onSurfaceVariant, density))
+
+            // 命令块（等宽，surfaceContainerHighest 圆角块）
+            addView(commandBlock(context, request, onSurface, commandBg, density))
+
+            // 命中规则
+            addView(ruleText(context, request, ruleColor, density))
+
+            // 允许（上）—— GrantPermissionsButtons.Top
+            addView(
+                button(
+                    context, density,
+                    text = context.getString(R.string.tool_permission_allow),
+                    bgColor = PRIMARY_CONTAINER,
+                    textColor = ON_PRIMARY_CONTAINER,
+                    topLeft = BUTTON_CORNER_OUT_DP, topRight = BUTTON_CORNER_OUT_DP,
+                    bottomLeft = BUTTON_CORNER_IN_DP, bottomRight = BUTTON_CORNER_IN_DP,
+                    bottomMarginDp = BUTTON_GAP_DP,
+                ) { onDecision(true) },
+            )
+
+            // 拒绝（下）—— GrantPermissionsButtons.Buttom
+            addView(
+                button(
+                    context, density,
+                    text = context.getString(R.string.tool_permission_deny),
+                    bgColor = PRIMARY_CONTAINER,
+                    textColor = ON_PRIMARY_CONTAINER,
+                    topLeft = BUTTON_CORNER_IN_DP, topRight = BUTTON_CORNER_IN_DP,
+                    bottomLeft = BUTTON_CORNER_OUT_DP, bottomRight = BUTTON_CORNER_OUT_DP,
+                ) { onDecision(false) },
+            )
+        }
+    }
+
+    // ============================================================
+    // 内容元素
+    // ============================================================
+
+    private fun introText(
+        context: Context,
+        request: ToolPermissionRequest,
+        color: Int,
+        density: Float,
+    ): TextView = TextView(context).apply {
+        text = context.getString(R.string.tool_permission_request_intro, request.toolName)
+        setTextColor(color)
+        textSize = 14f
+        setPadding(
+            (TITLE_PAD_H_DP * density).toInt(), 0, (TITLE_PAD_H_DP * density).toInt(),
+            (TITLE_PAD_BOTTOM_DP * density).toInt() / 2,
+        )
+    }
+
+    private fun commandBlock(
+        context: Context,
+        request: ToolPermissionRequest,
+        textColor: Int,
+        bg: Int,
+        density: Float,
+    ): TextView = TextView(context).apply {
+        text = request.command
+        setTextColor(textColor)
+        textSize = 13f
+        typeface = Typeface.MONOSPACE
+        val pad = (12f * density).toInt()
+        setPadding(pad, pad, pad, pad)
+        background = GradientDrawable().apply {
+            setColor(bg)
+            cornerRadius = 12f * density
+        }
+        // 单行省略比 10 行截断更接近"对话框预览"语义
+        maxLines = 1
+        ellipsize = android.text.TextUtils.TruncateAt.END
+        layoutParams = LinearLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT,
+        ).apply {
+            setMargins(
+                (TITLE_PAD_H_DP * density).toInt(), 0, (TITLE_PAD_H_DP * density).toInt(),
+                (TITLE_PAD_BOTTOM_DP * density).toInt() / 2,
+            )
+        }
+    }
+
+    private fun ruleText(
+        context: Context,
+        request: ToolPermissionRequest,
+        color: Int,
+        density: Float,
+    ): TextView = TextView(context).apply {
+        text = context.getString(R.string.tool_permission_matched_rule, request.matchedRuleName)
+        setTextColor(color)
+        textSize = 14f
+        setPadding(
+            (TITLE_PAD_H_DP * density).toInt(), 0, (TITLE_PAD_H_DP * density).toInt(),
+            (24f * density).toInt(),
+        )
+    }
+
+    /** Shizuku GrantPermissionsButtons：match_parent / minHeight 56dp / padding 16 / 14sp medium / 居中 */
+    private fun button(
+        context: Context,
+        density: Float,
+        text: String,
+        bgColor: Int,
+        textColor: Int,
+        topLeft: Float,
+        topRight: Float,
+        bottomLeft: Float,
+        bottomRight: Float,
+        bottomMarginDp: Float = 0f,
+        onClick: () -> Unit,
+    ): TextView = TextView(context).apply {
+        this.text = text
+        setTextColor(textColor)
+        textSize = BUTTON_TEXT_SIZE_SP
+        typeface = Typeface.create("sans-serif-medium", Typeface.NORMAL)
+        gravity = Gravity.CENTER
+        minHeight = (BUTTON_MIN_HEIGHT_DP * density).toInt()
+        val pad = (BUTTON_PAD_DP * density).toInt()
+        setPadding(pad, pad, pad, pad)
+        background = GradientDrawable().apply {
+            setColor(bgColor)
+            cornerRadii = floatArrayOf(
+                topLeft * density, topLeft * density,
+                topRight * density, topRight * density,
+                bottomRight * density, bottomRight * density,
+                bottomLeft * density, bottomLeft * density,
+            )
+        }
+        isClickable = true
+        setOnClickListener { onClick() }
+        layoutParams = LinearLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT,
+        ).apply {
+            setMargins(
+                (BUTTON_MARGIN_H_DP * density).toInt(), 0,
+                (BUTTON_MARGIN_H_DP * density).toInt(),
+                (bottomMarginDp * density).toInt(),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
@@ -355,22 +355,7 @@ fun HomePageContent(
  */
 @Composable
 private fun ToolPermissionDialog() {
-    val context = LocalContext.current
     val pending by ToolPermissionCoordinator.pendingConfirmation.collectAsState()
-
-    // 纯通知：仅告知有请求在等待，决策必须在应用内完成
-    LaunchedEffect(pending?.id) {
-        val request = pending ?: return@LaunchedEffect
-        if (MainActivity.isResumed) return@LaunchedEffect
-        val command = request.command.let { if (it.length > 80) it.take(80) + "…" else it }
-        XIpcBridge.postNotification(
-            context = context,
-            title = context.getString(R.string.tool_permission_notification_title),
-            content = context.getString(R.string.tool_permission_notification_content, command),
-            uri = null,
-            client = null,
-        )
-    }
 
     val request = pending ?: return
     LiquidDialog(

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/HomeChatState.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/HomeChatState.kt
@@ -186,10 +186,7 @@ internal interface HomeChatRuntime {
 
 private object LlmHomeChatRuntime : HomeChatRuntime {
     override fun stream(query: String): Flow<LlmStreamEvent> =
-        LLMController.stream(
-            query = query,
-            fromUserInterface = true,
-        )
+        LLMController.stream(query)
 
     override suspend fun resetConversation() = LLMController.resetConversation()
     override suspend fun stopCurrentRound() =

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -185,12 +185,10 @@
     <string name="execution_rules_enabled_mode_disabled">停用</string>
     <string name="execution_rules_enabled_mode_confirm">詢問我</string>
     <string name="tool_permission_dialog_title">AI 請求執行操作</string>
-    <string name="tool_permission_request_intro">工具「%1$s」請求執行以下命令：</string>
+    <string name="tool_permission_request_intro">Zafiro 的工具「%1$s」請求執行以下命令：</string>
     <string name="tool_permission_matched_rule">命中規則「%1$s」</string>
     <string name="tool_permission_allow">允許本次</string>
     <string name="tool_permission_deny">拒絕</string>
-    <string name="tool_permission_notification_title">Zafiro 正在等待你的確認</string>
-    <string name="tool_permission_notification_content">AI 請求執行被攔截的命令：%1$s。開啟應用程式以允許或拒絕。</string>
     <string name="execution_rules_field_patterns">比對規則</string>
     <string name="execution_rules_field_patterns_hint">例如：\brm\s+-rf\b</string>
     <string name="execution_rules_field_patterns_description">每行輸入一個關鍵字或正則表達式，只要符合其中一項，便會攔截該指令。</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -186,12 +186,10 @@
     <string name="execution_rules_enabled_mode_disabled">Disabled</string>
     <string name="execution_rules_enabled_mode_confirm">Ask me</string>
     <string name="tool_permission_dialog_title">AI requests to run an operation</string>
-    <string name="tool_permission_request_intro">Tool "%1$s" wants to run the following command:</string>
+    <string name="tool_permission_request_intro">Zafiro tool "%1$s" wants to run the following command:</string>
     <string name="tool_permission_matched_rule">Matched rule "%1$s"</string>
     <string name="tool_permission_allow">Allow once</string>
     <string name="tool_permission_deny">Deny</string>
-    <string name="tool_permission_notification_title">Zafiro is waiting for your confirmation</string>
-    <string name="tool_permission_notification_content">AI wants to run a blocked command: %1$s. Open the app to allow or deny.</string>
     <string name="execution_rules_field_patterns">Patterns</string>
     <string name="execution_rules_field_patterns_hint">For example: \brm\s+-rf\b</string>
     <string name="execution_rules_field_patterns_description">Enter one keyword or regular expression per line. The command is blocked as soon as any rule matches.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -186,12 +186,10 @@
     <string name="execution_rules_enabled_mode_disabled">Desactivado</string>
     <string name="execution_rules_enabled_mode_confirm">Preguntarme</string>
     <string name="tool_permission_dialog_title">La IA solicita ejecutar una operación</string>
-    <string name="tool_permission_request_intro">La herramienta "%1$s" solicita ejecutar el siguiente comando:</string>
+    <string name="tool_permission_request_intro">La herramienta de Zafiro "%1$s" solicita ejecutar el siguiente comando:</string>
     <string name="tool_permission_matched_rule">Regla alcanzada: "%1$s"</string>
     <string name="tool_permission_allow">Permitir una vez</string>
     <string name="tool_permission_deny">Denegar</string>
-    <string name="tool_permission_notification_title">Zafiro espera tu confirmación</string>
-    <string name="tool_permission_notification_content">La IA solicita ejecutar un comando bloqueado: %1$s. Abre la aplicación para permitirlo o denegarlo.</string>
     <string name="execution_rules_field_patterns">Reglas</string>
     <string name="execution_rules_field_patterns_hint">Ejemplo: \brm\s+-rf\b</string>
     <string name="execution_rules_field_patterns_description">Introduzca una palabra clave o expresión regular por línea. El comando se interceptará si coincide con cualquiera de ellas.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -185,12 +185,10 @@
     <string name="execution_rules_enabled_mode_disabled">無効</string>
     <string name="execution_rules_enabled_mode_confirm">確認を求める</string>
     <string name="tool_permission_dialog_title">AI が操作の実行を要求しています</string>
-    <string name="tool_permission_request_intro">ツール「%1$s」が次のコマンドの実行を要求しています：</string>
+    <string name="tool_permission_request_intro">Zafiro のツール「%1$s」が次のコマンドの実行を要求しています：</string>
     <string name="tool_permission_matched_rule">一致したルール「%1$s」</string>
     <string name="tool_permission_allow">今回のみ許可</string>
     <string name="tool_permission_deny">拒否</string>
-    <string name="tool_permission_notification_title">Zafiro が確認を待っています</string>
-    <string name="tool_permission_notification_content">AI がブロックされたコマンドの実行を要求しています：%1$s。アプリを開いて許可または拒否してください。</string>
     <string name="execution_rules_field_patterns">ルール</string>
     <string name="execution_rules_field_patterns_hint">例：\brm\s+-rf\b</string>
     <string name="execution_rules_field_patterns_description">1行につき1つのキーワードまたは正規表現を入力します。いずれかにマッチした場合、そのコマンドをブロックします。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,12 +185,10 @@
     <string name="execution_rules_enabled_mode_disabled">不生效</string>
     <string name="execution_rules_enabled_mode_confirm">询问我</string>
     <string name="tool_permission_dialog_title">AI 请求执行操作</string>
-    <string name="tool_permission_request_intro">工具「%1$s」请求执行以下命令：</string>
+    <string name="tool_permission_request_intro">Zafiro 的工具「%1$s」请求执行以下命令：</string>
     <string name="tool_permission_matched_rule">命中规则「%1$s」</string>
     <string name="tool_permission_allow">允许本次</string>
     <string name="tool_permission_deny">拒绝</string>
-    <string name="tool_permission_notification_title">Zafiro 正在等待你的确认</string>
-    <string name="tool_permission_notification_content">AI 请求执行被拦截的命令：%1$s。打开应用以允许或拒绝。</string>
     <string name="execution_rules_field_patterns">规则</string>
     <string name="execution_rules_field_patterns_hint">例如：\brm\s+-rf\b</string>
     <string name="execution_rules_field_patterns_description">每行输入一个关键字或正则表达式，命中任意一条时，拦截该命令。</string>


### PR DESCRIPTION
## 背景

应用不在前台时，CONFIRM 型工具权限确认之前只能静默拒绝（宿主路径一律 DENIED_UNAVAILABLE）。本次引入全局 overlay 弹窗，让后台请求也能拿到用户决策。

## 改动

- **新增 **： 窗口，M3 对话框样式（surface + 28dp 圆角、居中图标、20sp 居中标题、纵向全宽按钮 56dp 高 / 2dp 缝 / 12-4dp 内收圆角、 色板），明暗两套。布局参数对齐 Shizuku  + 。
- ** 路由**：前台 → 既有 Compose 对话框；后台 → overlay；无 overlay 权限 → 。删除旧的  来源开关与通知逻辑。
- **** 注册 ，首次无权限时通过 root  自授权（与  同模式）。overlay 加不上走 ，不误为用户拒绝。
- **清理**：删除通知字符串与无用 import；测试断言同步更新。

## 待确认

- overlay 权限丢失（被系统收回）时走静默拒绝，符合预期
- 导航栏在 overlay 显示期间仍可操作（系统行为，Shizuku 同）