### PR TITLE
chore: clean up TODOs and unreferenced strings

### DIFF
--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/LLMController.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/LLMController.kt
@@ -65,7 +65,6 @@ import com.niki914.zafiro.settings.model.RuntimeLlmConfig as LlmConfig
  */
 object LLMController {
     private const val LOG_TAG = "niki914_nexus_LLMController"
-    internal const val CONFIG_REQUIRED_MESSAGE = "请先填写配置" // <--- TODO res
     internal const val NO_IDLE_TIMEOUT_SECONDS = Long.MAX_VALUE / 1000
 
     private val promptComposer =
@@ -143,7 +142,7 @@ object LLMController {
     @Volatile
     private var mcpFailureSignature: String? = null
 
-    // 测试注入点：T1 单测经 Okia.open(dependencies) 装配 fake loop/mapper。 <--- TODO Workaround???
+    // Test seam: overridden in unit tests to inject a fake Okia with stub dependencies.
     internal var okiaFactory: OkiaFactory = OkiaFactory { apiType, restore, config ->
         openOkiaWithDefaultProtocol(apiType, restore, config)
     }
@@ -791,5 +790,5 @@ object LLMController {
         val sessionProtocol: LlmProtocol?,
     )
 
-    private class LlmConfigRequiredException : IllegalStateException(CONFIG_REQUIRED_MESSAGE)
+    private class LlmConfigRequiredException : IllegalStateException("LLM config is required")
 }

--- a/app/src/main/java/com/niki914/zafiro/app/conversation/ConversationFormatter.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/conversation/ConversationFormatter.kt
@@ -21,15 +21,12 @@ import com.niki914.zafiro.app.ui.model.ToolPresentation
  */
 object ConversationFormatter {
     private const val LOG_TAG = "niki914_nexus_ConversationFormatter"
-    private const val DEFAULT_TITLE = "新对话" // TODO languages
     private const val MAX_TITLE_LENGTH = 40
     private const val MAX_PREVIEW_LENGTH = 20
     private const val ELLIPSIS = "..."
 
     fun titleFromFirstInput(firstUserInput: String): String {
-        val title = firstUserInput.trim()
-        if (title.isEmpty()) return DEFAULT_TITLE
-        return title.take(MAX_TITLE_LENGTH)
+        return firstUserInput.trim().take(MAX_TITLE_LENGTH)
     }
 
     fun previewFromText(text: String): String {

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -37,7 +37,6 @@
     <string name="ui_tool_status_running">執行中</string>
     <string name="ui_tool_status_success">成功</string>
     <string name="ui_tool_status_failed">失敗</string>
-    <string name="ui_tool_status_failed_reason_interrupted">用戶中斷</string>
     <plurals name="ui_tool_chain_count">
         <item quantity="other">%d 個工具</item>
     </plurals>
@@ -91,7 +90,6 @@
     <string name="ui_settings_builtin_tools_summary">管理 Zafiro 提供的內建工具</string>
     <string name="ui_settings_skills">Skills</string>
     <string name="ui_settings_skills_summary">管理本地 Skills</string>
-    <string name="ui_settings_custom_py_tools_summary">管理自訂 Python 工具</string>
     <string name="skill_page_description">開啟或關閉本地 Skills。啟用後，Agent 可在對話中按需使用。</string>
     <string name="skill_loading">正在讀取 Skills...</string>
     <string name="skill_empty">目前沒有可用的 Skill。</string>
@@ -109,7 +107,6 @@
     <string name="skill_import_overwrite">覆蓋</string>
     <string name="skill_import_cancel">取消</string>
     <string name="skill_import_resolve_failed">無法存取所選文件夾</string>
-    <string name="skill_import_error">匯入失敗</string>
     <string name="ui_settings_mcp">MCP</string>
     <string name="ui_settings_mcp_summary">連接外部 MCP 服務與工具</string>
     <string name="ui_settings_takeover">接管規則</string>
@@ -139,7 +136,6 @@
     <string name="ui_settings_configure_description">調整模型連接、提示詞與代理設定。</string>
     <string name="ui_settings_configure_save">儲存設定</string>
     <string name="ui_settings_configure_prompt_label">提示詞</string>
-    <string name="ui_settings_configure_prompt_placeholder">你希望助理怎樣做？</string>
     <string name="prompt_editor_description">編輯 System Prompt。儲存後，變更會在下一次對話時生效。</string>
     <string name="prompt_error_load_failed">讀取提示詞失敗，請返回重試。</string>
     <string name="ui_settings_configure_proxy_label">代理</string>
@@ -215,9 +211,6 @@
     <string name="takeover_field_patterns_hint">天氣\n.*鬧鐘.*\n開啟.*</string>
     <string name="takeover_field_patterns_description">每行輸入一個關鍵字或正則表達式，只要符合其中一項，便會使用上方的接管方式。</string>
     <string name="takeover_save_action">儲存規則</string>
-    <string name="takeover_rule_enabled">已啟用</string>
-    <string name="takeover_rule_disabled">已停用</string>
-    <string name="takeover_rule_summary_more"> 等 %1$d 條</string>
     <string name="takeover_error_name_required">請輸入規則名稱</string>
     <string name="takeover_error_patterns_required">請輸入至少一條規則</string>
     <string name="takeover_error_load_failed_generic">讀取接管規則失敗</string>
@@ -228,7 +221,6 @@
     <string name="takeover_delete_dialog_title">刪除接管規則</string>
     <string name="takeover_delete_dialog_text">確定要刪除接管規則「%1$s」嗎？此操作不可撤銷。</string>
     <string name="takeover_error_delete_failed">刪除接管規則失敗：%1$s</string>
-    <string name="takeover_save_failed">儲存失敗：%1$s</string>
 
     <!-- Builtin Tool Module -->
     <string name="builtin_tool_page_description">開啟或關閉預設內建工具。啟用後，工具會在下一次對話時更新。</string>
@@ -339,8 +331,6 @@
     <string name="ui_settings_configure_endpoint_mismatch_cancel_keep">保留</string>
     <string name="ui_settings_configure_endpoint_mismatch_cancel_save">直接儲存</string>
     <string name="ui_settings_configure_protocol_hint">切換協議後，請確認端點與協議匹配。</string>
-    <string name="notif_network_error_title">網路異常</string>
-    <string name="notif_network_error_body">網路連線失敗，請檢查網路後重試</string>
     <string name="error_mcp_load_failed">讀取 MCP 配置失敗</string>
     <string name="error_mcp_save_failed">儲存 MCP 配置失敗</string>
     <string name="error_mcp_delete_failed">刪除 MCP 配置失敗</string>
@@ -362,9 +352,6 @@
     <string name="feedback_feature_template">## 功能建議\n\n## 使用場景\n\n## 預期效果</string>
     <string name="host_breeno_display_name">小布助手</string>
     <string name="host_xiaoai_display_name">小愛同學</string>
-    <string name="fallback_assistant_name">助手</string>
-    <string name="notif_unsupported_version_title">宿主版本未適配</string>
-    <string name="notif_unsupported_version_body">當前%1$s版本還未被 Zafiro 支援\n宿主版本：%2$s</string>
     <string name="feedback_bug_template">## 問題描述\n\n## 復現步驟\n\n## 預期行為\n\n## 實際行為\n\n## 設備資訊\n- Android 版本：\n- 助手（小布或其他）：\n- 模組版本：\n\n## 更多\n可以補充日誌、截圖錄屏等資訊，以便於我們理解</string>
 
     <string name="ui_settings_appearance">外觀</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -37,7 +37,6 @@
     <string name="ui_tool_status_running">Running</string>
     <string name="ui_tool_status_success">Success</string>
     <string name="ui_tool_status_failed">Failed</string>
-    <string name="ui_tool_status_failed_reason_interrupted">Interrupted</string>
     <plurals name="ui_tool_chain_count">
         <item quantity="one">%d tool</item>
         <item quantity="other">%d tools</item>
@@ -92,7 +91,6 @@
     <string name="ui_settings_builtin_tools_summary">Manage tools provided by Zafiro</string>
     <string name="ui_settings_skills">Skills</string>
     <string name="ui_settings_skills_summary">Manage local Skills</string>
-    <string name="ui_settings_custom_py_tools_summary">Manage custom Python tools</string>
     <string name="skill_page_description">Turn local Skills on or off. Enabled Skills can be used by the Agent when needed.</string>
     <string name="skill_loading">Loading Skills...</string>
     <string name="skill_empty">No Skills are available right now.</string>
@@ -110,7 +108,6 @@
     <string name="skill_import_overwrite">Overwrite</string>
     <string name="skill_import_cancel">Cancel</string>
     <string name="skill_import_resolve_failed">Unable to access the selected folder</string>
-    <string name="skill_import_error">Import failed</string>
     <string name="ui_settings_mcp">MCP</string>
     <string name="ui_settings_mcp_summary">Connect external MCP services and tools</string>
     <string name="ui_settings_takeover">Takeover Rules</string>
@@ -140,7 +137,6 @@
     <string name="ui_settings_configure_description">Configure model access, prompts, and proxy settings.</string>
     <string name="ui_settings_configure_save">Save Configuration</string>
     <string name="ui_settings_configure_prompt_label">Prompt</string>
-    <string name="ui_settings_configure_prompt_placeholder">What should your assistant do?</string>
     <string name="prompt_editor_description">Edit the System Prompt. Saved changes apply in the next conversation.</string>
     <string name="prompt_error_load_failed">Failed to load the prompt. Go back and retry.</string>
     <string name="ui_settings_configure_proxy_label">Proxy</string>
@@ -216,9 +212,6 @@
     <string name="takeover_field_patterns_hint">weather\n.*alarm.*\nopen.*</string>
     <string name="takeover_field_patterns_description">Enter one keyword or regular expression per line. The selected responder is used as soon as any rule matches.</string>
     <string name="takeover_save_action">Save Rule</string>
-    <string name="takeover_rule_enabled">Enabled</string>
-    <string name="takeover_rule_disabled">Disabled</string>
-    <string name="takeover_rule_summary_more"> and %1$d total</string>
     <string name="takeover_error_name_required">Please enter a rule name</string>
     <string name="takeover_error_patterns_required">Please enter at least one pattern</string>
     <string name="takeover_error_load_failed_generic">Failed to load takeover rules</string>
@@ -229,7 +222,6 @@
     <string name="takeover_delete_dialog_title">Delete Takeover Rule</string>
     <string name="takeover_delete_dialog_text">Are you sure you want to delete the takeover rule \"%1$s\"? This action cannot be undone.</string>
     <string name="takeover_error_delete_failed">Failed to delete takeover rules: %1$s</string>
-    <string name="takeover_save_failed">Failed to save: %1$s</string>
 
     <!-- Builtin Tool Module -->
     <string name="builtin_tool_page_description">Turn preset built-in tools on or off. Changes take effect in the next conversation.</string>
@@ -299,13 +291,8 @@
     <string name="update_dialog_cancel">Later</string>
 
     <!-- Notification strings -->
-    <string name="notif_network_error_title">Network Error</string>
-    <string name="notif_network_error_body">Network connection failed. Please check your network and try again.</string>
-    <string name="notif_unsupported_version_title">Unsupported Host Version</string>
-    <string name="notif_unsupported_version_body">The current %1$s version is not yet supported by Zafiro\nHost version: %2$s</string>
 
     <!-- Fallback -->
-    <string name="fallback_assistant_name">Assistant</string>
 
     <!-- Host App Display Names -->
     <string name="host_breeno_display_name">Breeno</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -37,7 +37,6 @@
     <string name="ui_tool_status_running">Ejecutando</string>
     <string name="ui_tool_status_success">Completado</string>
     <string name="ui_tool_status_failed">Error</string>
-    <string name="ui_tool_status_failed_reason_interrupted">Interrumpido por el usuario</string>
     <plurals name="ui_tool_chain_count">
         <item quantity="one">%d herramienta</item>
         <item quantity="other">%d herramientas</item>
@@ -92,7 +91,6 @@
     <string name="ui_settings_builtin_tools_summary">Gestionar las herramientas integradas de Zafiro</string>
     <string name="ui_settings_skills">Skills</string>
     <string name="ui_settings_skills_summary">Gestionar Skills locales</string>
-    <string name="ui_settings_custom_py_tools_summary">Gestionar herramientas personalizadas de Python</string>
     <string name="skill_page_description">Activar o desactivar Skills locales. Cuando están activadas, el agente puede usarlas según sea necesario durante las conversaciones.</string>
     <string name="skill_loading">Cargando Skills...</string>
     <string name="skill_empty">No hay Skills disponibles actualmente.</string>
@@ -110,7 +108,6 @@
     <string name="skill_import_overwrite">Sobrescribir</string>
     <string name="skill_import_cancel">Cancelar</string>
     <string name="skill_import_resolve_failed">No se puede acceder a la carpeta seleccionada</string>
-    <string name="skill_import_error">Error al importar</string>
     <string name="ui_settings_mcp">MCP</string>
     <string name="ui_settings_mcp_summary">Conectar servicios y herramientas MCP externos</string>
     <string name="ui_settings_takeover">Reglas de control</string>
@@ -140,7 +137,6 @@
     <string name="ui_settings_configure_description">Ajustar la configuración del modelo, prompt del sistema y proxy.</string>
     <string name="ui_settings_configure_save">Guardar configuración</string>
     <string name="ui_settings_configure_prompt_label">Prompt del sistema</string>
-    <string name="ui_settings_configure_prompt_placeholder">¿Cómo debería comportarse el asistente?</string>
     <string name="prompt_editor_description">Edita el System Prompt. Los cambios se aplicarán en la siguiente conversación tras guardar.</string>
     <string name="prompt_error_load_failed">No se pudo cargar el prompt. Vuelve atrás e inténtalo de nuevo.</string>
     <string name="ui_settings_configure_proxy_label">Proxy</string>
@@ -216,9 +212,6 @@
     <string name="takeover_field_patterns_hint">tiempo\n.*alarma.*\nabrir.*</string>
     <string name="takeover_field_patterns_description">Introduzca una palabra clave o expresión regular por línea. Si se detecta una coincidencia, se utilizará el asistente seleccionado arriba.</string>
     <string name="takeover_save_action">Guardar regla</string>
-    <string name="takeover_rule_enabled">Activada</string>
-    <string name="takeover_rule_disabled">Desactivada</string>
-    <string name="takeover_rule_summary_more"> y %1$d más</string>
     <string name="takeover_error_name_required">Introduzca un nombre para la regla</string>
     <string name="takeover_error_patterns_required">Introduzca al menos una regla</string>
     <string name="takeover_error_load_failed_generic">Error al cargar las reglas de control</string>
@@ -229,7 +222,6 @@
     <string name="takeover_delete_dialog_title">Eliminar regla de control</string>
     <string name="takeover_delete_dialog_text">¿Está seguro de que desea eliminar la regla de control «%1$s»? Esta acción no se puede deshacer.</string>
     <string name="takeover_error_delete_failed">Error al eliminar la regla de control: %1$s</string>
-    <string name="takeover_save_failed">Error al guardar: %1$s</string>
 
     <!-- Builtin Tool Module -->
     <string name="builtin_tool_page_description">Active o desactive las herramientas integradas. Los cambios se aplicarán en la siguiente conversación.</string>
@@ -299,8 +291,6 @@
     <string name="update_dialog_cancel">Ahora no</string>
 
     <!-- Notification strings -->
-    <string name="notif_network_error_title">Error de red</string>
-    <string name="notif_network_error_body">Error en la conexión. Compruebe la red y vuelva a intentarlo.</string>
 
     <!-- Error: MCP -->
     <string name="error_mcp_load_failed">Error al cargar la configuración de MCP</string>
@@ -334,9 +324,6 @@
     <string name="host_xiaoai_display_name">XiaoAi</string>
 
     <!-- XService notifications -->
-    <string name="fallback_assistant_name">Asistente</string>
-    <string name="notif_unsupported_version_title">Versión de la app host no compatible</string>
-    <string name="notif_unsupported_version_body">La versión actual de %1$s aún no es compatible con Zafiro\nVersión de la app host: %2$s</string>
 
     <string name="feedback_bug_template">## Descripción del problema\n\n## Pasos para reproducir\n\n## Comportamiento esperado\n\n## Comportamiento real\n\n## Información del dispositivo\n- Versión de Android:\n- Asistente (Breeno u otro):\n- Versión del módulo:\n\n## Información adicional\nPuede adjuntar registros, capturas o grabaciones de pantalla para ayudarnos a entender el problema.</string>
     <string name="conversation_fork_title">Fork · %1$s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -37,7 +37,6 @@
     <string name="ui_tool_status_running">実行中</string>
     <string name="ui_tool_status_success">成功</string>
     <string name="ui_tool_status_failed">失敗</string>
-    <string name="ui_tool_status_failed_reason_interrupted">ユーザーによる中断</string>
     <plurals name="ui_tool_chain_count">
     <item quantity="other">%d 個のツール</item>
     </plurals>
@@ -91,7 +90,6 @@
     <string name="ui_settings_builtin_tools_summary">Zafiro が提供するツールを管理</string>
     <string name="ui_settings_skills">Skills</string>
     <string name="ui_settings_skills_summary">ローカルの Skills を管理</string>
-    <string name="ui_settings_custom_py_tools_summary">カスタム Python ツールを管理</string>
     <string name="skill_page_description">ローカル Skills の有効化/無効化を切り替えます。有効にすると、Agent が会話中に必要に応じて使用します。</string>
     <string name="skill_loading">Skills を読み込み中...</string>
     <string name="skill_empty">利用可能な Skill はありません。</string>
@@ -109,7 +107,6 @@
     <string name="skill_import_overwrite">上書き</string>
     <string name="skill_import_cancel">キャンセル</string>
     <string name="skill_import_resolve_failed">選択したフォルダにアクセスできません</string>
-    <string name="skill_import_error">インポート失敗</string>
     <string name="ui_settings_mcp">MCP</string>
     <string name="ui_settings_mcp_summary">外部 MCP サービスとツールを連携</string>
     <string name="ui_settings_takeover">制御ルール</string>
@@ -139,7 +136,6 @@
     <string name="ui_settings_configure_description">モデル連携、プロンプト、プロキシ設定を調整します。</string>
     <string name="ui_settings_configure_save">設定を保存</string>
     <string name="ui_settings_configure_prompt_label">プロンプト</string>
-    <string name="ui_settings_configure_prompt_placeholder">アシスタントにどのような振る舞いをさせますか？</string>
     <string name="prompt_editor_description">システムプロンプトを編集します。保存された変更は次回の会話から反映されます。</string>
     <string name="prompt_error_load_failed">プロンプトの読み込みに失敗しました。戻って再試行してください。</string>
     <string name="ui_settings_configure_proxy_label">プロキシ</string>
@@ -215,9 +211,6 @@
     <string name="takeover_field_patterns_hint">天気\n.*アラーム.*\n.*を開く</string>
     <string name="takeover_field_patterns_description">1行につき1つのキーワードまたは正規表現を入力します。いずれかにマッチした場合、上記の応答方法を使用します。</string>
     <string name="takeover_save_action">ルールを保存</string>
-    <string name="takeover_rule_enabled">有効</string>
-    <string name="takeover_rule_disabled">無効</string>
-    <string name="takeover_rule_summary_more"> 他 %1$d 件</string>
     <string name="takeover_error_name_required">ルール名を入力してください</string>
     <string name="takeover_error_patterns_required">ルールを少なくとも1つ入力してください</string>
     <string name="takeover_error_load_failed_generic">制御ルールの読み込みに失敗しました</string>
@@ -228,7 +221,6 @@
     <string name="takeover_delete_dialog_title">制御ルールの削除</string>
     <string name="takeover_delete_dialog_text">制御ルール「%1$s」を削除してもよろしいですか？この操作は取り消せません。</string>
     <string name="takeover_error_delete_failed">制御ルールの削除に失敗しました：%1$s</string>
-    <string name="takeover_save_failed">保存に失敗しました：%1$s</string>
 
     <!-- Builtin Tool Module -->
     <string name="builtin_tool_page_description">プリセットされている組み込みツールの有効/無効を切り替えます。有効化されたツールは次回の会話から更新されます。</string>
@@ -298,8 +290,6 @@
     <string name="update_dialog_cancel">後で</string>
 
     <!-- Notification strings -->
-    <string name="notif_network_error_title">ネットワークエラー</string>
-    <string name="notif_network_error_body">ネットワーク接続に失敗しました。接続を確認して再試行してください</string>
 
     <!-- Error: MCP -->
     <string name="error_mcp_load_failed">MCP 設定の読み込みに失敗しました</string>
@@ -333,9 +323,6 @@
     <string name="host_xiaoai_display_name">XiaoAi</string>
 
     <!-- XService notifications -->
-    <string name="fallback_assistant_name">アシスタント</string>
-    <string name="notif_unsupported_version_title">ホストバージョン未対応</string>
-    <string name="notif_unsupported_version_body">現在の%1$sバージョンはまだ Zafiro に対応していません\nホストバージョン：%2$s</string>
 
     <string name="feedback_bug_template">## 問題の説明\n\n## 再現手順\n\n## 期待される動作\n\n## 実際の動作\n\n## デバイス情報\n- Android バージョン：\n- アシスタント（Breeno またはその他）：\n- モジュールのバージョン：\n\n## その他\n理解を深めるため、ログやスクリーンショット、画面録画などを添付できます</string>
     <string name="conversation_fork_title">Fork · %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,7 +37,6 @@
     <string name="ui_tool_status_running">执行中</string>
     <string name="ui_tool_status_success">成功</string>
     <string name="ui_tool_status_failed">失败</string>
-    <string name="ui_tool_status_failed_reason_interrupted">用户中断</string>
     <plurals name="ui_tool_chain_count">
         <item quantity="other">%d 个工具</item>
     </plurals>
@@ -91,7 +90,6 @@
     <string name="ui_settings_builtin_tools_summary">管理 Zafiro 提供的工具</string>
     <string name="ui_settings_skills">Skills</string>
     <string name="ui_settings_skills_summary">管理本地 Skills</string>
-    <string name="ui_settings_custom_py_tools_summary">管理自定义 Python 工具</string>
     <string name="skill_page_description">开启或关闭本地 Skills。开启后，Agent 可在对话中按需使用。</string>
     <string name="skill_loading">正在读取 Skills...</string>
     <string name="skill_empty">当前没有可用的 Skill。</string>
@@ -109,7 +107,6 @@
     <string name="skill_import_overwrite">覆盖</string>
     <string name="skill_import_cancel">取消</string>
     <string name="skill_import_resolve_failed">无法访问所选文件夹</string>
-    <string name="skill_import_error">导入失败</string>
     <string name="ui_settings_mcp">MCP</string>
     <string name="ui_settings_mcp_summary">接入外部 MCP 服务与工具</string>
     <string name="ui_settings_takeover">接管规则</string>
@@ -139,7 +136,6 @@
     <string name="ui_settings_configure_description">调整模型接入、提示词与代理配置。</string>
     <string name="ui_settings_configure_save">保存配置</string>
     <string name="ui_settings_configure_prompt_label">提示词</string>
-    <string name="ui_settings_configure_prompt_placeholder">你的助手应该怎么做？</string>
     <string name="prompt_editor_description">编辑 System Prompt。保存后，变更会在下次对话生效。</string>
     <string name="prompt_error_load_failed">读取提示词失败，请返回重试。</string>
     <string name="ui_settings_configure_proxy_label">代理</string>
@@ -215,9 +211,6 @@
     <string name="takeover_field_patterns_hint">天气\n.*闹钟.*\n打开.*</string>
     <string name="takeover_field_patterns_description">每行输入一个关键字或正则表达式，命中任意一条时，使用上方的接管方式。</string>
     <string name="takeover_save_action">保存规则</string>
-    <string name="takeover_rule_enabled">已启用</string>
-    <string name="takeover_rule_disabled">已停用</string>
-    <string name="takeover_rule_summary_more"> 等 %1$d 条</string>
     <string name="takeover_error_name_required">请输入规则名称</string>
     <string name="takeover_error_patterns_required">请输入至少一条规则</string>
     <string name="takeover_error_load_failed_generic">读取接管规则失败</string>
@@ -228,7 +221,6 @@
     <string name="takeover_delete_dialog_title">删除接管规则</string>
     <string name="takeover_delete_dialog_text">确定要删除接管规则「%1$s」吗？此操作不可撤销。</string>
     <string name="takeover_error_delete_failed">删除接管规则失败：%1$s</string>
-    <string name="takeover_save_failed">保存失败：%1$s</string>
 
     <!-- Builtin Tool Module -->
     <string name="builtin_tool_page_description">开启或关闭预设的内置工具。开启后，工具将在下次对话更新。</string>
@@ -298,8 +290,6 @@
     <string name="update_dialog_cancel">稍后</string>
 
     <!-- Notification strings -->
-    <string name="notif_network_error_title">网络异常</string>
-    <string name="notif_network_error_body">网络连接失败，请检查网络后重试</string>
 
     <!-- Error: MCP -->
     <string name="error_mcp_load_failed">读取 MCP 配置失败</string>
@@ -333,9 +323,6 @@
     <string name="host_xiaoai_display_name">小爱同学</string>
 
     <!-- XService notifications -->
-    <string name="fallback_assistant_name">助手</string>
-    <string name="notif_unsupported_version_title">宿主版本未适配</string>
-    <string name="notif_unsupported_version_body">当前%1$s版本还未被 Zafiro 支持\n宿主版本：%2$s</string>
 
     <string name="feedback_bug_template">## 问题描述\n\n## 复现步骤\n\n## 预期行为\n\n## 实际行为\n\n## 设备信息\n- Android 版本：\n- 助手（小布或其他）：\n- 模块版本：\n\n## 更多\n可以补充日志、截图录屏等信息，以便于我们理解</string>
     <string name="conversation_fork_title">Fork · %1$s</string>


### PR DESCRIPTION
## Summary

- Remove 3 TODO comments: hardcoded DEFAULT_TITLE, CONFIG_REQUIRED_MESSAGE dead code, okiaFactory workaround comment
- Delete 13 unreferferred UI strings across 5 locales (65 deletions)

## Changes

### ConversationFormatter.kt
- Delete hardcoded `DEFAULT_TITLE = "新对话"`. `titleFromFirstInput()` returns empty for empty input. UI already handles blank titles via `ifBlank { stringResource(ui_conversation_history_untitled) }`.

### LLMController.kt
- Delete `CONFIG_REQUIRED_MESSAGE` constant. The exception message was never shown downstream — both UI consumers (HomeChatComponents + AgentRuntimeService) map `LlmErrorCode.ConfigRequired` to `strings.xml` resources. Simplify `LlmConfigRequiredException` to no-arg constructor.
- Delete misleading `<--- TODO Workaround???` comment on `okiaFactory`. It is a standard test seam, add one-line doc comment.

### 13 unreferenced strings (0 refs each across all modules)
- `fallback_assistant_name`
- `notif_network_error_body` / `title`
- `notif_unsupported_version_body` / `title`
- `skill_import_error` (superseded by `error_skill_import_failed`)
- `takeover_rule_disabled` / `enabled` / `summary_more`
- `takeover_save_failed`
- `ui_settings_configure_prompt_placeholder`
- `ui_settings_custom_py_tools_summary`
- `ui_tool_status_failed_reason_interrupted`

Build passes. Failing tests are pre-existing and unrelated (LLMControllerRefreshSkillTest 60s timeout, TextPacerTest, AboutSettingsViewModelTest).
