### PR TITLE
docs: add badges, roadmap and tech stack entries

### DIFF
--- a/.claude/skills/release-new-version/SKILL.md
+++ b/.claude/skills/release-new-version/SKILL.md
@@ -68,22 +68,27 @@ Propose one number with a one-line justification referencing the change list. Al
 
 Confirm once more before anything irreversible. Then:
 
-1. Update `versionCode = <new code>`, `versionName = "<new name>"` in `app/build.gradle.kts`, plus any other files from the approved list. Do not touch any other build config.
-2. Commit: `release: bump to <new name>`, push to `origin main`.
-3. Tag and push:
+1. Update the code-line badge so it lands in the release commit:
+   ```bash
+   bash scripts/update-code-badge.sh   # relative to the skill directory; the script cd's to the repo root itself
+   ```
+   It recounts production Kotlin + Python lines (excluding tests / build / generated) and rewrites the `kotlin-XX.Xk` badge in both READMEs. Include the README changes in the release commit.
+2. Update `versionCode = <new code>`, `versionName = "<new name>"` in `app/build.gradle.kts`, plus any other files from the approved list. Do not touch any other build config.
+3. Commit: `release: bump to <new name>`, push to `origin main`.
+4. Tag and push:
    ```bash
    git tag v<code>-<name>
    git push origin v<code>-<name>
    ```
    Tag push triggers CI: build → sign → create Release. CI reads signing config from GitHub Secrets; do not expect signing to work anywhere else.
-4. Wait for CI:
+5. Wait for CI:
    ```bash
    gh run list --workflow=release.yml --limit=1    # find the latest run
    gh run watch <run-id> --exit-status             # wait for it to finish
    gh run view <run-id> --log-failed               # on failure, read only the failed steps
    gh run rerun <run-id>                           # rerun after fixing
    ```
-5. Replace CI-generated release notes (they are a PR list) with the approved draft:
+6. Replace CI-generated release notes (they are a PR list) with the approved draft:
    ```bash
    gh release edit <tag> -R niki914/zafiro --notes "<approved notes>"
    ```

--- a/.claude/skills/release-new-version/scripts/update-code-badge.sh
+++ b/.claude/skills/release-new-version/scripts/update-code-badge.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Count production Kotlin + Python lines (excluding tests / build / generated)
+# and update the "kotlin-XX.Xk" badge in README.md and README_CN.md.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+files=$(git ls-files '*.kt' '*.py' | grep -vE '(^|/)(build|generated)/|/src/(android)?Test/|Test\.kt$|/test_[^/]*\.py$')
+if [ -z "$files" ]; then
+  echo "error: no source files found" >&2
+  exit 1
+fi
+
+lines=$(printf '%s\n' "$files" | xargs wc -l | tail -1 | awk '{print $1}')
+k=$(awk -v n="$lines" 'BEGIN { printf "%.1fk", n/1000 }')
+badge="https://img.shields.io/badge/kotlin-${k}-blue"
+
+for f in README.md README_CN.md; do
+  if grep -q 'img.shields.io/badge/kotlin-' "$f"; then
+    sed -i.bak "s|https://img.shields.io/badge/kotlin-[0-9.]*k-blue|${badge}|" "$f" && rm -f "$f.bak"
+  else
+    echo "error: kotlin badge not found in $f" >&2
+    exit 1
+  fi
+done
+
+echo "updated: ${lines} lines -> ${badge}"

--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@
 
 <p align="center">
   <a href="https://github.com/niki914/zafiro"><img src="https://img.shields.io/github/stars/niki914/zafiro?label=stars" alt="stars"/></a>
+  <a href="https://deepwiki.com/niki914/zafiro"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"/></a>
   <a href="https://github.com/niki914/zafiro/releases/latest"><img src="https://img.shields.io/github/v/release/niki914/zafiro?include_prereleases" alt="release"/></a>
   <a href="https://github.com/niki914/zafiro/releases/latest"><img src="https://img.shields.io/github/downloads/niki914/zafiro/total" alt="downloads"/></a>
+  <img src="https://img.shields.io/badge/kotlin-57.8k-blue" alt="kotlin lines"/>
+  <a href="https://app.codacy.com/gh/niki914/zafiro/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade"><img src="https://app.codacy.com/project/badge/Grade/b4cadbe5d2d74e3885106562cbd9715b" alt="Codacy"/></a>
 </p>
 
 <p align="center">
@@ -112,6 +115,8 @@ Through the [LSPosed](https://github.com/lsposed/lsposed) framework, Zafiro can 
 | Python Runtime | [Chaquopy](https://chaquo.com/chaquopy/)                             |
 | System Takeover       | [LSPosed](https://github.com/lsposed/lsposed) + Xposed API           |
 | Terminal / SSH   | [libterm](https://github.com/niki914/libterm)                        |
+| SVG Rendering      | [coil-resvg](https://github.com/hash-sequence/coil-resvg) (resvg)    |
+| G2 Rounded Corners | [Capsule](https://github.com/Kyant0/Capsule)                         |
 
 ## Getting Started
 
@@ -165,6 +170,12 @@ agentic-nexus/
         └── libterm-backend-ssh
 ```
 
+## Roadmap
+
+- Floating pet (desktop pet)
+- System voice assistant integration (non-Xposed takeover)
+- File import / sharing from outside the app
+
 ## Contributing
 
 Pull requests are welcome!
@@ -179,6 +190,7 @@ Pull requests are welcome!
 
 - [Telegram](https://t.me/+ZPX2xtSl6RwyZGNl) — discuss, ask questions, give feedback
 - [GitHub Issues](https://github.com/niki914/zafiro/issues) — report bugs or request features
+- [Afdian](https://afdian.com/a/niki914) — support the developer
 
 When reporting an issue, please include as much detail as possible: phone model and Android version, system voice assistant and its version, Zafiro version, steps to reproduce, and screenshots or screen recordings.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -10,8 +10,11 @@
 
 <p align="center">
   <a href="https://github.com/niki914/zafiro"><img src="https://img.shields.io/github/stars/niki914/zafiro?label=stars" alt="stars"/></a>
+  <a href="https://deepwiki.com/niki914/zafiro"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"/></a>
   <a href="https://github.com/niki914/zafiro/releases/latest"><img src="https://img.shields.io/github/v/release/niki914/zafiro?include_prereleases" alt="release"/></a>
   <a href="https://github.com/niki914/zafiro/releases/latest"><img src="https://img.shields.io/github/downloads/niki914/zafiro/total" alt="downloads"/></a>
+  <img src="https://img.shields.io/badge/kotlin-57.8k-blue" alt="kotlin lines"/>
+  <a href="https://app.codacy.com/gh/niki914/zafiro/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade"><img src="https://app.codacy.com/project/badge/Grade/b4cadbe5d2d74e3885106562cbd9715b" alt="Codacy"/></a>
 </p>
 
 <p align="center">
@@ -112,6 +115,8 @@ Zafiro 是你的 Android 手机上运行一个智能代理。我们为 Zafiro Ag
 | Python 运行时 | [Chaquopy](https://chaquo.com/chaquopy/)                             |
 | 系统接管       | [LSPosed](https://github.com/lsposed/lsposed) + Xposed API           |
 | 终端 / SSH   | [libterm](https://github.com/niki914/libterm)                        |
+| SVG 渲染      | [coil-resvg](https://github.com/hash-sequence/coil-resvg) (resvg)    |
+| G2 圆角       | [Capsule](https://github.com/Kyant0/Capsule)                         |
 
 ## 快速开始
 
@@ -165,6 +170,12 @@ agentic-nexus/
         └── libterm-backend-ssh
 ```
 
+## Roadmap
+
+- 悬浮宠物（桌宠）
+- 系统语音助手实现（非 Xposed 接管）
+- 应用外文件导入 / 分享
+
 ## 贡献
 
 欢迎提交 Pull Request!
@@ -179,6 +190,7 @@ agentic-nexus/
 
 - [Telegram](https://t.me/+ZPX2xtSl6RwyZGNl) — 交流、提问、反馈问题
 - [GitHub Issues](https://github.com/niki914/zafiro/issues) — 提交 Bug 或功能请求
+- [爱发电](https://afdian.com/a/niki914) — 支持开发者
 
 如果遇到问题，请尽量提供：手机型号与 Android 版本、系统语音助手及版本、Zafiro 版本、复现步骤、截图或录屏。
 


### PR DESCRIPTION
## Changes

- Add DeepWiki, Codacy (grade) and code-line badges to both READMEs (badge order: Star → DeepWiki → Release → Downloads → code lines → Quality)
- Add SVG rendering (coil-resvg) and G2 rounded corners (Capsule) to the Tech Stack table
- Add a Roadmap section (floating pet, non-Xposed voice assistant, file import/sharing)
- Add Afdian link to the Community section
- Add `update-code-badge.sh` to the release-new-version skill: recounts production Kotlin + Python lines (excluding tests / build / generated) and rewrites the `kotlin-XX.Xk` badge in both READMEs; wired into the release flow (Phase 4)