### PR TITLE
Keep Alive & fix orphan tool calls

### DIFF
--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/LLMController.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/LLMController.kt
@@ -7,6 +7,7 @@ import com.niki914.okia.conversation.Conversation
 import com.niki914.okia.conversation.SessionSnapshot
 import com.niki914.okia.error.RetryPolicy
 import com.niki914.okia.hooks.Hooks
+import com.niki914.okia.hooks.SerializationHolder
 import com.niki914.okia.loop.TurnResult
 import com.niki914.okia.mcp.McpDiscoveryState
 import com.niki914.okia.mcp.McpServer
@@ -15,6 +16,7 @@ import com.niki914.okia.mcp.McpTransport
 import com.niki914.okia.message.ContentBlock
 import com.niki914.okia.message.Message
 import com.niki914.okia.message.ThinkingLevel
+import com.niki914.okia.message.ToolCallOutcome
 import com.niki914.okia.protocol.AnthropicMessagesProtocol
 import com.niki914.okia.protocol.OpenAIChatCompletionCompat
 import com.niki914.okia.protocol.OpenAIChatCompletionProtocol
@@ -70,6 +72,10 @@ import com.niki914.zafiro.settings.model.RuntimeLlmConfig as LlmConfig
 object LLMController {
     private const val LOG_TAG = "niki914_nexus_LLMController"
     internal const val NO_IDLE_TIMEOUT_SECONDS = Long.MAX_VALUE / 1000
+
+    /** 孤儿工具调用兜底文案：只说结果缺失与疑似异常中断，不断言进程被杀。 */
+    private const val TOOL_RESULT_MISSING =
+        "Tool result missing: execution may have been interrupted abnormally."
 
     private val promptComposer =
         PromptComposer()
@@ -417,6 +423,7 @@ object LLMController {
                         "mcp=${state.snapshot.tools.mcpServers.size}"
             )
 
+            turnActive.value = true
             val startedAtMs = System.currentTimeMillis()
             var streamErrorReported = false
             var streamTerminated = false
@@ -559,6 +566,7 @@ object LLMController {
                 )
             }
         } finally {
+            turnActive.value = false
             AccessibilityController.onTurnEnd()
         }
     }.flowOn(Dispatchers.IO)
@@ -653,6 +661,7 @@ object LLMController {
             apiKey = config.apiKey
             model = config.model
             hooks += killToolResourcesHook
+            hooks += fixIncompleteToolCallsHook
             // null = 不超时（General Settings 提供「不限时」选项）
             idleTimeoutSeconds = config.idleTimeoutSeconds ?: NO_IDLE_TIMEOUT_SECONDS
             retryPolicy = RetryPolicy(maxAttempts = config.retryMaxAttempts)
@@ -796,6 +805,70 @@ object LLMController {
         return buildMcpFailureNotice(failed)
     }
 
+    /**
+     * 未闭合工具调用修复钩子：进程被杀等异常退出后，历史里可能存在只有
+     * ToolCall 没有 ToolResult 的消息（服务端报 "No tool output found for
+     * tool call"，会话报废）。每次请求序列化前扫描历史，为孤儿调用注入
+     * 兜底 Failure 结果，只修发出去的请求，不改会话树（幂等，每次重扫）。
+     */
+    private val fixIncompleteToolCallsHook = object : Hooks {
+        override suspend fun beforeSerialization(request: SerializationHolder) {
+            val history = request.history
+            val missing = countMissingToolResults(history)
+            if (missing > 0) {
+                Logger.i(LOG_TAG, "fixIncompleteToolCalls history=${history.size} missing=$missing")
+            }
+            val fixed = withMissingToolResultsFilled(history)
+            if (fixed != history) {
+                request.write(request.snapshot, fixed, "fix_incomplete_tool_calls")
+                Logger.i(LOG_TAG, "fixIncompleteToolCalls patched ${fixed.size - history.size} results")
+            }
+        }
+    }
+
+    private fun countMissingToolResults(history: List<Message>): Int {
+        val answered = history.filterIsInstance<Message.ToolResult>().mapTo(mutableSetOf()) { it.callId }
+        var missing = 0
+        for (message in history) {
+            if (message !is Message.Assistant) continue
+            missing += message.message.content
+                .filterIsInstance<ContentBlock.ToolCall>()
+                .count { it.id !in answered }
+        }
+        return missing
+    }
+
+    /** 为历史中无 ToolResult 的 ToolCall 注入兜底结果，插入位置 = 对应
+     *  Assistant 消息之后，保持协议要求的 call/result 相邻顺序。 */
+    private fun withMissingToolResultsFilled(history: List<Message>): List<Message> {
+        val answered = history.filterIsInstance<Message.ToolResult>().mapTo(mutableSetOf()) { it.callId }
+        if (answered.isEmpty() && history.none { it is Message.Assistant }) return history
+        val patched = mutableListOf<Message>()
+        var changed = false
+        for (message in history) {
+            patched += message
+            if (message !is Message.Assistant) continue
+            val missing = message.message.content
+                .filterIsInstance<ContentBlock.ToolCall>()
+                .filter { it.id !in answered }
+            if (missing.isEmpty()) continue
+            changed = true
+            missing.forEach { call ->
+                patched += Message.ToolResult(
+                    callId = call.id,
+                    toolName = call.name,
+                    outcome = ToolCallOutcome.Failure(
+                        message = TOOL_RESULT_MISSING,
+                        // content 才是回喂模型的正文（providerContent 取它），
+                        // 只填 message 模型会看到空结果
+                        content = TOOL_RESULT_MISSING,
+                    ),
+                )
+            }
+        }
+        return if (changed) patched else history
+    }
+
     // 全局工具资源 kill 钩子：OKIA 停止流程的 kill 步骤（beforeStop 每回合
     // 至多一次，参数为本回合已派发的工具调用，共享资源池不会被误杀）
     private val killToolResourcesHook = object : Hooks {
@@ -809,6 +882,13 @@ object LLMController {
             TerminalSessionPool.closeAll()
         }
     }
+
+    /**
+     * 回合进行中信号（Keep Alive）：stream() 全程为 true（网络请求 + 流式输出
+     * + 工具执行），终态后复位。MainActivity 观察它控制 FLAG_KEEP_SCREEN_ON。
+     */
+    private val turnActive = MutableStateFlow(false)
+    val keepScreenOn: StateFlow<Boolean> get() = turnActive
 
     // ── 杂项 ──────────────────────────────────────────────────────────────────
 

--- a/app/src/main/java/com/niki914/zafiro/app/MainActivity.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/MainActivity.kt
@@ -1,16 +1,21 @@
 package com.niki914.zafiro.app
 
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
+import androidx.lifecycle.lifecycleScope
 import com.niki914.zafiro.app.ui.ZafiroApp
 import com.niki914.zafiro.app.ui.model.AppLaunchDecision
 import com.niki914.zafiro.app.ui.model.ThemeController
+import com.niki914.zafiro.chat.LLMController
+import com.niki914.zafiro.repo.XRepo
 import com.niki914.zafiro.chat.agentic.shell.ToolPermissionCoordinator
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 // tag:niki914 | tag:nexus-x-log | message:niki914 | message:nexus-x-log
@@ -50,6 +55,28 @@ class MainActivity : AppCompatActivity() {
                 startupAssistantUi = startupAssistantUi,
                 launchDecision = launchDecision,
             )
+        }
+        observeKeepScreenOn()
+    }
+
+    /**
+     * Keep Alive：设置开关 && 回合进行中 → FLAG_KEEP_SCREEN_ON。
+     * flag 只在 Activity 可见时生效，回桌面/锁屏自动失效，无泄漏风险。
+     */
+    private fun observeKeepScreenOn() {
+        lifecycleScope.launch {
+            // 设置开关在 Activity 创建时读一次；切换后下次冷启动生效
+            // （ponytail: 不做设置变化热更新，低价值场景不值得一条额外流）
+            val settingOn = runCatching { XRepo.keepScreenOn() }.getOrDefault(true)
+            LLMController.keepScreenOn
+                .collect { turnActive ->
+                    val keepOn = settingOn && turnActive
+                    if (keepOn) {
+                        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                    } else {
+                        window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                    }
+                }
         }
     }
 

--- a/app/src/main/java/com/niki914/zafiro/app/MainActivity.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/MainActivity.kt
@@ -15,6 +15,7 @@ import com.niki914.zafiro.app.ui.model.ThemeController
 import com.niki914.zafiro.chat.LLMController
 import com.niki914.zafiro.repo.XRepo
 import com.niki914.zafiro.chat.agentic.shell.ToolPermissionCoordinator
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
@@ -65,12 +66,13 @@ class MainActivity : AppCompatActivity() {
      */
     private fun observeKeepScreenOn() {
         lifecycleScope.launch {
-            // 设置开关在 Activity 创建时读一次；切换后下次冷启动生效
-            // （ponytail: 不做设置变化热更新，低价值场景不值得一条额外流）
-            val settingOn = runCatching { XRepo.keepScreenOn() }.getOrDefault(true)
-            LLMController.keepScreenOn
-                .collect { turnActive ->
-                    val keepOn = settingOn && turnActive
+            // 设置初值：读盘失败按开启兑底（默认开）
+            runCatching { XRepo.keepScreenOn() }
+            combine(
+                XRepo.keepScreenOnSetting,
+                LLMController.keepScreenOn,
+            ) { settingOn, turnActive -> settingOn && turnActive }
+                .collect { keepOn ->
                     if (keepOn) {
                         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
                     } else {

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/GeneralSettingsContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/GeneralSettingsContent.kt
@@ -35,6 +35,7 @@ private const val APPEARANCE_ROW_ID = "general.appearance"
 private const val LOAD_LAST_ROW_ID = "general.load_last"
 private const val IDLE_TIMEOUT_ROW_ID = "general.idle_timeout"
 private const val RETRY_ATTEMPTS_ROW_ID = "general.retry_attempts"
+private const val KEEP_SCREEN_ON_ROW_ID = "general.keep_screen_on"
 
 private const val LANGUAGE_TAG_ZH_CN = "zh-CN"
 private const val LANGUAGE_TAG_ZH_TW = "zh-TW"
@@ -72,6 +73,7 @@ fun GeneralSettingsContent(onPush: (ZafiroPage) -> Unit = {}) {
     var showLanguageDialog by rememberSaveable { mutableStateOf(false) }
     var idleTimeoutSeconds by rememberSaveable { mutableStateOf(60L) }
     var retryMaxAttempts by rememberSaveable { mutableStateOf(3) }
+    var keepScreenOn by rememberSaveable { mutableStateOf(true) }
     var showIdleTimeoutDialog by rememberSaveable { mutableStateOf(false) }
     var showRetryDialog by rememberSaveable { mutableStateOf(false) }
 
@@ -81,6 +83,7 @@ fun GeneralSettingsContent(onPush: (ZafiroPage) -> Unit = {}) {
             loadLastConversation = XRepo.loadLastConversationOnStartup()
             idleTimeoutSeconds = XRepo.llmIdleTimeoutSeconds()
             retryMaxAttempts = XRepo.llmRetryMaxAttempts()
+            keepScreenOn = XRepo.keepScreenOn()
         }.onFailure {
             Logger.w("niki914_nexus_GeneralSettings", "load failed ${it.message}")
         }
@@ -122,6 +125,11 @@ fun GeneralSettingsContent(onPush: (ZafiroPage) -> Unit = {}) {
                         title = stringResource(R.string.ui_settings_general_retry_attempts),
                         currentState = retryAttemptsLabel(retryMaxAttempts),
                     ),
+                    SettingsRowSpec.Toggle(
+                        id = KEEP_SCREEN_ON_ROW_ID,
+                        title = stringResource(R.string.ui_settings_general_keep_screen_on),
+                        checked = keepScreenOn,
+                    ),
                 ),
             ),
         ),
@@ -147,6 +155,11 @@ fun GeneralSettingsContent(onPush: (ZafiroPage) -> Unit = {}) {
                         loadLastConversation = action.checked
                         scope.launch {
                             XRepo.setLoadLastConversationOnStartup(action.checked)
+                        }
+                    } else if (action.id == KEEP_SCREEN_ON_ROW_ID) {
+                        keepScreenOn = action.checked
+                        scope.launch {
+                            XRepo.setKeepScreenOn(action.checked)
                         }
                     }
 

--- a/app/src/main/java/com/niki914/zafiro/repo/AppStateSettingsCodec.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/AppStateSettingsCodec.kt
@@ -25,6 +25,8 @@ internal data class AppStateSettings(
     val llmIdleTimeoutSeconds: Long = 60L,
     /** 传输层自动重试次数。 */
     val llmRetryMaxAttempts: Int = 3,
+    /** 回答进行中保持屏幕常亮。 */
+    val keepScreenOn: Boolean = true,
 )
 
 internal object AppStateSettingsCodec {
@@ -44,6 +46,7 @@ internal object AppStateSettingsCodec {
             themeSeedColor = root.string(THEME_SEED_COLOR_KEY).ifBlank { "FF52DBC9" },
             llmIdleTimeoutSeconds = root.long(LLM_IDLE_TIMEOUT_KEY, default = 60L),
             llmRetryMaxAttempts = root.int(LLM_RETRY_ATTEMPTS_KEY, default = 3),
+            keepScreenOn = root.boolean(KEEP_SCREEN_ON_KEY, default = true),
         )
     }
 
@@ -60,6 +63,7 @@ internal object AppStateSettingsCodec {
                 THEME_SEED_COLOR_KEY to JsonPrimitive(state.themeSeedColor),
                 LLM_IDLE_TIMEOUT_KEY to JsonPrimitive(state.llmIdleTimeoutSeconds),
                 LLM_RETRY_ATTEMPTS_KEY to JsonPrimitive(state.llmRetryMaxAttempts),
+                KEEP_SCREEN_ON_KEY to JsonPrimitive(state.keepScreenOn),
             )
         ).toString()
     }
@@ -74,4 +78,5 @@ internal object AppStateSettingsCodec {
     private const val THEME_SEED_COLOR_KEY = "theme_seed_color"
     private const val LLM_IDLE_TIMEOUT_KEY = "llm_idle_timeout_seconds"
     private const val LLM_RETRY_ATTEMPTS_KEY = "llm_retry_max_attempts"
+    private const val KEEP_SCREEN_ON_KEY = "keep_screen_on"
 }

--- a/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
@@ -317,6 +317,17 @@ object XRepo {
         }
     }
 
+    suspend fun keepScreenOn(): Boolean {
+        return AppStateSettingsCodec.parse(readJson(StoreDescriptorRegistry.APP_STATE_ID)).keepScreenOn
+    }
+
+    suspend fun setKeepScreenOn(value: Boolean) {
+        updateJson(StoreDescriptorRegistry.APP_STATE_ID) { json ->
+            val current = AppStateSettingsCodec.parse(json)
+            AppStateSettingsCodec.encode(current.copy(keepScreenOn = value))
+        }
+    }
+
     suspend fun themeMode(): String {
         return AppStateSettingsCodec.parse(readJson(StoreDescriptorRegistry.APP_STATE_ID)).themeMode
     }

--- a/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
@@ -14,6 +14,7 @@ import com.niki914.zafiro.settings.model.RuntimeTakeoverTarget
 import com.niki914.zafiro.settings.model.TAKEOVER_FIELD_NAME
 import com.niki914.zafiro.settings.model.TAKEOVER_FIELD_PATTERNS
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
@@ -317,11 +318,17 @@ object XRepo {
         }
     }
 
+    /** Keep Alive 设置的进程内热更新通道：读时回填初值，写时同步。 */
+    val keepScreenOnSetting = MutableStateFlow(true)
+
     suspend fun keepScreenOn(): Boolean {
-        return AppStateSettingsCodec.parse(readJson(StoreDescriptorRegistry.APP_STATE_ID)).keepScreenOn
+        return AppStateSettingsCodec.parse(readJson(StoreDescriptorRegistry.APP_STATE_ID))
+            .keepScreenOn
+            .also { keepScreenOnSetting.value = it }
     }
 
     suspend fun setKeepScreenOn(value: Boolean) {
+        keepScreenOnSetting.value = value
         updateJson(StoreDescriptorRegistry.APP_STATE_ID) { json ->
             val current = AppStateSettingsCodec.parse(json)
             AppStateSettingsCodec.encode(current.copy(keepScreenOn = value))

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -316,6 +316,8 @@
     <string name="ui_settings_general_idle_timeout_off">不逾時</string>
     <string name="ui_settings_general_retry_attempts">自動重試次數</string>
     <string name="ui_settings_general_retry_summary">請求失敗後的自動重試</string>
+    <string name="ui_settings_general_keep_screen_on">回應期間保持螢幕常亮</string>
+    <string name="ui_settings_general_keep_screen_on_summary">回應與工具執行期間保持螢幕常亮</string>
     <string name="ui_settings_saved_configuration_title">已儲存配置</string>
     <string name="ui_settings_saved_configuration_delete_title">刪除配置</string>
     <string name="ui_settings_saved_configuration_delete_text">該配置將被刪除，此操作無法復原。</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -354,6 +354,8 @@
     <string name="ui_settings_general_idle_timeout_off">No timeout</string>
     <string name="ui_settings_general_retry_attempts">Auto retries</string>
     <string name="ui_settings_general_retry_summary">Automatic retries after a failed request</string>
+    <string name="ui_settings_general_keep_screen_on">Keep screen on while answering</string>
+    <string name="ui_settings_general_keep_screen_on_summary">Keep the screen on while the agent is responding and running tools</string>
     <string name="ui_settings_saved_configuration_title">Saved configurations</string>
     <string name="ui_settings_saved_configuration_delete_title">Delete configuration</string>
     <string name="ui_settings_saved_configuration_delete_text">This configuration will be deleted and cannot be recovered.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -354,6 +354,8 @@
     <string name="ui_settings_general_idle_timeout_off">Sin límite</string>
     <string name="ui_settings_general_retry_attempts">Reintentos automáticos</string>
     <string name="ui_settings_general_retry_summary">Reintentos automáticos tras un error de solicitud</string>
+    <string name="ui_settings_general_keep_screen_on">Mantener la pantalla encendida al responder</string>
+    <string name="ui_settings_general_keep_screen_on_summary">Mantener la pantalla encendida mientras el agente responde y ejecuta herramientas</string>
     <string name="ui_settings_saved_configuration_title">Configuraciones guardadas</string>
     <string name="ui_settings_saved_configuration_delete_title">Eliminar configuración</string>
     <string name="ui_settings_saved_configuration_delete_text">Esta configuración se eliminará y la acción no se podrá deshacer.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -353,6 +353,8 @@
     <string name="ui_settings_general_idle_timeout_off">タイムアウトなし</string>
     <string name="ui_settings_general_retry_attempts">自動リトライ回数</string>
     <string name="ui_settings_general_retry_summary">リクエスト失敗後の自動リトライ</string>
+    <string name="ui_settings_general_keep_screen_on">回答中は画面をオンに保つ</string>
+    <string name="ui_settings_general_keep_screen_on_summary">エージェントの応答とツール実行中は画面をオフにしません</string>
     <string name="ui_settings_saved_configuration_title">保存済みの設定</string>
     <string name="ui_settings_saved_configuration_delete_title">設定の削除</string>
     <string name="ui_settings_saved_configuration_delete_text">この設定は削除されます。この操作は元に戻せません。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -359,6 +359,8 @@
     <string name="ui_settings_general_idle_timeout_off">不超时</string>
     <string name="ui_settings_general_retry_attempts">自动重试次数</string>
     <string name="ui_settings_general_retry_summary">请求失败后的自动重试</string>
+    <string name="ui_settings_general_keep_screen_on">回答期间保持屏幕常亮</string>
+    <string name="ui_settings_general_keep_screen_on_summary">回答与工具执行期间保持屏幕常亮</string>
     <string name="ui_settings_saved_configuration_title">已保存配置</string>
     <string name="ui_settings_saved_configuration_delete_title">删除配置</string>
     <string name="ui_settings_saved_configuration_delete_text">该配置将被删除，此操作无法恢复。</string>


### PR DESCRIPTION
## Changes

### fix: patch missing tool results before serialization
- Abnormal process termination (e.g. tool kills the main process) could leave history with a ToolCall but no ToolResult; providers then reject the whole conversation with "No tool output found for tool call".
- A `beforeSerialization` hook now scans the outgoing history and injects a fallback `Failure` result for orphan calls (`Tool result missing: execution may have been interrupted abnormally.`).
- Wire-only and idempotent: the session tree stays untouched.

### feat: keep screen on while a turn is in progress
- New **Keep Alive** toggle in General Settings (default on, 5 languages).
- Turn-active StateFlow on `LLMController` drives `FLAG_KEEP_SCREEN_ON` on `MainActivity`, covering network wait, streaming output and tool execution. Flag auto-clears when the activity is not visible.