### PR TITLE
feat: add timeline grouping to conversation history list

### DIFF
--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/ConversationHistoryPageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/ConversationHistoryPageContent.kt
@@ -1,23 +1,37 @@
 package com.niki914.zafiro.app.ui.content
 
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -28,8 +42,10 @@ import com.niki914.uikit.infra.ProvideLiquidScreenContentForPreview
 import com.niki914.uikit.infra.component.SettingsGroupCard
 import com.niki914.uikit.infra.component.SwipeDismissSettingsItemCard
 import com.niki914.uikit.infra.liquidScreenTopPadding
+import com.niki914.uikit.infra.shape.G2CardShape
 import com.niki914.zafiro.app.R
 import com.niki914.zafiro.app.conversation.ConversationSummary
+import java.util.Calendar
 
 internal data class ConversationHistoryUiState(
     val isLoading: Boolean = false,
@@ -102,6 +118,8 @@ private fun ConversationHistoryListContent(
     val deleteErrorPrefix = deleteErrorMessage?.let {
         stringResource(R.string.ui_conversation_history_delete_error, it)
     }
+    val sections = remember(conversations) { groupByTimeline(conversations) }
+    var collapsedBuckets by rememberSaveable { mutableStateOf(emptySet<TimelineBucket>()) }
 
     LazyColumn(
         modifier = modifier
@@ -114,25 +132,43 @@ private fun ConversationHistoryListContent(
         ),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        items(
-            items = conversations,
-            key = { conversation -> conversation.id },
-        ) { conversation ->
-            val title = conversation.title.ifBlank { untitledConversation }
-            SwipeDismissSettingsItemCard(
-                title = title,
-                summary = conversation.lastMessagePreview.takeIf { it.isNotBlank() },
-                showChevron = true,
-                highlightPulseKey = activeConversationId?.takeIf { it == conversation.id },
-                highlightPulseDurationMillis = 500,
-                onClick = {
-                    onConversationClick(conversation.id)
-                },
-                onDismissRequest = {
-                    onConversationDeleteRequest(conversation)
-                },
-                modifier = Modifier.fillMaxWidth(),
-            )
+        sections.forEach { section ->
+            val expanded = section.bucket !in collapsedBuckets
+            item(key = "header_${section.bucket}", contentType = "timeline_header") {
+                TimelineSectionHeader(
+                    title = stringResource(section.bucket.labelRes()),
+                    isExpanded = expanded,
+                    onToggle = {
+                        collapsedBuckets = if (section.bucket in collapsedBuckets) {
+                            collapsedBuckets - section.bucket
+                        } else {
+                            collapsedBuckets + section.bucket
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            if (expanded) {
+                section.conversations.forEach { conversation ->
+                    val title = conversation.title.ifBlank { untitledConversation }
+                    item(key = conversation.id, contentType = "conversation") {
+                        SwipeDismissSettingsItemCard(
+                            title = title,
+                            summary = conversation.lastMessagePreview.takeIf { it.isNotBlank() },
+                            showChevron = true,
+                            highlightPulseKey = activeConversationId?.takeIf { it == conversation.id },
+                            highlightPulseDurationMillis = 500,
+                            onClick = {
+                                onConversationClick(conversation.id)
+                            },
+                            onDismissRequest = {
+                                onConversationDeleteRequest(conversation)
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                }
+            }
         }
 
         if (deleteErrorPrefix != null) {
@@ -141,6 +177,109 @@ private fun ConversationHistoryListContent(
             }
         }
     }
+}
+
+/** 时间线 section header（方案 B，轻量文本行）：labelLarge 淡色标题 + 右 chevron，整行可点 toggle。 */
+@Composable
+private fun TimelineSectionHeader(
+    title: String,
+    isExpanded: Boolean,
+    onToggle: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val chevronRotation by animateFloatAsState(
+        targetValue = if (isExpanded) 90f else 0f,
+        animationSpec = spring(dampingRatio = 0.8f, stiffness = Spring.StiffnessMedium),
+        label = "timelineChevron",
+    )
+    Row(
+        modifier = modifier
+            .clip(G2CardShape(14.dp))
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = onToggle,
+            )
+            .padding(horizontal = 4.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f),
+        )
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+            modifier = Modifier
+                .size(18.dp)
+                .graphicsLayer { rotationZ = chevronRotation },
+        )
+    }
+}
+
+// ── 时间线分桶 ────────────────────────────────────────────────────────────
+
+enum class TimelineBucket { Today, ThisWeek, ThisMonth, Older }
+
+private fun TimelineBucket.labelRes(): Int = when (this) {
+    TimelineBucket.Today -> R.string.ui_conversation_history_today
+    TimelineBucket.ThisWeek -> R.string.ui_conversation_history_this_week
+    TimelineBucket.ThisMonth -> R.string.ui_conversation_history_this_month
+    TimelineBucket.Older -> R.string.ui_conversation_history_older
+}
+
+private data class TimelineSection(
+    val bucket: TimelineBucket,
+    val conversations: List<ConversationSummary>,
+)
+
+/**
+ * 按 updatedAt 分桶：今天 / 本周 / 本月 / 更早（日历边界，非滚动窗口）。
+ * 输入已按 updated_at DESC 排序；输出 section 按桶顺序，空桶不出现，桶内保持原序。
+ */
+private fun groupByTimeline(conversations: List<ConversationSummary>): List<TimelineSection> {
+    if (conversations.isEmpty()) return emptyList()
+    val now = Calendar.getInstance()
+    return conversations
+        .groupBy { bucketOf(it.updatedAt, now) }
+        .let { byBucket ->
+            TimelineBucket.entries.mapNotNull { bucket ->
+                byBucket[bucket]?.let { TimelineSection(bucket, it) }
+            }
+        }
+}
+
+private fun bucketOf(updatedAt: Long, now: Calendar): TimelineBucket {
+    if (updatedAt <= 0L) return TimelineBucket.Older
+    val time = Calendar.getInstance().apply { timeInMillis = updatedAt }
+    return when {
+        sameDay(time, now) -> TimelineBucket.Today
+        withinThisWeek(time, now) -> TimelineBucket.ThisWeek
+        sameMonth(time, now) -> TimelineBucket.ThisMonth
+        else -> TimelineBucket.Older
+    }
+}
+
+private fun sameDay(a: Calendar, b: Calendar): Boolean =
+    a.get(Calendar.YEAR) == b.get(Calendar.YEAR) &&
+            a.get(Calendar.DAY_OF_YEAR) == b.get(Calendar.DAY_OF_YEAR)
+
+private fun sameMonth(a: Calendar, b: Calendar): Boolean =
+    a.get(Calendar.YEAR) == b.get(Calendar.YEAR) &&
+            a.get(Calendar.MONTH) == b.get(Calendar.MONTH)
+
+private fun withinThisWeek(time: Calendar, now: Calendar): Boolean {
+    val weekStart = (now.clone() as Calendar).apply {
+        set(Calendar.HOUR_OF_DAY, 0)
+        set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+        add(Calendar.DAY_OF_YEAR, -((get(Calendar.DAY_OF_WEEK) + 5) % 7))
+    }
+    return time.timeInMillis >= weekStart.timeInMillis
 }
 
 @Composable
@@ -228,6 +367,8 @@ private fun ConversationHistoryInlineErrorText(
 )
 @Composable
 private fun ConversationHistoryListPreview() {
+    val now = System.currentTimeMillis()
+    val day = 24L * 60 * 60 * 1000
     BaseTheme {
         ProvideLiquidScreenContentForPreview(topPadding = 0.dp) {
             ConversationHistoryPageContent(
@@ -237,11 +378,31 @@ private fun ConversationHistoryListPreview() {
                             id = "conversation-1",
                             title = "检查当前工具状态",
                             preview = "I've done the check and summarized the result.",
+                            updatedAt = now - 30 * 60 * 1000,
                         ),
                         previewConversationSummary(
                             id = "conversation-2",
                             title = "分析日志",
                             preview = "The failure path starts after the second request.",
+                            updatedAt = now - 3 * day,
+                        ),
+                        previewConversationSummary(
+                            id = "conversation-3",
+                            title = "上周的会话",
+                            preview = "Summary of last week's work.",
+                            updatedAt = now - 5 * day,
+                        ),
+                        previewConversationSummary(
+                            id = "conversation-4",
+                            title = "上个月",
+                            preview = "Older conversation.",
+                            updatedAt = now - 20 * day,
+                        ),
+                        previewConversationSummary(
+                            id = "conversation-5",
+                            title = "很久以前",
+                            preview = "Very old.",
+                            updatedAt = now - 120 * day,
                         ),
                     ),
                 ),
@@ -297,13 +458,14 @@ private fun previewConversationSummary(
     id: String,
     title: String,
     preview: String,
+    updatedAt: Long = 0L,
 ): ConversationSummary {
     return ConversationSummary(
         id = id,
         title = title,
         titleEdited = false,
-        createdAt = 0L,
-        updatedAt = 0L,
+        createdAt = updatedAt,
+        updatedAt = updatedAt,
         lastMessagePreview = preview,
         turnCount = 1,
     )

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -60,6 +60,10 @@
     <string name="ui_home_retrying_attempt">重試 %1$d/%2$d</string>
     <string name="runtime_error_internal">內部錯誤</string>
     <string name="ui_home_history_content_description">對話歷史</string>
+    <string name="ui_conversation_history_today">今天</string>
+    <string name="ui_conversation_history_this_week">本週</string>
+    <string name="ui_conversation_history_this_month">本月</string>
+    <string name="ui_conversation_history_older">更早</string>
     <string name="ui_conversation_history_back_content_description">返回</string>
     <string name="ui_conversation_history_loading">正在讀取對話歷史...</string>
     <string name="ui_conversation_history_empty_title">暫無對話歷史</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -61,6 +61,10 @@
     <string name="ui_home_retrying_attempt">Retrying %1$d/%2$d</string>
     <string name="runtime_error_internal">Internal error</string>
     <string name="ui_home_history_content_description">Conversation history</string>
+    <string name="ui_conversation_history_today">Today</string>
+    <string name="ui_conversation_history_this_week">This week</string>
+    <string name="ui_conversation_history_this_month">This month</string>
+    <string name="ui_conversation_history_older">Earlier</string>
     <string name="ui_conversation_history_back_content_description">Back</string>
     <string name="ui_conversation_history_loading">Loading conversation history...</string>
     <string name="ui_conversation_history_empty_title">No conversation history yet</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -61,6 +61,10 @@
     <string name="ui_home_retrying_attempt">Reintento %1$d/%2$d</string>
     <string name="runtime_error_internal">Error interno</string>
     <string name="ui_home_history_content_description">Historial de conversaciones</string>
+    <string name="ui_conversation_history_today">Hoy</string>
+    <string name="ui_conversation_history_this_week">Esta semana</string>
+    <string name="ui_conversation_history_this_month">Este mes</string>
+    <string name="ui_conversation_history_older">Anterior</string>
     <string name="ui_conversation_history_back_content_description">Volver</string>
     <string name="ui_conversation_history_loading">Cargando historial...</string>
     <string name="ui_conversation_history_empty_title">Sin conversaciones</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -60,6 +60,10 @@
     <string name="ui_home_retrying_attempt">再試行 %1$d/%2$d</string>
     <string name="runtime_error_internal">内部エラー</string>
     <string name="ui_home_history_content_description">会話履歴</string>
+    <string name="ui_conversation_history_today">今日</string>
+    <string name="ui_conversation_history_this_week">今週</string>
+    <string name="ui_conversation_history_this_month">今月</string>
+    <string name="ui_conversation_history_older">より前</string>
     <string name="ui_conversation_history_back_content_description">戻る</string>
     <string name="ui_conversation_history_loading">会話履歴を読み込み中...</string>
     <string name="ui_conversation_history_empty_title">会話履歴はありません</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,10 @@
     <string name="ui_home_retrying_attempt">重试 %1$d/%2$d</string>
     <string name="runtime_error_internal">内部错误</string>
     <string name="ui_home_history_content_description">对话历史</string>
+    <string name="ui_conversation_history_today">今天</string>
+    <string name="ui_conversation_history_this_week">本周</string>
+    <string name="ui_conversation_history_this_month">本月</string>
+    <string name="ui_conversation_history_older">更早</string>
     <string name="ui_conversation_history_back_content_description">返回</string>
     <string name="ui_conversation_history_loading">正在读取对话历史...</string>
     <string name="ui_conversation_history_empty_title">暂无对话历史</string>


### PR DESCRIPTION
## Summary\n- Group conversations by updatedAt into Today / This Week / This Month / Earlier sections\n- Collapsible section headers with chevron animation (Plan B lightweight style)\n- Collapse state saved across navigation returns (rememberSaveable), not persisted to disk\n- Data layer untouched — uses existing updatedAt and sort order\n\n## Test plan\n- [ ] Install debug APK and open conversation history\n- [ ] Verify sections appear in correct order with proper labels\n- [ ] Tap section header to collapse/expand\n- [ ] Navigate into a conversation and back — collapse state preserved\n- [ ] Empty / error / loading states unaffected