### PR TITLE
feat: screenshot tool and image preview for tool results

### DIFF
--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/LlmStreamEvent.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/LlmStreamEvent.kt
@@ -1,5 +1,7 @@
 package com.niki914.zafiro.chat
 
+import com.niki914.okia.message.ContentBlock
+
 
 sealed interface LlmStreamEvent {
     data object RoundStarted : LlmStreamEvent
@@ -37,6 +39,8 @@ sealed interface LlmStreamEvent {
     data class ToolSucceeded(
         val call: ToolCallStatus,
         val outputText: String? = null,
+        /** 工具返回的图片引用（view_image / screenshot 等），path 指向 image_cache 落盘文件。 */
+        val images: List<ContentBlock.Image> = emptyList(),
     ) : LlmStreamEvent
 
     data class ToolFailed(

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/ImageIO.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/ImageIO.kt
@@ -1,9 +1,15 @@
 package com.niki914.zafiro.chat.agentic
 
 import com.niki914.okia.ImageLoader
+import com.niki914.xposed.api.util.ContextProvider
+import com.niki914.zafiro.chat.agentic.buildin.BuiltinToolResult
 import com.niki914.zafiro.chat.agentic.image.IngestError
+import com.niki914.zafiro.chat.agentic.image.IngestResult
+import com.niki914.zafiro.chat.agentic.image.ImageCodec
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import java.io.File
 
 /**
@@ -29,7 +35,44 @@ class AndroidImageLoader(
 /** ingest 成功产出：落盘路径（mimeType 由 ImageCodec 管线保证恒为 image/jpeg，不重复携带）。 */
 data class IngestedImage(val path: String)
 
-/** IngestError → 工具错误码 JSON 的映射（供 ViewImageBuiltin 使用）。 */
+/**
+ * 图片类内置工具（view_image / screenshot）共享的 codec 惰性单例：
+ * 进程内缓存一个 ImageCodec 实例，避免每次调用重复构建。
+ */
+internal object SharedImageCodec {
+    @Volatile
+    private var codec: ImageCodec? = null
+
+    suspend fun get(): ImageCodec? {
+        codec?.let { return it }
+        val context = try {
+            ContextProvider.await().applicationContext
+        } catch (e: Exception) {
+            return null
+        } ?: return null
+        return ImageCodec(context).also { codec = it }
+    }
+}
+
+/** ingest 成功 → 与 view_image/screenshot 共用的 data.image JSON 结果（契约两工具一致）。 */
+internal fun IngestResult.Ok.toImageToolResult(message: String): BuiltinToolResult = BuiltinToolResult.success(
+    message = message,
+    data = JsonObject(
+        mapOf(
+            "image" to JsonObject(
+                mapOf(
+                    "path" to JsonPrimitive(image.path),
+                    "mime_type" to JsonPrimitive(image.mimeType),
+                    "width" to JsonPrimitive(image.width),
+                    "height" to JsonPrimitive(image.height),
+                    "bytes" to JsonPrimitive(image.bytes),
+                )
+            )
+        )
+    )
+)
+
+/** IngestError → 工具错误码 JSON 的映射（供 ViewImageBuiltin / ScreenshotBuiltin 使用）。 */
 internal fun IngestError.toToolError(): Pair<String, String> = when (this) {
     IngestError.FileNotFound -> "FILE_NOT_FOUND" to "Image file not found or is not a readable file."
     IngestError.EmptyContent -> "EMPTY_CONTENT" to "Image file is empty."

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/BuiltinToolRegistry.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/BuiltinToolRegistry.kt
@@ -10,6 +10,7 @@ import com.niki914.zafiro.chat.agentic.buildin.impl.OpenUriBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.PyMetaToolsBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.ScreenOperationAccessibilityBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.ScreenOperationShellBuiltin
+import com.niki914.zafiro.chat.agentic.buildin.impl.ScreenshotBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.TerminalBuiltin
 import com.niki914.zafiro.chat.agentic.buildin.impl.ViewImageBuiltin
 
@@ -36,6 +37,7 @@ class BuiltinToolRegistry(
                 FindInstalledAppsBuiltin(),
                 ScreenOperationAccessibilityBuiltin(),
                 ScreenOperationShellBuiltin(),
+                ScreenshotBuiltin(),
                 ViewImageBuiltin(),
             )
         )

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/ScreenshotBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/ScreenshotBuiltin.kt
@@ -1,0 +1,126 @@
+package com.niki914.zafiro.chat.agentic.buildin.impl
+
+import com.niki914.logging.Logger
+import com.niki914.xposed.api.util.ContextProvider
+import com.niki914.zafiro.chat.agentic.buildin.BuiltinTool
+import com.niki914.zafiro.chat.agentic.buildin.BuiltinToolRequest
+import com.niki914.zafiro.chat.agentic.buildin.BuiltinToolResult
+import com.niki914.zafiro.chat.agentic.image.IngestError
+import com.niki914.zafiro.chat.agentic.image.IngestResult
+import com.niki914.zafiro.chat.agentic.shell.TerminalCommandOutcome
+import com.niki914.zafiro.chat.agentic.shell.TerminalSessionPool
+import com.niki914.zafiro.chat.agentic.SharedImageCodec
+import com.niki914.zafiro.chat.agentic.toImageToolResult
+import com.niki914.zafiro.chat.agentic.toToolError
+import kotlinx.serialization.json.JsonPrimitive
+import java.io.File
+
+/**
+ * screenshot 工具：截取整个设备屏幕，ingest 后返回图片引用。
+ * 无参数；截屏目标路径由工具自行生成（AI 不感知路径来源）。
+ *
+ * 截屏通道（MVP）：libterm root → shizuku 逐个尝试，跑 `screencap -p`。
+ * 无障碍兜底通道留缝（返回 unsupported），后续作为 root 不可用时的 fallback。
+ * 结果契约与 view_image 完全一致：data.image = { path, mime_type, width, height, bytes }。
+ */
+class ScreenshotBuiltin : BuiltinTool() {
+    override val name: String = "screenshot"
+    override val description: String = """
+Capture the entire device screen as an image so the model can see it.
+Use when the user asks about what is currently on screen, or to verify the visual result of an action.
+Returns an image reference (path, dimensions, size) on success, or an error code if no privileged
+shell (root/shizuku) is available or the capture failed.
+    """.trimIndent()
+    override val defaultEnabled: Boolean = true
+    override val inputSchemaJson: String? = SCHEMA
+
+    override suspend fun invoke(request: BuiltinToolRequest): BuiltinToolResult {
+        val codec = SharedImageCodec.get() ?: return BuiltinToolResult.failure(
+            code = "CODEC_UNAVAILABLE",
+            message = "Image codec is not available.",
+            hint = "Application context is not initialized yet. Retry later."
+        )
+
+        val rawPath = captureRawScreenshot()
+            ?: return BuiltinToolResult.failure(
+                code = "PERMISSION_DENIED",
+                message = "Screen capture requires a privileged shell (root or shizuku); neither is available.",
+                hint = "Grant root or start shizuku, then retry."
+            )
+
+        try {
+            return when (val result = codec.ingestFile(rawPath)) {
+                is IngestResult.Ok -> result.toImageToolResult(
+                    message = "Screenshot captured: ${result.image.path}",
+                )
+
+                is IngestResult.Err -> {
+                    val (code, message) = result.error.toToolError()
+                    BuiltinToolResult.failure(
+                        code = code,
+                        message = message,
+                        hint = "The screen was captured but the image could not be processed. Retry."
+                    )
+                }
+            }
+        } finally {
+            // 原始 PNG 只服务于 ingest，转码 JPEG 落盘后即可删除
+            runCatching { File(rawPath).delete() }
+        }
+    }
+
+    /**
+     * 通过 libterm 截屏到 app 私有目录，返回原始文件绝对路径；失败返回 null。
+     * root → shizuku 逐个尝试（同 AccessibilityController 的降级模式）；
+     * exitCode == 0 且文件真实存在才算成功——denied 的 su 可能返回非 root shell，
+     * 仅凭 TerminalCommandOutcome.Success 不可信。
+     */
+    private suspend fun captureRawScreenshot(): String? {
+        val context = try {
+            ContextProvider.await().applicationContext
+        } catch (e: Exception) {
+            return null
+        } ?: return null
+        val cacheDir = File(context.cacheDir, "screenshot").apply { mkdirs() }
+        val rawFile = File(cacheDir, "capture_${System.currentTimeMillis()}.png")
+
+        for (identity in listOf("root", "shizuku")) {
+            val outcome = TerminalSessionPool.openAndExecute(
+                identity = identity,
+                cwd = null,
+                command = "screencap -p ${rawFile.absolutePath}",
+                timeoutMs = CAPTURE_TIMEOUT_MS,
+            )
+            val session = (outcome as? TerminalCommandOutcome.Success)?.session
+                ?: (outcome as? TerminalCommandOutcome.Timeout)?.session
+            if (session != null) {
+                runCatching { TerminalSessionPool.close(session) }
+            }
+            if (outcome is TerminalCommandOutcome.Success && outcome.result.exitCode == 0) {
+                // cat > file 重定向场景下 shell 退出码可能不可靠，以文件存在为准
+                if (rawFile.exists() && rawFile.length() > 0) {
+                    return rawFile.absolutePath
+                }
+            }
+            Logger.w(
+                LOG_TAG,
+                "screencap failed identity=$identity outcome=${outcome::class.simpleName}"
+            )
+        }
+        // 无障碍兜底通道留缝：当前未实现，root/shizuku 均不可用时直接失败
+        return null
+    }
+
+    private companion object {
+        private const val LOG_TAG = "niki914_nexus_ScreenshotBuiltin"
+        private const val CAPTURE_TIMEOUT_MS = 15_000L
+
+        private val SCHEMA = """
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}
+        """.trimIndent()
+    }
+}

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/ViewImageBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/ViewImageBuiltin.kt
@@ -1,13 +1,12 @@
 package com.niki914.zafiro.chat.agentic.buildin.impl
 
-import com.niki914.xposed.api.util.ContextProvider
-import kotlin.concurrent.Volatile
 import com.niki914.zafiro.chat.agentic.buildin.BuiltinTool
 import com.niki914.zafiro.chat.agentic.buildin.BuiltinToolRequest
 import com.niki914.zafiro.chat.agentic.buildin.BuiltinToolResult
-import com.niki914.zafiro.chat.agentic.image.ImageCodec
 import com.niki914.zafiro.chat.agentic.image.IngestError
 import com.niki914.zafiro.chat.agentic.image.IngestResult
+import com.niki914.zafiro.chat.agentic.SharedImageCodec
+import com.niki914.zafiro.chat.agentic.toImageToolResult
 import com.niki914.zafiro.chat.agentic.toToolError
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -23,18 +22,6 @@ import kotlinx.serialization.json.jsonObject
  * ingest 失败时返回结构化错误码，由 Agent 决定后续操作。
  */
 class ViewImageBuiltin : BuiltinTool() {
-    @Volatile
-    private var codec: ImageCodec? = null
-
-    private suspend fun ensureCodec(): ImageCodec? {
-        codec?.let { return it }
-        val context = try {
-            ContextProvider.await().applicationContext
-        } catch (e: Exception) {
-            return null
-        } ?: return null
-        return ImageCodec(context).also { codec = it }
-    }
     override val name: String = "view_image"
     override val description: String = """
 Read an image file from disk so the model can see it.
@@ -64,27 +51,14 @@ Returns the normalized file path if the image was ingested successfully, or an e
             )
         }
 
-        val codec = ensureCodec() ?: return BuiltinToolResult.failure(
+        val codec = SharedImageCodec.get() ?: return BuiltinToolResult.failure(
             code = "CODEC_UNAVAILABLE",
             message = "Image codec is not available.",
             hint = "Application context is not initialized yet. Retry later."
         )
         return when (val result = codec.ingestFile(path)) {
-            is IngestResult.Ok -> BuiltinToolResult.success(
+            is IngestResult.Ok -> result.toImageToolResult(
                 message = "Image ingested: ${result.image.path}",
-                data = JsonObject(
-                    mapOf(
-                        "image" to JsonObject(
-                            mapOf(
-                                "path" to JsonPrimitive(result.image.path),
-                                "mime_type" to JsonPrimitive(result.image.mimeType),
-                                "width" to JsonPrimitive(result.image.width),
-                                "height" to JsonPrimitive(result.image.height),
-                                "bytes" to JsonPrimitive(result.image.bytes),
-                            )
-                        )
-                    )
-                )
             )
             is IngestResult.Err -> {
                 val (code, message) = result.error.toToolError()

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/stream/LlmStreamEventMapper.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/stream/LlmStreamEventMapper.kt
@@ -239,7 +239,7 @@ object LlmStreamEventMapper {
         val call = toolCall.toStatus()
         val outcome = this.outcome
         return when (outcome) {
-            is ToolCallOutcome.Success -> LlmStreamEvent.ToolSucceeded(call, outcome.content)
+            is ToolCallOutcome.Success -> LlmStreamEvent.ToolSucceeded(call, outcome.content, outcome.images)
             is ToolCallOutcome.Intercepted ->
                 if (outcome.isError) LlmStreamEvent.ToolFailed(
                     call,

--- a/app/src/main/java/com/niki914/zafiro/app/conversation/ConversationFormatter.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/conversation/ConversationFormatter.kt
@@ -93,7 +93,7 @@ object ConversationFormatter {
                         id = nextId++,
                         userText = message.textBlocks().joinToString("\n"),
                         images = message.content.filterIsInstance<ContentBlock.Image>().map {
-                            HomeChatImage(id = it.path.hashCode().toString(), path = it.path)
+                            HomeChatImage.of(it)
                         },
                     )
                 }
@@ -116,6 +116,7 @@ object ConversationFormatter {
                         state = state,
                         resultText = resultText,
                         failedReason = failedReason,
+                        images = (message.outcome as? ToolCallOutcome.Success)?.images.orEmpty(),
                     )
                     turns.replaceLastOrAdd(updated)
                 }
@@ -181,6 +182,7 @@ object ConversationFormatter {
         state: HomeToolState,
         resultText: String? = null,
         failedReason: String? = null,
+        images: List<ContentBlock.Image> = emptyList(),
     ): HomeChatTurn {
         val index = blocks.indexOfLast { block ->
             block is HomeChatBlock.Tool && block.status.matchesTool(callId, toolName)
@@ -194,6 +196,9 @@ object ConversationFormatter {
                         state = state,
                         resultText = resultText,
                         failedReason = failedReason,
+                        images = images.map {
+                            HomeChatImage.of(it)
+                        },
                     ),
                 )
             },

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/CollapsibleBlock.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/CollapsibleBlock.kt
@@ -75,6 +75,7 @@ internal val OutputBtnInset = 36.dp   // 多行输出右缘给右上角按钮让
 internal val CopyBtnSize = 26.dp      // 复制按钮
 internal val CopyIconSize = 14.dp     // 复制图标
 internal val ResultScrollMaxHeight = 102.dp // 工具结果/思考正文滚动高度上限
+internal val ToolImagePreviewSize = 120.dp  // 工具结果图片预览卡边长（与消息内大图卡一致）
 
 // 块正文统一色规则：onSurfaceVariant 满值（不叠 alpha）。
 // 层级三档：收起行 variant×0.7 < 块内正文 variant < 助手回答 onSurface。

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/HomeChatComponents.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/HomeChatComponents.kt
@@ -602,11 +602,12 @@ private fun rememberPathBitmap(path: String): ImageBitmap? =
     }.value
 
 /**
- * 单张图片卡。尺寸由调用方决定（composer 待发 60dp / 消息内大图卡）。
- * 顶部 30% 纵向渐变遮罩（black 50% → 0%），右上角白色关闭钮，无圆形背景。
+ * 单张图片卡。尺寸由调用方决定（composer 待发 60dp / 消息内大图卡 / 工具结果预览）。
+ * 顶部 30% 纵向渐变遮罩（black 50% → 0%），右上角白色关闭钮（可选），无圆形背景。
+ * 供本文件与 ToolChain（工具结果图片预览）共用。
  */
 @Composable
-private fun HomeChatImageCard(
+internal fun HomeChatImageCard(
     image: HomeChatImage,
     size: Dp,
     cornerRadius: Dp,

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/ToolChain.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/ToolChain.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import com.niki914.uikit.infra.shape.G2FieldShape
 import com.niki914.zafiro.app.R
+import com.niki914.zafiro.app.ui.model.HomeChatImage
 import com.niki914.zafiro.app.ui.model.HomeToolState
 import com.niki914.zafiro.app.ui.model.HomeToolStatus
 import com.niki914.zafiro.app.ui.model.ToolPresentation
@@ -184,24 +185,48 @@ private fun SingleToolRow(
                 .fillMaxWidth()
                 .then(contentModifier)
         ) {
-            if (useCommandBody) {
-                CodeToolBody(
+            when {
+                status.images.isNotEmpty() -> ImagePreviewBody(images = status.images)
+                useCommandBody -> CodeToolBody(
                     command = inputPreview.orEmpty(),
                     copyText = status.inputText,
                     output = displayOutput(status).trim(),
                     isError = status.state == HomeToolState.Failed,
                 )
-            } else if (status.name in ResultTextToolNames && status.state != HomeToolState.Failed) {
-                ResultTextBody(text = displayOutput(status).trim())
-            } else {
-                // 兕底：正文只显示本地化「成功 / 失败」，失败红色。
-                FallbackResultBody(isFailed = status.state == HomeToolState.Failed)
+
+                status.name in ResultTextToolNames && status.state != HomeToolState.Failed ->
+                    ResultTextBody(text = displayOutput(status).trim())
+
+                else ->
+                    // 兕底：正文只显示本地化「成功 / 失败」，失败红色。
+                    FallbackResultBody(isFailed = status.state == HomeToolState.Failed)
             }
         }
     }
 }
 
 // ── tool result bodies ──────────────────────────────────────────────────────
+
+/**
+ * 图片预览体：工具返回了图片（view_image / screenshot 等）时展示落盘图缩略卡。
+ * 通用分派（images 非空即渲染），不依赖工具名；复用消息图片卡组件。
+ */
+@Composable
+private fun ImagePreviewBody(images: List<HomeChatImage>) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(BlockSpacing, Alignment.CenterHorizontally),
+    ) {
+        images.forEach { image ->
+            HomeChatImageCard(
+                image = image,
+                size = ToolImagePreviewSize,
+                cornerRadius = 18.dp,
+                onRemove = null,
+            )
+        }
+    }
+}
 
 /**
  * 命令型结果体：上下两段独立着色，中间 2dp 透明缝隙露出页面背景（M3E 分割样式）。

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/HomeChatState.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/HomeChatState.kt
@@ -90,6 +90,8 @@ data class HomeToolStatus(
     val displayNameRes: Int? = null,
     /** 工具参数原文（复制用）；显示预览由 UI 从原文裁剪。null → 只显示标题无预览、无复制。 */
     val inputText: String? = null,
+    /** 工具返回的图片引用（view_image / screenshot 等），path 指向 image_cache 落盘文件。 */
+    val images: List<HomeChatImage> = emptyList(),
 )
 
 sealed interface HomeChatBlock {
@@ -130,7 +132,13 @@ data class HomeChatTurn(
 data class HomeChatImage(
     val id: String,
     val path: String,
-)
+) {
+    companion object {
+        /** ContentBlock.Image（工具结果/历史恢复）→ UI 图片卡模型，id 取 path hash 保持跨会话稳定。 */
+        fun of(block: com.niki914.okia.message.ContentBlock.Image): HomeChatImage =
+            HomeChatImage(id = block.path.hashCode().toString(), path = block.path)
+    }
+}
 
 data class HomeChatUiState(
     val input: String = "",
@@ -603,6 +611,7 @@ class HomeChatViewModel internal constructor(
                 it.updateTool(
                     event.call,
                     HomeToolState.Succeeded, event.outputText,
+                    images = event.images,
                 )
             }
 
@@ -846,7 +855,7 @@ class HomeChatViewModel internal constructor(
                     id = newTurnId,
                     userText = userText,
                     images = userImages.map {
-                        HomeChatImage(id = it.path.hashCode().toString(), path = it.path)
+                        HomeChatImage.of(it)
                     },
                 ),
                 isGenerating = true,
@@ -1016,6 +1025,7 @@ class HomeChatViewModel internal constructor(
         state: HomeToolState,
         resultText: String? = null,
         failedReason: String? = null,
+        images: List<ContentBlock.Image> = emptyList(),
     ): HomeChatTurn = copy(
         blocks = blocks + HomeChatBlock.Tool(
             HomeToolStatus(
@@ -1026,6 +1036,9 @@ class HomeChatViewModel internal constructor(
                 failedReason = failedReason,
                 displayNameRes = ToolPresentation.displayNameResOf(call.name),
                 inputText = ToolPresentation.inputOf(call.name, call.argumentsJson),
+                images = images.map {
+                    HomeChatImage.of(it)
+                },
             ),
         ),
     )
@@ -1035,10 +1048,11 @@ class HomeChatViewModel internal constructor(
         state: HomeToolState,
         resultText: String? = null,
         failedReason: String? = null,
+        images: List<ContentBlock.Image> = emptyList(),
     ): HomeChatTurn {
         val index = findToolBlockIndex(call.callId, call.label)
         if (index == -1) {
-            return appendTool(call, state, resultText, failedReason)
+            return appendTool(call, state, resultText, failedReason, images)
         }
         return copy(
             blocks = blocks.toMutableList().also { mutableBlocks ->
@@ -1051,6 +1065,9 @@ class HomeChatViewModel internal constructor(
                         failedReason = failedReason,
                         displayNameRes = ToolPresentation.displayNameResOf(call.name),
                         inputText = ToolPresentation.inputOf(call.name, call.argumentsJson),
+                        images = images.map {
+                            HomeChatImage.of(it)
+                        },
                     ),
                 )
             },

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/ToolPresentation.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/ToolPresentation.kt
@@ -3,6 +3,8 @@ package com.niki914.zafiro.app.ui.model
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.Terminal
 import androidx.compose.runtime.Composable
@@ -30,6 +32,8 @@ object ToolPresentation {
 
     private val TerminalIcon = Icons.Filled.Terminal
     private val Skill = Icons.AutoMirrored.Filled.MenuBook
+    private val Camera = Icons.Filled.CameraAlt
+    private val ImageTool = Icons.Filled.Image
 
     /** 默认（兜底）图标：扳手。 */
     val Default = Icons.Filled.Build
@@ -47,6 +51,8 @@ object ToolPresentation {
                 ignoreCase = true
             ) -> TerminalIcon
 
+            name == "screenshot" -> Camera
+            name == "view_image" -> ImageTool
             name.contains("skill", ignoreCase = true) -> Skill
             else -> Default
         }
@@ -66,6 +72,8 @@ object ToolPresentation {
         "find_installed_apps" -> R.string.ui_tool_display_find_installed_apps
         "screen_operation_accessibility" -> R.string.ui_tool_display_screen_operation_accessibility
         "screen_operation_shell" -> R.string.ui_tool_display_screen_operation_shell
+        "screenshot" -> R.string.ui_tool_display_screenshot
+        "view_image" -> R.string.ui_tool_display_view_image
         else -> null
     }
 

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -303,6 +303,8 @@
     <string name="ui_tool_display_find_installed_apps">尋找應用程式</string>
     <string name="ui_tool_display_screen_operation_accessibility">螢幕操作</string>
     <string name="ui_tool_display_screen_operation_shell">螢幕操作</string>
+    <string name="ui_tool_display_screenshot">擷取螢幕</string>
+    <string name="ui_tool_display_view_image">檢視圖片</string>
     <string name="dialog_cancel">取消</string>
     <string name="dialog_confirm_delete">刪除</string>
     <string name="ui_settings_section_general">一般</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -341,6 +341,8 @@
     <string name="ui_tool_display_find_installed_apps">Find installed apps</string>
     <string name="ui_tool_display_screen_operation_accessibility">Screen Operation</string>
     <string name="ui_tool_display_screen_operation_shell">Screen Operation</string>
+    <string name="ui_tool_display_screenshot">Screenshot</string>
+    <string name="ui_tool_display_view_image">View Image</string>
     <string name="dialog_cancel">Cancel</string>
     <string name="dialog_confirm_delete">Delete</string>
     <string name="ui_settings_section_general">General</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -341,6 +341,8 @@
     <string name="ui_tool_display_find_installed_apps">Buscar apps instaladas</string>
     <string name="ui_tool_display_screen_operation_accessibility">Operaciones de pantalla</string>
     <string name="ui_tool_display_screen_operation_shell">Operaciones de pantalla</string>
+    <string name="ui_tool_display_screenshot">Captura de pantalla</string>
+    <string name="ui_tool_display_view_image">Ver imagen</string>
     <string name="dialog_cancel">Cancelar</string>
     <string name="dialog_confirm_delete">Eliminar</string>
     <string name="ui_settings_section_general">General</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -340,6 +340,8 @@
     <string name="ui_tool_display_find_installed_apps">アプリを探す</string>
     <string name="ui_tool_display_screen_operation_accessibility">画面操作</string>
     <string name="ui_tool_display_screen_operation_shell">画面操作</string>
+    <string name="ui_tool_display_screenshot">スクリーンショット</string>
+    <string name="ui_tool_display_view_image">画像を表示</string>
     <string name="dialog_cancel">キャンセル</string>
     <string name="dialog_confirm_delete">削除</string>
     <string name="ui_settings_section_general">一般</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -340,6 +340,8 @@
     <string name="ui_tool_display_find_installed_apps">查找应用</string>
     <string name="ui_tool_display_screen_operation_accessibility">屏幕操作</string>
     <string name="ui_tool_display_screen_operation_shell">屏幕操作</string>
+    <string name="ui_tool_display_screenshot">截屏</string>
+    <string name="ui_tool_display_view_image">查看图片</string>
     <string name="dialog_cancel">取消</string>
     <string name="dialog_confirm_delete">删除</string>
     <string name="ui_settings_configure_endpoint_mismatch_title">更新端点</string>


### PR DESCRIPTION
## Summary

- Add `screenshot` builtin tool: captures the entire device screen via libterm root shell (`screencap`), ingests the PNG through the shared ImageCodec pipeline (JPEG, image_cache), returns the same `data.image` contract as `view_image`. Errors in tool output when no root shell is available.
- Add image preview for tool results: tool result cards now render an image preview when the tool outcome carries images (generic dispatch on `images.isNotEmpty()`, not tool-name based). Applies to `view_image` and `screenshot`, and any future image-returning tool.
- Thread `images` end-to-end: `ToolCallOutcome.Success.images` → `LlmStreamEvent.ToolSucceeded` → `HomeToolStatus.images` → UI; also restored on conversation reload via `ConversationFormatter`.
- Extract shared logic: `SharedImageCodec` singleton + `IngestResult.Ok.toImageToolResult()` (used by both image tools), `HomeChatImage.of(block)` factory (replaces 5 duplicated mappings).
- Add display names (4 locales) and icons (CameraAlt / Image) for both tools.

## Test plan

- [ ] Manual: trigger `screenshot` tool with root available → tool card shows centered image preview
- [ ] Manual: trigger `view_image` → same preview rendering
- [ ] Manual: reload conversation from history → image preview restored
- [ ] Manual: screenshot without root → tool outputs PERMISSION_DENIED error