### PR TITLE
feat: export full tool output to file on truncation

### DIFF
--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/LLMController.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/LLMController.kt
@@ -38,6 +38,7 @@ import com.niki914.zafiro.chat.agentic.accessibility.AccessibilityController
 import com.niki914.zafiro.chat.agentic.python.PyRuntime
 import com.niki914.zafiro.chat.agentic.shell.TerminalSessionPool
 import com.niki914.zafiro.chat.agentic.shell.ToolPermissionCoordinator
+import com.niki914.zafiro.util.ToolOutputTruncator
 import com.niki914.zafiro.chat.agentic.stream.LlmStreamEventMapper
 import com.niki914.zafiro.settings.RuntimeEnvironment
 import com.niki914.zafiro.settings.model.LlmProtocol
@@ -120,6 +121,8 @@ object LLMController {
         return setOf(
             File(context.filesDir, "image_cache").absolutePath,
             File(context.filesDir, "downloads").absolutePath,
+            // 截断导出目录：agent 可用 terminal 回读全量工具输出
+            File(context.filesDir, ToolOutputTruncator.EXPORT_DIR_NAME).absolutePath,
         )
     }
 

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/ExecutePythonBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/ExecutePythonBuiltin.kt
@@ -3,6 +3,7 @@ package com.niki914.zafiro.chat.agentic.buildin.impl
 import com.niki914.zafiro.chat.agentic.buildin.BuiltinToolRequest
 import com.niki914.zafiro.chat.agentic.buildin.TextResultBuiltinTool
 import com.niki914.zafiro.chat.agentic.buildin.TextToolResult
+import com.niki914.zafiro.chat.agentic.python.PyExecOutput
 import com.niki914.zafiro.chat.agentic.python.PyRuntime
 import com.niki914.zafiro.chat.agentic.shell.ShellCommandSafetyPolicy
 import com.niki914.zafiro.util.ToolOutputTruncator
@@ -22,8 +23,10 @@ class ExecutePythonBuiltin(
      * @param code     Python source code to execute.
      * @param timeoutMs Max wait in milliseconds.
      */
-    var executor: suspend (code: String, timeoutMs: Long) -> String = PyRuntime::exec,
+    var executor: suspend (code: String, timeoutMs: Long) -> PyExecOutput = PyRuntime::exec,
     private val safetyPolicy: ShellCommandSafetyPolicy = ShellCommandSafetyPolicy(),
+    /** 截断导出目录（filesDir/tool_output），测试可注入临时目录。 */
+    var exportDir: java.io.File? = ToolOutputTruncator.defaultExportDir(),
 ) : TextResultBuiltinTool() {
 
     override val name: String = "execute_python"
@@ -36,7 +39,9 @@ Can drive Android system commands (am, pm, input) via os.popen or subprocess; pr
 State does not persist between calls: every run starts fresh — no variables, working directory, environment
 changes, open handles, or background tasks. Persist intentionally through files when needed.
 
-Limits: timeout 30 s default, 120 s max; output capped at 50 KB.
+Limits: timeout 30 s default, 120 s max. Output over 2000 lines / 50 KB is
+truncated; the full output is saved to a file whose absolute path is included
+in the result — read it back with terminal commands (e.g. cat) when needed.
     """.trimIndent()
 
     override val defaultEnabled: Boolean = true
@@ -73,9 +78,8 @@ Limits: timeout 30 s default, 120 s max; output capped at 50 KB.
             )
         }
         return try {
-            val output = executor(code, timeoutMs)
-            val capped = capOutput(output)
-            TextToolResult.success(capped)
+            val result = executor(code, timeoutMs)
+            TextToolResult.success(filter(result))
         } catch (e: TimeoutCancellationException) {
             TextToolResult.failure(
                 code = "TIMEOUT",
@@ -84,24 +88,22 @@ Limits: timeout 30 s default, 120 s max; output capped at 50 KB.
         } catch (e: CancellationException) {
             throw e
         } catch (t: Throwable) {
-            val msg = t.message ?: "Python execution failed."
-            val isTimeout = msg.contains("timed out after")
-            TextToolResult.failure(
-                code = if (isTimeout) "TIMEOUT" else "PYTHON_ERROR",
-                message = msg,
-            )
+            TextToolResult.failure(code = "PYTHON_ERROR", message = t.message ?: "Python execution failed.")
         }
     }
 
-    private fun capOutput(
-        output: String,
-        maxBytes: Int = ToolOutputTruncator.DEFAULT_MAX_BYTES
-    ): String {
-        val truncation = ToolOutputTruncator.truncateTail(output, maxBytes = maxBytes)
-        if (!truncation.truncated) return output
-        return truncation.content + "\n\n[Output truncated: showing last " +
-                truncation.content.count { it == '\n' } + " of " + truncation.totalLines +
-                " lines]"
+    /**
+     * 超限截断 + 导出：Python 路径把传输文件 move 到导出目录（零拷贝），
+     * inline 降级路径现场写导出文件。timedOut 时输出仍走同一过滤
+     * （对齐 pi：超时的部分输出也截断展示 + 全量落盘）。
+     */
+    private fun filter(result: PyExecOutput): String {
+        val body = ToolOutputTruncator.filterForAgent(
+            fullContent = result.output,
+            existingFile = result.file,
+            exportDir = exportDir,
+        )
+        return if (result.timedOut) "$body\n\n[Execution timed out: partial output shown]" else body
     }
 
     private fun parseArgs(argumentsJson: String): ParseResult {

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/PyMetaToolsBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/PyMetaToolsBuiltin.kt
@@ -6,7 +6,9 @@ import com.niki914.zafiro.chat.agentic.buildin.BuiltinToolRegistry
 import com.niki914.zafiro.chat.agentic.buildin.BuiltinToolRequest
 import com.niki914.zafiro.chat.agentic.buildin.BuiltinToolResult
 import com.niki914.zafiro.chat.agentic.python.CustomPyToolHarness
+import com.niki914.zafiro.chat.agentic.python.PyExecOutput
 import com.niki914.zafiro.chat.agentic.python.PyRuntime
+import com.niki914.zafiro.util.ToolOutputTruncator
 import com.niki914.zafiro.chat.agentic.shell.ShellCommandSafetyPolicy
 import com.niki914.zafiro.settings.RuntimeEnvironment
 import com.niki914.zafiro.settings.model.RuntimeCustomPyTool
@@ -33,9 +35,11 @@ import kotlinx.serialization.json.put
  * - test 用同一 harness 试跑草稿 code 或已存工具，write 前可先 test。
  */
 class PyMetaToolsBuiltin(
-    private val exec: suspend (code: String, timeoutMs: Long) -> String = PyRuntime::exec,
+    private val exec: suspend (code: String, timeoutMs: Long) -> PyExecOutput = PyRuntime::exec,
     private val safetyPolicy: ShellCommandSafetyPolicy = ShellCommandSafetyPolicy(),
     private val reservedNames: Set<String>? = null,
+    /** 截断导出目录，测试可注入临时目录；默认 filesDir/tool_output。 */
+    private val exportDir: java.io.File? = ToolOutputTruncator.defaultExportDir(),
 ) : BuiltinTool() {
 
     override val name: String = "py_meta_tools"
@@ -218,7 +222,12 @@ Store the result of a run by printing from main; stdout is returned.
         }
 
         return try {
-            val output = exec(CustomPyToolHarness.buildRunner(code, args.argsJson), timeoutMs)
+            val result = exec(CustomPyToolHarness.buildRunner(code, args.argsJson), timeoutMs)
+            val output = ToolOutputTruncator.filterForAgent(
+                fullContent = result.output,
+                existingFile = result.file,
+                exportDir = exportDir,
+            )
             BuiltinToolResult.success(
                 message = "Test run finished.",
                 data = buildJsonObject { put("stdout", output) },
@@ -251,6 +260,7 @@ Store the result of a run by printing from main; stdout is returned.
     private suspend fun introspect(code: String): Introspection {
         val output = try {
             exec(CustomPyToolHarness.buildIntrospection(code), INTROSPECTION_TIMEOUT_MS)
+                .output // 内部结构化输出，不截断不导出
         } catch (e: TimeoutCancellationException) {
             return Introspection(
                 null,

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/TerminalBuiltin.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/buildin/impl/TerminalBuiltin.kt
@@ -21,6 +21,7 @@ import com.niki914.zafiro.chat.agentic.shell.TerminalSessionPool
 import com.niki914.zafiro.chat.agentic.shell.TerminalToolResponse
 import com.niki914.zafiro.chat.agentic.shell.TerminalToolResponse.stderrText
 import com.niki914.zafiro.chat.agentic.shell.TerminalToolResponse.stdoutText
+import com.niki914.zafiro.util.ToolOutputTruncator
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
@@ -35,6 +36,8 @@ import kotlinx.serialization.json.longOrNull
 
 class TerminalBuiltin(
     private val safetyPolicy: ShellCommandSafetyPolicy = ShellCommandSafetyPolicy(),
+    /** 截断导出目录（filesDir/tool_output），测试可注入临时目录；null 时经 ContextProvider 取。 */
+    private val exportDirOverride: java.io.File? = null,
 ) : BuiltinTool(), RawJsonBuiltinTool {
     override val name: String = "terminal"
 
@@ -151,7 +154,7 @@ class TerminalBuiltin(
                 is TerminalCommandOutcome.Success -> {
                     val result = outcome.result
                     TerminalToolResponse.commandSuccessFlat(
-                        stdout = mergedStdout(result, mergeStderr),
+                        stdout = filteredStdout(result, mergeStderr),
                         stderr = if (mergeStderr) "" else result.stderrText(),
                         exitCode = result.exitCode ?: UNKNOWN_EXIT_CODE,
                     )
@@ -160,7 +163,7 @@ class TerminalBuiltin(
                 is TerminalCommandOutcome.Timeout -> {
                     val result = outcome.result
                     TerminalToolResponse.commandTimeoutFlat(
-                        stdout = mergedStdout(result, mergeStderr),
+                        stdout = filteredStdout(result, mergeStderr),
                         stderr = if (mergeStderr) "" else result.stderrText(),
                         timeoutSec = timeoutMs / 1000L,
                     )
@@ -276,7 +279,7 @@ class TerminalBuiltin(
                 is TerminalCommandOutcome.Success -> {
                     val result = outcome.result
                     TerminalToolResponse.commandSuccessFlat(
-                        stdout = mergedStdout(result, mergeStderr),
+                        stdout = filteredStdout(result, mergeStderr),
                         stderr = if (mergeStderr) "" else result.stderrText(),
                         exitCode = result.exitCode ?: UNKNOWN_EXIT_CODE,
                     )
@@ -285,7 +288,7 @@ class TerminalBuiltin(
                 is TerminalCommandOutcome.Timeout -> {
                     val result = outcome.result
                     TerminalToolResponse.commandTimeoutFlat(
-                        stdout = mergedStdout(result, mergeStderr),
+                        stdout = filteredStdout(result, mergeStderr),
                         stderr = if (mergeStderr) "" else result.stderrText(),
                         timeoutSec = timeoutMs / 1000L,
                     )
@@ -706,6 +709,14 @@ class TerminalBuiltin(
     private fun mergedStdout(result: CommandResult, mergeStderr: Boolean): String {
         val stdout = result.stdoutText()
         return if (mergeStderr) stdout + result.stderrText() else stdout
+    }
+
+    /** 前台输出统一过滤：超限截断 + 全量导出（对齐 ToolOutputTruncator 口径）。 */
+    private fun filteredStdout(result: CommandResult, mergeStderr: Boolean): String {
+        return ToolOutputTruncator.filterForAgent(
+            fullContent = mergedStdout(result, mergeStderr),
+            exportDir = exportDirOverride ?: ToolOutputTruncator.defaultExportDir(),
+        )
     }
 
     // ── Data types ───────────────────────────────────────────────────────────

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/python/CustomPyToolExecutor.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/python/CustomPyToolExecutor.kt
@@ -1,6 +1,7 @@
 package com.niki914.zafiro.chat.agentic.python
 
 import com.niki914.zafiro.chat.LocalTool
+import com.niki914.zafiro.util.ToolOutputTruncator
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.serialization.json.Json
@@ -9,22 +10,30 @@ import kotlinx.serialization.json.JsonPrimitive
 
 /**
  * CustomPyTool 执行器：把 LLM 的参数 JSON 经 [CustomPyToolHarness.buildRunner] 拼接后
- * 交给 [PyRuntime.exec]（:python 进程）。输出即 stdout（runtime.py 已做
- * 50KB 截断）。结果用 {"ok":...} JSON 约定，与 BuiltinToolResult 对齐，
- * 由 LocalToolResultClassifier 拆 Success/Failure。
+ * 交给 [PyRuntime.exec]（:python 进程）。输出即 stdout（截断+导出由
+ * [ToolOutputTruncator.filterForAgent] 统一处理）。结果用 {"ok":...} JSON 约定，
+ * 与 BuiltinToolResult 对齐，由 LocalToolResultClassifier 拆 Success/Failure。
  */
 class CustomPyToolExecutor(
-    private val exec: suspend (code: String, timeoutMs: Long) -> String = PyRuntime::exec,
+    private val exec: suspend (code: String, timeoutMs: Long) -> PyExecOutput = PyRuntime::exec,
+    /** 截断导出目录，测试可注入临时目录；默认 filesDir/tool_output。 */
+    private val exportDir: java.io.File? = ToolOutputTruncator.defaultExportDir(),
 ) {
     suspend fun execute(tool: LocalTool.Py, argumentsJson: String): String {
         val args = parseArguments(argumentsJson)
         return try {
-            val output = exec(CustomPyToolHarness.buildRunner(tool.code, args), tool.timeoutMs)
+            val result = exec(CustomPyToolHarness.buildRunner(tool.code, args), tool.timeoutMs)
             JsonObject(
                 mapOf(
                     "ok" to JsonPrimitive(true),
                     "tool" to JsonPrimitive(tool.name),
-                    "stdout" to JsonPrimitive(output),
+                    "stdout" to JsonPrimitive(
+                        ToolOutputTruncator.filterForAgent(
+                            fullContent = result.output,
+                            existingFile = result.file,
+                            exportDir = exportDir,
+                        )
+                    ),
                 )
             ).toString()
         } catch (e: TimeoutCancellationException) {

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/python/IPythonWorkerService.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/python/IPythonWorkerService.kt
@@ -6,13 +6,57 @@ import android.os.IInterface
 import android.os.Parcel
 
 /**
+ * Python exec 的结构化结果。Binder 返回值不再承载两种语义（路径 vs 内容）：
+ * - [Status.OK]：输出已写入 [filePath]（worker 自算 cacheDir，无需入参传递）
+ * - [Status.TIMEOUT]：超时，[filePath] 指向已产出的部分输出文件
+ * - [Status.EXEC_ERROR]：worker 侧异常文本，走 [inlineText]（历史遗留字符串路径）
+ * - 写盘失败（极罕见）：[Status.OK] + [inlineText] 装尾部 1MB clip（谁裁剪谁负责，Java 不感知）
+ */
+data class PyExecResult(
+    val status: Status,
+    val filePath: String?,
+    val inlineText: String?,
+) {
+    enum class Status { OK, TIMEOUT, EXEC_ERROR }
+
+    companion object {
+        const val INLINE_CLIP_BYTES = 1024 * 1024
+
+        fun fromParcel(reply: Parcel): PyExecResult {
+            val status = Status.entries[reply.readInt()]
+            return PyExecResult(
+                status = status,
+                filePath = if (reply.readInt() != 0) reply.readString() else null,
+                inlineText = if (reply.readInt() != 0) reply.readString() else null,
+            )
+        }
+    }
+
+    fun writeToParcel(reply: Parcel) {
+        reply.writeInt(status.ordinal)
+        if (filePath != null) {
+            reply.writeInt(1)
+            reply.writeString(filePath)
+        } else {
+            reply.writeInt(0)
+        }
+        if (inlineText != null) {
+            reply.writeInt(1)
+            reply.writeString(inlineText)
+        } else {
+            reply.writeInt(0)
+        }
+    }
+}
+
+/**
  * Binder interface to the Python worker running in the dedicated `:python` process.
  *
  * All three methods are synchronous (blocking) calls:
  * - [exec] blocks until the Python code finishes or its own join timeout fires
- *   (returns the `TimeoutError` text). If the interpreter is hard-stuck (native
- *   code holding the GIL), the call may never return — the client must wrap it
- *   in a timeout and then call [kill].
+ *   (returns [PyExecResult.Status.TIMEOUT] with a partial-output file). If the
+ *   interpreter is hard-stuck (native code holding the GIL), the call may never
+ *   return — the client must wrap it in a timeout and then call [kill].
  * - [ping] performs a fast interpreter probe; it also never returns when the
  *   interpreter is stuck. The client uses it to detect a dead interpreter
  *   before paying a full exec timeout.
@@ -20,7 +64,7 @@ import android.os.Parcel
  *   (always executable while a Binder thread is free).
  */
 interface IPythonWorkerService : IInterface {
-    fun exec(code: String?, timeoutMs: Long): String?
+    fun exec(code: String?, timeoutMs: Long): PyExecResult
     fun ping(): String?
     fun kill()
 
@@ -39,7 +83,7 @@ interface IPythonWorkerService : IInterface {
                     val timeoutMs = data.readLong()
                     val result = exec(codeText, timeoutMs)
                     reply?.writeNoException()
-                    reply?.writeString(result)
+                    result.writeToParcel(reply!!)
                     return true
                 }
 
@@ -80,7 +124,7 @@ interface IPythonWorkerService : IInterface {
         private class Proxy(private val remote: IBinder) : IPythonWorkerService {
             override fun asBinder(): IBinder = remote
 
-            override fun exec(code: String?, timeoutMs: Long): String? {
+            override fun exec(code: String?, timeoutMs: Long): PyExecResult {
                 val data = Parcel.obtain()
                 val reply = Parcel.obtain()
                 try {
@@ -89,7 +133,7 @@ interface IPythonWorkerService : IInterface {
                     data.writeLong(timeoutMs)
                     remote.transact(TRANSACTION_exec, data, reply, 0)
                     reply.readException()
-                    return reply.readString()
+                    return PyExecResult.fromParcel(reply)
                 } finally {
                     reply.recycle()
                     data.recycle()

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/python/PyRuntime.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/python/PyRuntime.kt
@@ -23,10 +23,23 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
+import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 
 class PythonWorkerUnavailableException :
     IllegalStateException("Python worker is not connected")
+
+/**
+ * exec 的最终结果，供下游消费：
+ * - [output]：完整输出文本（优先从传输文件读取）
+ * - [file]：输出传输文件（cacheDir/py_output），未消费时保留给上层做截断导出
+ * - [timedOut]：worker 侧 join 超时（部分输出在 [file]/[output] 里）
+ */
+data class PyExecOutput(
+    val output: String,
+    val file: File?,
+    val timedOut: Boolean,
+)
 
 /**
  * Client for the Python worker in the dedicated `:python` process.
@@ -144,7 +157,7 @@ object PyRuntime {
      * Never returns a stuck result: a hard-stuck interpreter is killed and
      * the connection re-established before the retry.
      */
-    suspend fun exec(code: String, timeoutMs: Long): String {
+    suspend fun exec(code: String, timeoutMs: Long): PyExecOutput {
         pythonUsed = true
         activeExecCount.incrementAndGet()
         val startedAtMs = System.currentTimeMillis()
@@ -153,7 +166,8 @@ object PyRuntime {
             return execInternal(code, timeoutMs).also { result ->
                 Logger.i(
                     LOG_TAG,
-                    "python exec done codeLength=${code.length} resultLength=${result.length} " +
+                    "python exec done codeLength=${code.length} outputLength=${result.output.length} " +
+                            "file=${result.file?.path} timedOut=${result.timedOut} " +
                             "elapsedMs=${System.currentTimeMillis() - startedAtMs}"
                 )
             }
@@ -172,7 +186,7 @@ object PyRuntime {
         }
     }
 
-    private suspend fun execInternal(code: String, timeoutMs: Long): String {
+    private suspend fun execInternal(code: String, timeoutMs: Long): PyExecOutput {
         ensureConnected()
         var svc = testService ?: service ?: throw PythonWorkerUnavailableException()
         if (!isHealthy(svc)) {
@@ -223,11 +237,16 @@ object PyRuntime {
             }
         } ?: false
 
-    private suspend fun execOn(svc: IPythonWorkerService, code: String, timeoutMs: Long): String {
+    private suspend fun execOn(
+        svc: IPythonWorkerService,
+        code: String,
+        timeoutMs: Long,
+    ): PyExecOutput {
         try {
-            return withTimeout(timeoutMs + EXEC_GRACE_MS) {
+            val result = withTimeout(timeoutMs + EXEC_GRACE_MS) {
                 withContext(Dispatchers.IO) { svc.exec(code, timeoutMs) }
-            } ?: ""
+            }
+            return consume(result)
         } catch (e: TimeoutCancellationException) {
             killAndReconnect()
             throw e
@@ -235,6 +254,26 @@ object PyRuntime {
             service = null
             throw PythonWorkerUnavailableException()
         }
+    }
+
+    /** worker 结构化结果 → [PyExecOutput]：读传输文件还原全文，文件留给上层决定导出或删除。 */
+    private fun consume(result: PyExecResult): PyExecOutput {
+        val file = result.filePath?.takeIf { it.isNotEmpty() }?.let(::File)
+        val output = when {
+            file != null && file.exists() -> {
+                // ponytail: 全文一次性读入内存；输出源头已有 1MB Binder clip 兜底，
+                // 若未来需要处理超大输出应改为流式读取
+                file.readText(Charsets.UTF_8)
+            }
+            result.inlineText != null -> result.inlineText
+            else -> ""
+        }
+        // inline 降级路径没有文件；文件路径仅在正常写盘时存在
+        return PyExecOutput(
+            output = output,
+            file = file?.takeIf { it.exists() },
+            timedOut = result.status == PyExecResult.Status.TIMEOUT,
+        )
     }
 
     private suspend fun ensureConnected() {

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/python/PythonWorkerService.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/python/PythonWorkerService.kt
@@ -43,6 +43,12 @@ class PythonWorkerService : Service() {
         pythonHandler.post {
             try {
                 Python.start(AndroidPlatform(applicationContext))
+                // runtime.py 从这里拿传输文件目录（cacheDir/py_output）；
+                // 不设则缺省 /tmp，Android 上不可写 → 写盘降级全量走 inline
+                Python.getInstance()
+                    .getModule("os")
+                    .get("environ")!!
+                    .callAttr("__setitem__", "ZAFIRO_CACHE_DIR", applicationContext.cacheDir.absolutePath)
             } catch (t: Throwable) {
                 initFailure = t
             } finally {
@@ -66,15 +72,24 @@ class PythonWorkerService : Service() {
     }
 
     private inner class Stub : IPythonWorkerService.Stub() {
-        override fun exec(code: String?, timeoutMs: Long): String? {
+        override fun exec(code: String?, timeoutMs: Long): PyExecResult {
             awaitReady()
             val py = Python.getInstance()
             val runtime = py.getModule("runtime")
-            return runtime.callAttr(
+            val result = runtime.callAttr(
                 "exec_code",
                 code ?: "",
                 timeoutMs / 1000.0
-            ).toString()
+            )
+            // runtime.exec_code 返回 {status, file_path, inline_text}
+            val status = when (result.callAttr("get", "status").toString()) {
+                "timeout" -> PyExecResult.Status.TIMEOUT
+                "exec_error" -> PyExecResult.Status.EXEC_ERROR
+                else -> PyExecResult.Status.OK
+            }
+            val filePath = result.callAttr("get", "file_path").toString().ifEmpty { null }
+            val inlineText = result.callAttr("get", "inline_text").toString().ifEmpty { null }
+            return PyExecResult(status, filePath, inlineText)
         }
 
         override fun ping(): String? {

--- a/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/shell/TerminalSessionPool.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/chat/agentic/shell/TerminalSessionPool.kt
@@ -38,7 +38,9 @@ object TerminalSessionPool {
     private const val PUBLIC_HANDLE_LENGTH = 4
     private const val MAX_HANDLE_GENERATION_ATTEMPTS = 64
     private const val DEFAULT_INTERACTIVE_READ_MAX_BYTES = 8192
-    private const val DEFAULT_READ_MAX_BYTES = 8192
+    // 与 ToolOutputTruncator.DEFAULT_MAX_BYTES 对齐；readSession 截断由统一入口处理并导出全量
+    // FIXME(async-refactor): 异步轮询链路重构时一并收口 readSession 的上限与导出语义
+    private const val DEFAULT_READ_MAX_BYTES = ToolOutputTruncator.DEFAULT_MAX_BYTES
     private const val GENERATED_HANDLE_COLLISION_MESSAGE = "Generated session handle collision."
     private val PUBLIC_HANDLE_REGEX: Regex = Regex("^[0-9a-f]{4}$")
     private val lock = Any()
@@ -600,7 +602,7 @@ object TerminalSessionPool {
         val completedUnexpectedError = synchronized(lock) { entry.completedUnexpectedError }
         // 2. Completed with a result.
         if (completedResult != null) {
-            val output = truncateOutput(mergedOutput(completedResult), maxBytes)
+            val output = truncateOutput(mergedOutput(completedResult), maxBytes, exportDir())
             return if (completedResult.timedOut) {
                 TerminalReadOutcome.TimedOut(
                     session = session,
@@ -653,7 +655,7 @@ object TerminalSessionPool {
             }
             return TerminalReadOutcome.Running(
                 session = session,
-                output = truncateOutput(output, maxBytes),
+                output = truncateOutput(output, maxBytes, exportDir()),
                 elapsedSeconds = elapsedSeconds(asyncState.startTimeMs),
             )
         }
@@ -931,13 +933,19 @@ object TerminalSessionPool {
         }
     }
 
-    private fun truncateOutput(text: String, maxBytes: Int): String {
-        val truncation = ToolOutputTruncator.truncateTail(text, maxBytes = maxBytes)
-        if (!truncation.truncated) return text
-        return truncation.content + "\n\n[Output truncated: showing last " +
-                truncation.content.count { it == '\n' } + " of " + truncation.totalLines +
-                " lines]"
+    /**
+     * 后台轮询输出统一过滤：截断 + 全量导出（FIXME(async-refactor): 异步
+     * 轮询重构时收口此处；DELTA 模式增量导出语义待重新设计）。
+     */
+    private fun truncateOutput(text: String, maxBytes: Int, exportDir: java.io.File?): String {
+        return ToolOutputTruncator.filterForAgent(fullContent = text, exportDir = exportDir)
     }
+
+    /** 截断导出目录（filesDir/tool_output）；无 Context（单测）时返回 null（不导出）。 */
+    internal var exportDirOverride: java.io.File? = null
+
+    private fun exportDir(): java.io.File? =
+        exportDirOverride ?: ToolOutputTruncator.defaultExportDir()
 
     private fun mergedOutput(result: CommandResult): String {
         return result.stdoutText() + result.stderrText()

--- a/agent-runtime/src/main/java/com/niki914/zafiro/util/ToolOutputTruncator.kt
+++ b/agent-runtime/src/main/java/com/niki914/zafiro/util/ToolOutputTruncator.kt
@@ -1,5 +1,9 @@
 package com.niki914.zafiro.util
 
+import com.niki914.logging.Logger
+import java.io.File
+import kotlin.random.Random
+
 /**
  * 工具输出统一截断器，对齐 pi 的 truncateHead / truncateTail 语义：
  * - 行数 / 字节双限制（2000 行 / 50KB）先到先生效；
@@ -8,6 +12,20 @@ package com.niki914.zafiro.util
  * 调用方负责在 [Truncation.truncated] 时附截断提示。
  */
 object ToolOutputTruncator {
+
+    private const val LOG_TAG = "niki914_nexus_ToolOutputTruncator"
+
+    /** 截断导出目录（App 沙箱 filesDir 下），agent 可用 terminal 回读全量。 */
+    const val EXPORT_DIR_NAME = "tool_output"
+
+    /**
+     * 生产默认导出目录：filesDir/tool_output。无 Context（单测）时返回 null
+     * （不导出），调用方无需各自接 ContextProvider。
+     */
+    fun defaultExportDir(): File? {
+        val context = com.niki914.xposed.api.util.ContextProvider.awaitIfAvailable() ?: return null
+        return File(context.filesDir, EXPORT_DIR_NAME)
+    }
 
     const val DEFAULT_MAX_LINES = 2000
     const val DEFAULT_MAX_BYTES = 50 * 1024
@@ -81,4 +99,67 @@ object ToolOutputTruncator {
         while (start < bytes.size && (bytes[start].toInt() and 0xC0) == 0x80) start++
         return String(bytes, start, bytes.size - start, Charsets.UTF_8)
     }
+
+    /**
+     * 统一入口：过滤全文，超限时导出全量文件并在提示中附绝对路径（对齐 pi）。
+     *
+     * @param fullContent 工具完整输出
+     * @param existingFile 输出已有落盘文件（如 Python 传输文件）：截断时直接
+     *   move 到导出目录（零拷贝）；null 时现场写入导出文件
+     * @param exportDir 导出目录（filesDir/tool_output），null 表示不导出（仅截断）
+     * @return 截断后内容（超限时末尾附 Full output 路径提示）
+     */
+    fun filterForAgent(
+        fullContent: String,
+        existingFile: File? = null,
+        exportDir: File? = null,
+    ): String {
+        val truncation = truncateTail(fullContent)
+        if (!truncation.truncated) {
+            // 传输文件消费完即删（未截断无需导出）
+            existingFile?.takeIf { it.exists() }?.delete()
+            return fullContent
+        }
+        val exportPath = exportTo(fullContent, existingFile, exportDir)
+        return buildString {
+            append(truncation.content)
+            append("\n\n[Output truncated: showing last ")
+            append(truncation.content.count { it == '\n' })
+            append(" of ")
+            append(truncation.totalLines)
+            append(" lines]")
+            if (exportPath != null) {
+                append("\n[Full output: ")
+                append(exportPath)
+                append("]")
+            }
+        }
+    }
+
+    /** 把全量输出落到导出目录：优先 move 已有文件（零拷贝），否则现写。返回绝对路径。 */
+    private fun exportTo(fullContent: String, existingFile: File?, exportDir: File?): String? {
+        if (exportDir == null) return null
+        return try {
+            exportDir.mkdirs()
+            val target = File(exportDir, exportFileName())
+            if (existingFile != null && existingFile.exists()) {
+                if (!existingFile.renameTo(target)) {
+                    // 跨目录 rename 失败（罕见）：降级复制 + 删源
+                    existingFile.copyTo(target, overwrite = true)
+                    existingFile.delete()
+                }
+            } else {
+                target.writeText(fullContent, Charsets.UTF_8)
+            }
+            Logger.d(LOG_TAG, "tool output exported bytes=${target.length()} path=${target.absolutePath}")
+            target.absolutePath
+        } catch (e: Exception) {
+            // 导出失败不阻断主链路：截断提示照常返回，只是没有全量文件可回读
+            Logger.w(LOG_TAG, "tool output export failed: ${e.message}")
+            null
+        }
+    }
+
+    private fun exportFileName(): String =
+        (Random.nextBits(32).toLong() and 0xFFFFFFFFL).toString(16).padStart(8, '0') + ".log"
 }

--- a/agent-runtime/src/main/python/runtime.py
+++ b/agent-runtime/src/main/python/runtime.py
@@ -1,61 +1,12 @@
+import io
+import os
 import sys
 import threading
-from io import StringIO
+import uuid
 
-_CHUNK = 4096
-
-
-class OutputBudget:
-    """Shared byte budget consumed by one or more :class:`BoundedWriter`."""
-
-    def __init__(self, max_bytes: int = 50000):
-        self.max_bytes = max_bytes
-        self.remaining = max_bytes
-
-
-class BoundedWriter:
-    """Write-only buffer that draws from a shared :class:`OutputBudget`.
-
-    Once the budget is exhausted every subsequent write is silently
-    discarded.  A truncation marker is appended by :meth:`getvalue`.
-    """
-
-    def __init__(self, budget: OutputBudget):
-        self._budget = budget
-        self._buf = StringIO()
-        self._truncated = False
-
-    def write(self, s: str) -> int:
-        if self._budget.remaining <= 0:
-            if s:
-                self._truncated = True
-            return len(s)
-        for i in range(0, len(s), _CHUNK):
-            if self._budget.remaining <= 0:
-                break
-            chunk = s[i:i + _CHUNK]
-            b = chunk.encode("utf-8")
-            if len(b) <= self._budget.remaining:
-                self._buf.write(chunk)
-                self._budget.remaining -= len(b)
-            else:
-                # Take as many complete UTF-8 bytes as fit.
-                keep = b[:self._budget.remaining].decode("utf-8", errors="ignore")
-                self._buf.write(keep)
-                self._budget.remaining = 0
-                self._truncated = True
-                break
-        return len(s)
-
-    def flush(self):
-        """No-op — satisfies the TextIO flush() contract (e.g. print(..., flush=True))."""
-        pass
-
-    def getvalue(self) -> str:
-        val = self._buf.getvalue()
-        if self._truncated:
-            val += f"\n\n[output truncated at {self._budget.max_bytes} bytes]"
-        return val
+# Worker 进程自算 cacheDir 子目录（Java 侧无需传路径）。
+# 传输语义：Java 读到内容后即消费（截断时 move 到 filesDir/tool_output
+# 作为导出，否则删除）。cacheDir 系统可随时回收，进程崩溃残留有兜底。
 
 
 class _ThreadRouter:
@@ -63,9 +14,9 @@ class _ThreadRouter:
 
     exec_code never swaps the global stream (concurrent Binder threads
     calling exec_code would otherwise overwrite each other's stdout and
-    cross-wire results). Each exec thread binds its own writer; any other
-    thread — including threads spawned by the exec'd code — falls back to
-    the original stream.
+    cross-wire results). Each exec thread binds its own file handle; any
+    other thread — including threads spawned by the exec'd code — falls
+    back to the original stream.
     """
 
     def __init__(self, fallback):
@@ -91,51 +42,123 @@ class _ThreadRouter:
         return False
 
 
+class _InlineBuffer:
+    """写盘失败时的内存降级缓冲：尾部 1MB 滚动窗口 + StringIO 累计 stderr。"""
+
+    MAX_BYTES = 1024 * 1024
+
+    def __init__(self):
+        self._buf = io.StringIO()
+        self._tail = ""
+
+    def write(self, s: str) -> int:
+        self._buf.write(s)
+        self._tail = (self._tail + s).encode("utf-8")[-self.MAX_BYTES:].decode(
+            "utf-8", errors="ignore"
+        )
+        return len(s)
+
+    def flush(self):
+        pass
+
+    def getvalue(self) -> str:
+        return self._buf.getvalue()
+
+    def get_tail(self) -> str:
+        return self._tail
+
+
 _real_stdout = sys.stdout
 _real_stderr = sys.stderr
 sys.stdout = _ThreadRouter(_real_stdout)
 sys.stderr = _ThreadRouter(_real_stderr)
 
 
-def exec_code(code: str, timeout: float = 30.0) -> str:
+def _new_output_file() -> str:
+    out_dir = os.path.join(os.environ.get("ZAFIRO_CACHE_DIR", "/tmp"), "py_output")
+    os.makedirs(out_dir, exist_ok=True)
+    return os.path.join(out_dir, uuid.uuid4().hex + ".log")
+
+
+def _combine(out: str, err: str) -> str:
+    """stdout + stderr 拼接，与旧 inline 语义一致：stderr 有内容才加分隔符。"""
+    return out + ("\n--- stderr ---\n" + err if err else "")
+
+
+def _exec_result(status: str, file_path: str = "", inline_text: str = "") -> dict:
+    return {"status": status, "file_path": file_path, "inline_text": inline_text}
+
+
+def exec_code(code: str, timeout: float = 30.0) -> dict:
     """Execute Python code in a daemon thread with a timeout.
 
-    Captures stdout and stderr with a shared 50 KB budget. Safe under
-    concurrent invocations: output capture is thread-local.
-    Raises *TimeoutError* if the thread is still alive after *timeout*
-    seconds.
+    stdout + stderr are streamed in full into a per-call file under
+    cacheDir/py_output — no output budget, no Binder payload for content.
+    Safe under concurrent invocations: output capture is thread-local.
 
     Args:
         code: Python source code to execute.
         timeout: Maximum seconds to wait (float, default 30.0).
 
     Returns:
-        Captured stdout + optional stderr.
+        dict: {"status", "file_path", "inline_text"}.
+        - status "ok": normal run, output in file_path
+        - status "timeout": partial output stays in file_path
+        - inline_text is the degraded inline payload used only when writing
+          the file failed (tail-clipped at 1 MB, stdout and stderr separated
+          by a --- stderr --- marker).
     """
-    budget = OutputBudget()
-    out_buf = BoundedWriter(budget)
-    err_buf = BoundedWriter(budget)
+    out_path = None
+    out_f = err_f = None
+    inline_out = inline_err = None
+    try:
+        out_path = _new_output_file()
+        out_f = open(out_path, "w", encoding="utf-8")
+        err_f = open(out_path, "a", encoding="utf-8")
+    except OSError:
+        # ponytail: 写盘失败降级 inline（1MB clip tail），目录不可写属极罕见；
+        # 若降级也高频出现，应把输出改走 Binder 直接回传并砍掉文件链路
+        inline_out = _InlineBuffer()
+        inline_err = _InlineBuffer()
 
     def run():
-        sys.stdout.bind(out_buf)
-        sys.stderr.bind(err_buf)
+        sys.stdout.bind(inline_out if inline_out is not None else out_f)
+        sys.stderr.bind(inline_err if inline_err is not None else err_f)
         try:
             exec(code, {"__builtins__": __builtins__})
         except Exception as e:
             print(f"{type(e).__name__}: {e}", file=sys.stderr)
+        finally:
+            for f in (out_f, err_f):
+                if f is not None:
+                    try:
+                        f.flush()
+                    except Exception:
+                        pass
+            sys.stdout.unbind()
+            sys.stderr.unbind()
 
     t = threading.Thread(target=run)
     t.daemon = True
     t.start()
     t.join(timeout=timeout)
 
-    output = out_buf.getvalue()
-    err_text = err_buf.getvalue()
-    if err_text:
-        output += "\n--- stderr ---\n" + err_text
+    if out_f is not None:
+        # 不 close：worker 线程可能仍在写（超时场景），flush 即可，
+        # 文件随 worker 结束自然完整；残留由 cacheDir 兜底回收。
+        for f in (out_f, err_f):
+            try:
+                f.flush()
+            except Exception:
+                pass
+
     if t.is_alive():
-        raise TimeoutError(
-            f"Execution timed out after {timeout}s\n\n"
-            f"Partial output:\n{output}"
-        )
-    return output
+        return _exec_result("timeout", file_path=out_path or "")
+
+    if out_path is not None:
+        return _exec_result("ok", file_path=out_path)
+
+    # 写盘失败降级：inline 返回尾部 1MB（stdout+stderr 顺序拼接）
+    return _exec_result(
+        "ok", inline_text=_combine(inline_out.get_tail(), inline_err.get_tail())
+    )

--- a/agent-runtime/src/test/java/com/niki914/zafiro/chat/CustomPyToolExecutorTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/zafiro/chat/CustomPyToolExecutorTest.kt
@@ -1,6 +1,7 @@
 package com.niki914.zafiro.chat
 
 import com.niki914.zafiro.chat.agentic.python.CustomPyToolExecutor
+import com.niki914.zafiro.chat.agentic.python.PyExecOutput
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
@@ -24,7 +25,7 @@ class CustomPyToolExecutorTest {
     fun execute_wrapsStdoutInOkJson() = runTest {
         val executor = CustomPyToolExecutor(exec = { code, _ ->
             assertTrue(code.contains("main(**_args)"))
-            "hello"
+            PyExecOutput("hello", null, timedOut = false)
         })
 
         val json = Json.parseToJsonElement(executor.execute(tool, "{\"text\":\"x\"}")).jsonObject
@@ -36,7 +37,7 @@ class CustomPyToolExecutorTest {
 
     @Test
     fun execute_blankArgumentsTreatedAsEmptyObject() = runTest {
-        val executor = CustomPyToolExecutor(exec = { _, _ -> "ok" })
+        val executor = CustomPyToolExecutor(exec = { _, _ -> PyExecOutput("ok", null, timedOut = false) })
 
         val json = Json.parseToJsonElement(executor.execute(tool, "")).jsonObject
 
@@ -58,7 +59,7 @@ class CustomPyToolExecutorTest {
     fun execute_timeout_mapsToTimeoutFailure() = runTest {
         val executor = CustomPyToolExecutor(exec = { _, _ ->
             withTimeout(1) { kotlinx.coroutines.delay(5_000) }
-            ""
+            PyExecOutput("", null, timedOut = false)
         })
 
         val json = Json.parseToJsonElement(executor.execute(tool, "{}")).jsonObject
@@ -72,7 +73,7 @@ class CustomPyToolExecutorTest {
         var received = ""
         val spyExecutor = CustomPyToolExecutor(exec = { code, _ ->
             received = code
-            "ok"
+            PyExecOutput("ok", null, timedOut = false)
         })
 
         spyExecutor.execute(tool, "not-json{")

--- a/agent-runtime/src/test/java/com/niki914/zafiro/chat/ExecutePythonBuiltinTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/zafiro/chat/ExecutePythonBuiltinTest.kt
@@ -2,15 +2,22 @@ package com.niki914.zafiro.chat
 
 import com.niki914.zafiro.chat.agentic.buildin.BuiltinToolRequest
 import com.niki914.zafiro.chat.agentic.buildin.impl.ExecutePythonBuiltin
+import com.niki914.zafiro.chat.agentic.python.PyExecOutput
+import com.niki914.zafiro.chat.agentic.python.PyExecResult
 import com.niki914.zafiro.chat.agentic.shell.ShellCommandSafetyPolicy
 import com.niki914.zafiro.settings.model.RuntimeExecutionRule
 import com.niki914.zafiro.settings.model.RuntimeExecutionRuleEnabledMode
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ExecutePythonBuiltinTest {
+
+    @get:Rule
+    val silentLogger = com.niki914.zafiro.chat.util.SilentLoggerRule()
 
     private fun allowAllPolicy(): ShellCommandSafetyPolicy =
         ShellCommandSafetyPolicy(
@@ -20,11 +27,25 @@ class ExecutePythonBuiltinTest {
 
     private suspend fun invoke(
         argumentsJson: String,
-        executor: suspend (String, Long) -> String = { _, _ -> "" },
+        executor: suspend (String, Long) -> PyExecOutput = { _, _ -> inlineOutput("") },
         safetyPolicy: ShellCommandSafetyPolicy = allowAllPolicy(),
+        exportDir: java.io.File? = null,
     ): String {
-        val tool = ExecutePythonBuiltin(executor = executor, safetyPolicy = safetyPolicy)
+        val tool = ExecutePythonBuiltin(
+            executor = executor,
+            safetyPolicy = safetyPolicy,
+            exportDir = exportDir,
+        )
         return tool.invokeRaw(BuiltinToolRequest("execute_python", argumentsJson))
+    }
+
+    private fun inlineOutput(text: String): PyExecOutput =
+        PyExecOutput(text, null, timedOut = false)
+
+    private fun fileOutput(text: String, dir: java.io.File): PyExecOutput {
+        val f = java.io.File.createTempFile("pyout", ".log", dir)
+        f.writeText(text)
+        return PyExecOutput(text, f, timedOut = false)
     }
 
     // ---- success ----
@@ -36,7 +57,7 @@ class ExecutePythonBuiltinTest {
             executor = { code, timeoutMs ->
                 assertEquals("print('hello')", code)
                 assertEquals(30_000L, timeoutMs)
-                "hello\n"
+                inlineOutput("hello\n")
             },
         )
         assertTrue(result.startsWith("#!tool-result"))
@@ -50,7 +71,7 @@ class ExecutePythonBuiltinTest {
             """{"code":"x=1","timeout_ms":60000}""",
             executor = { _, timeoutMs ->
                 assertEquals(60_000L, timeoutMs)
-                "ok"
+                inlineOutput("ok")
             },
         )
         assertTrue(result.contains("ok"))
@@ -102,16 +123,71 @@ class ExecutePythonBuiltinTest {
     }
 
     @Test
-    fun invoke_executorThrowsTimeoutMessage_returnsTimeoutCode() = runTest {
+    fun invoke_executorThrowsAnyMessage_returnsPythonError() = runTest {
+        // 超时已走结构化路径（PyExecOutput.timedOut），异常不再嗅探字符串：
+        // executor 抛什么都是 PYTHON_ERROR
         val result = invoke(
-            """{"code":"while True: pass"}""",
+            """{"code":"raise"}""",
             executor = { _, _ ->
                 throw RuntimeException("Execution timed out after 30s\n\nPartial output:\nsome output")
             },
         )
         assertTrue(result.contains("#!status: failure"))
-        assertTrue(result.contains("#!code: TIMEOUT"))
-        assertTrue(result.contains("timed out after"))
+        assertTrue(result.contains("#!code: PYTHON_ERROR"))
+    }
+
+    @Test
+    fun invoke_structuredTimeout_appendsPartialNote() = runTest {
+        val result = invoke(
+            """{"code":"while True: pass"}""",
+            executor = { _, _ ->
+                PyExecOutput("partial output\n", null, timedOut = true)
+            },
+        )
+        assertTrue(result.contains("partial output"))
+        assertTrue(result.contains("timed out"))
+    }
+
+    @Test
+    fun invoke_fileOutput_small_notExported() = runTest {
+        val dir = java.nio.file.Files.createTempDirectory("pyexport").toFile()
+        val exportDir = java.nio.file.Files.createTempDirectory("pyexport").toFile()
+        try {
+            val result = invoke(
+                """{"code":"print('ok')"}""",
+                executor = { _, _ -> fileOutput("ok\n", dir) },
+                exportDir = exportDir,
+            )
+            assertTrue(result.contains("ok"))
+            // 未截断：传输文件已被消费删除，导出目录无文件
+            assertFalse(java.io.File(dir, "x").exists())
+            assertEquals(0, exportDir.listFiles()?.size)
+        } finally {
+            dir.deleteRecursively()
+            exportDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun invoke_truncatedOutput_exportsFullFile() = runTest {
+        val dir = java.nio.file.Files.createTempDirectory("pyexport").toFile()
+        val exportDir = java.nio.file.Files.createTempDirectory("pyexport").toFile()
+        try {
+            val big = "x\n".repeat(30000) // 60KB > 50KB
+            val result = invoke(
+                """{"code":"print('big')"}""",
+                executor = { _, _ -> fileOutput(big, dir) },
+                exportDir = exportDir,
+            )
+            assertTrue(result.contains("[Output truncated"))
+            assertTrue(result.contains("[Full output: "))
+            // 传输文件被 move 到导出目录
+            val exported = exportDir.listFiles()!!.single()
+            assertEquals(big, exported.readText())
+        } finally {
+            dir.deleteRecursively()
+            exportDir.deleteRecursively()
+        }
     }
 
     // ---- safety policy ----
@@ -144,7 +220,7 @@ class ExecutePythonBuiltinTest {
     fun invoke_policyAllows_continuesToExecute() = runTest {
         val result = invoke(
             """{"code":"print('safe')"}""",
-            executor = { _, _ -> "safe output" },
+            executor = { _, _ -> inlineOutput("safe output") },
         )
         assertTrue(result.contains("#!status: success"))
         assertTrue(result.contains("safe output"))
@@ -158,7 +234,7 @@ class ExecutePythonBuiltinTest {
             """{"code":"x","timeout_ms":-5}""",
             executor = { _, timeoutMs ->
                 assertEquals(1_000L, timeoutMs)
-                ""
+                inlineOutput("")
             },
         )
     }
@@ -169,7 +245,7 @@ class ExecutePythonBuiltinTest {
             """{"code":"x","timeout_ms":999999}""",
             executor = { _, timeoutMs ->
                 assertEquals(120_000L, timeoutMs)
-                ""
+                inlineOutput("")
             },
         )
     }

--- a/agent-runtime/src/test/java/com/niki914/zafiro/chat/LocalToolExecutorTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/zafiro/chat/LocalToolExecutorTest.kt
@@ -14,6 +14,7 @@ import com.niki914.zafiro.chat.agentic.buildin.RawJsonBuiltinTool
 import com.niki914.zafiro.chat.agentic.buildin.TextToolResult
 import com.niki914.zafiro.chat.agentic.buildin.TextToolResultCodec
 import com.niki914.zafiro.chat.agentic.python.CustomPyToolExecutor
+import com.niki914.zafiro.chat.agentic.python.PyExecOutput
 import com.niki914.zafiro.chat.util.SilentLoggerRule
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -69,7 +70,9 @@ class LocalToolExecutorTest {
     @Test
     fun execute_pySuccess_mapsToSuccessOutcome() = runBlocking {
         val py = LocalTool.Py("py_a", "desc", "print('hi')", null)
-        val pyExec = fakePyExecutor { _, _ -> "{\"ok\":true,\"stdout\":\"hi\"}" }
+        val pyExec = fakePyExecutor { _, _ ->
+            PyExecOutput("{\"ok\":true,\"stdout\":\"hi\"}", null, timedOut = false)
+        }
         val executor = LocalToolExecutor(
             customPyToolExecutor = pyExec,
             currentTools = { pyResolved(listOf(py)) },
@@ -86,7 +89,7 @@ class LocalToolExecutorTest {
         val pyExec = fakePyExecutor { _, _ ->
             throw RuntimeException("denied")
             @Suppress("UNREACHABLE_CODE")
-            ""
+            PyExecOutput("", null, timedOut = false)
         }
         val executor = LocalToolExecutor(
             customPyToolExecutor = pyExec,
@@ -268,7 +271,9 @@ class LocalToolExecutorTest {
     @Test
     fun custom_py_toolsWrite_inlineTool_executesViaInlineFallback() = runBlocking {
         val inline = mutableMapOf<String, LocalTool.Py>()
-        val pyExec = fakePyExecutor { _, _ -> "{\"ok\":true,\"stdout\":\"ran\"}" }
+        val pyExec = fakePyExecutor { _, _ ->
+            PyExecOutput("{\"ok\":true,\"stdout\":\"ran\"}", null, timedOut = false)
+        }
         val executor = LocalToolExecutor(
             customPyToolExecutor = pyExec,
             currentTools = { ResolvedTools() }, // snapshot 里没有该工具
@@ -283,7 +288,7 @@ class LocalToolExecutorTest {
     }
 
     private fun fakePyExecutor(
-        fake: suspend (String, Long) -> String,
+        fake: suspend (String, Long) -> PyExecOutput,
     ): CustomPyToolExecutor = CustomPyToolExecutor(exec = fake)
 
     private class StaticBuiltinTool(

--- a/agent-runtime/src/test/java/com/niki914/zafiro/chat/PyMetaToolsBuiltinTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/zafiro/chat/PyMetaToolsBuiltinTest.kt
@@ -2,6 +2,7 @@ package com.niki914.zafiro.chat
 
 import com.niki914.zafiro.chat.agentic.buildin.BuiltinToolRequest
 import com.niki914.zafiro.chat.agentic.buildin.impl.PyMetaToolsBuiltin
+import com.niki914.zafiro.chat.agentic.python.PyExecOutput
 import com.niki914.zafiro.settings.RuntimeEnvironment
 import com.niki914.zafiro.settings.model.RuntimeCustomPyTool
 import kotlinx.coroutines.test.runTest
@@ -21,8 +22,12 @@ class PyMetaToolsBuiltinTest {
     }
 
     /** 双身份 fake exec：introspection 请求返回签名 JSON，其余按 runner 语义回 stdout。 */
-    private val exec: suspend (code: String, timeoutMs: Long) -> String = { code, _ ->
-        if (code.contains("inspect.signature")) INTROSPECTION_OK else "hello"
+    private val exec: suspend (code: String, timeoutMs: Long) -> PyExecOutput = { code, _ ->
+        if (code.contains("inspect.signature")) {
+            PyExecOutput(INTROSPECTION_OK, null, timedOut = false)
+        } else {
+            PyExecOutput("hello", null, timedOut = false)
+        }
     }
 
     private fun gateway() =
@@ -59,8 +64,11 @@ class PyMetaToolsBuiltinTest {
         val tool = PyMetaToolsBuiltin(
             exec = { code, _ ->
                 if (code.contains("inspect.signature")) {
-                    """{"error":"UNANNOTATED_PARAMS","message":"Parameters need basic type annotations (str/int/float/bool): query"}"""
-                } else "ok"
+                    PyExecOutput(
+                        """{"error":"UNANNOTATED_PARAMS","message":"Parameters need basic type annotations (str/int/float/bool): query"}""",
+                        null, timedOut = false
+                    )
+                } else PyExecOutput("ok", null, timedOut = false)
             },
             reservedNames = setOf("terminal"),
         )
@@ -162,7 +170,7 @@ class PyMetaToolsBuiltinTest {
         val tool = PyMetaToolsBuiltin(
             exec = { code, _ ->
                 ranCode = code
-                "hello"
+                PyExecOutput("hello", null, timedOut = false)
             },
             reservedNames = setOf("terminal"),
         )

--- a/agent-runtime/src/test/java/com/niki914/zafiro/chat/agentic/python/PyRuntimeTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/zafiro/chat/agentic/python/PyRuntimeTest.kt
@@ -23,7 +23,7 @@ class PyRuntimeTest {
     private class FakeWorker : IPythonWorkerService {
         override fun asBinder(): IBinder = error("not used in tests")
 
-        var execResult: String? = "ok"
+        var execResult: PyExecResult = PyExecResult(PyExecResult.Status.OK, null, "ok")
         var execBlockMs: Long = 0L
         var pingBlockMs: Long = 0L
         var pingCalls = 0
@@ -31,7 +31,7 @@ class PyRuntimeTest {
         var killCount = 0
         var execCalls = 0
 
-        override fun exec(code: String?, timeoutMs: Long): String? {
+        override fun exec(code: String?, timeoutMs: Long): PyExecResult {
             execCalls++
             if (execBlockMs > 0) Thread.sleep(execBlockMs)
             return execResult
@@ -61,7 +61,7 @@ class PyRuntimeTest {
 
         val result = PyRuntime.exec("print('hi')", 30_000L)
 
-        assertEquals("ok", result)
+        assertEquals("ok", result.output)
         assertEquals(1, fake.execCalls)
         assertFalse(fake.killed)
     }
@@ -69,11 +69,15 @@ class PyRuntimeTest {
     @Test
     fun `exec normal timeout returns TimeoutError text without killing`() = runBlocking {
         val fake = FakeWorker().also { PyRuntime.testService = it }
-        fake.execResult = "Execution timed out after 30s\n\nPartial output:\n"
+        fake.execResult = PyExecResult(
+            PyExecResult.Status.TIMEOUT, null,
+            "Execution timed out after 30s\n\nPartial output:\n"
+        )
 
         val result = PyRuntime.exec("import time; time.sleep(999)", 30_000L)
 
-        assertTrue(result.contains("timed out after"))
+        assertTrue(result.output.contains("timed out after"))
+        assertTrue(result.timedOut)
         assertFalse(fake.killed)
     }
 
@@ -109,7 +113,7 @@ class PyRuntimeTest {
         // 测试模式无法真正重连：kill 后复用同一 fake 重试（生产路径是重新 bind 新进程）
         assertTrue(fake.killed)
         assertEquals(1, fake.execCalls)
-        assertEquals("ok", result)
+        assertEquals("ok", result.output)
     }
 
     @Test

--- a/agent-runtime/src/test/java/com/niki914/zafiro/util/ToolOutputTruncatorTest.kt
+++ b/agent-runtime/src/test/java/com/niki914/zafiro/util/ToolOutputTruncatorTest.kt
@@ -3,9 +3,14 @@ package com.niki914.zafiro.util
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
+import java.io.File
 
 class ToolOutputTruncatorTest {
+
+    @get:Rule
+    val silentLogger = com.niki914.zafiro.chat.util.SilentLoggerRule()
 
     @Test
     fun head_withinLimits_returnsUntouched() {
@@ -87,5 +92,68 @@ class ToolOutputTruncatorTest {
         assertTrue(result.truncated)
         // 尾部 10 字节 = 第二行（3字×3字节+换行1字节=10字节），边界不切半个字符
         assertEquals("第二行", result.content)
+    }
+
+    // ---- filterForAgent（统一入口：截断 + 导出 + 消费）----
+
+    private fun tempDir(): File = java.nio.file.Files.createTempDirectory("export").toFile()
+
+    @Test
+    fun filter_smallOutput_noExportAndFileDeleted() {
+        val exportDir = tempDir()
+        val transfer = File.createTempFile("tmp", ".log", tempDir())
+        transfer.writeText("ok\n")
+
+        val result = ToolOutputTruncator.filterForAgent("ok\n", transfer, exportDir)
+
+        assertEquals("ok\n", result)
+        assertFalse(transfer.exists()) // 未截断：传输文件消费后即删
+        assertEquals(0, exportDir.listFiles()?.size)
+    }
+
+    @Test
+    fun filter_truncated_movesTransferFileToExportDir() {
+        val exportDir = tempDir()
+        val transfer = File.createTempFile("tmp", ".log", tempDir())
+        val big = "x\n".repeat(30000)
+        transfer.writeText(big)
+
+        val result = ToolOutputTruncator.filterForAgent(big, transfer, exportDir)
+
+        assertTrue(result.contains("[Output truncated"))
+        assertTrue(result.contains("[Full output: "))
+        assertFalse(transfer.exists()) // 零拷贝 move
+        val exported = exportDir.listFiles()!!.single()
+        assertEquals(big, exported.readText())
+    }
+
+    @Test
+    fun filter_truncatedWithoutFile_writesExportFile() {
+        val exportDir = tempDir()
+        val big = "y".repeat(60_000)
+
+        val result = ToolOutputTruncator.filterForAgent(big, existingFile = null, exportDir = exportDir)
+
+        assertTrue(result.contains("[Full output: "))
+        val exported = exportDir.listFiles()!!.single()
+        assertEquals(big, exported.readText())
+    }
+
+    @Test
+    fun filter_truncatedWithoutExportDir_noPathHint() {
+        val big = "z\n".repeat(30000)
+
+        val result = ToolOutputTruncator.filterForAgent(big, existingFile = null, exportDir = null)
+
+        assertTrue(result.contains("[Output truncated"))
+        assertFalse(result.contains("[Full output"))
+    }
+
+    @Test
+    fun filter_exportFileName_is8HexDotLog() {
+        val exportDir = tempDir()
+        ToolOutputTruncator.filterForAgent("z\n".repeat(30000), exportDir = exportDir)
+        val name = exportDir.listFiles()!!.single().name
+        assertTrue(name.matches(Regex("[0-9a-f]{8}\\.log")))
     }
 }

--- a/agent-runtime/src/test/python/test_runtime.py
+++ b/agent-runtime/src/test/python/test_runtime.py
@@ -1,9 +1,10 @@
 """Unit tests for runtime.py — executable with plain unittest (no pytest)."""
 
+import os
+import shutil
 import sys
+import tempfile
 import unittest
-import time
-from io import StringIO
 
 # Ensure the runtime module is importable from the source tree.
 # The Gradle task sets PYTHONPATH; when running locally the repo root
@@ -14,63 +15,83 @@ except ImportError:
     sys.path.insert(0, "agent-runtime/src/main/python")
     import runtime
 
+_CACHE_DIR = tempfile.mkdtemp(prefix="runtime_test_cache_")
+os.environ["ZAFIRO_CACHE_DIR"] = _CACHE_DIR
+import importlib
+
+importlib.reload(runtime)
+
 
 class ExecCodeTest(unittest.TestCase):
-    """Tests for runtime.exec_code()."""
+    """Tests for runtime.exec_code() — file-based output capture."""
 
-    def test_captures_stdout(self):
-        output = runtime.exec_code("print('hello')")
-        self.assertIn("hello", output)
+    def tearDown(self):
+        py_output = os.path.join(_CACHE_DIR, "py_output")
+        if os.path.isdir(py_output):
+            shutil.rmtree(py_output)
 
-    def test_captures_stderr(self):
-        output = runtime.exec_code(
-            "import sys; print('err', file=sys.stderr)"
+    def test_returns_file_path_and_file_holds_stdout(self):
+        result = runtime.exec_code("print('hello')")
+        self.assertEqual("ok", result["status"])
+        path = result["file_path"]
+        self.assertTrue(os.path.isfile(path))
+        with open(path, encoding="utf-8") as f:
+            self.assertIn("hello", f.read())
+
+    def test_file_holds_stderr_after_stdout(self):
+        result = runtime.exec_code(
+            'import sys; print("err", file=sys.stderr)'
         )
-        self.assertIn("--- stderr ---", output)
-        self.assertIn("err", output)
+        self.assertEqual("ok", result["status"])
+        with open(result["file_path"], encoding="utf-8") as f:
+            content = f.read()
+        self.assertIn("err", content)
 
     def test_empty_output(self):
-        output = runtime.exec_code("x = 1")
-        self.assertEqual("", output.strip())
+        result = runtime.exec_code("x = 1")
+        self.assertEqual("ok", result["status"])
+        with open(result["file_path"], encoding="utf-8") as f:
+            self.assertEqual("", f.read())
+        self.assertEqual("", result["inline_text"])
 
     def test_exception_writes_to_stderr(self):
-        output = runtime.exec_code('raise ValueError("bad")')
-        self.assertIn("--- stderr ---", output)
-        self.assertIn("ValueError", output)
-        self.assertIn("bad", output)
+        result = runtime.exec_code('raise ValueError("bad")')
+        with open(result["file_path"], encoding="utf-8") as f:
+            content = f.read()
+        self.assertIn("ValueError", content)
+        self.assertIn("bad", content)
 
-    def test_returns_output_including_stderr(self):
-        output = runtime.exec_code(
-            'print("ok"); import sys; print("err", file=sys.stderr)'
-        )
-        self.assertIn("ok", output)
-        self.assertIn("err", output)
-        # stdout should appear before stderr separator
-        self.assertLess(
-            output.index("ok"),
-            output.index("--- stderr ---"),
-        )
+    def test_large_output_not_truncated(self):
+        """50KB+ 输出必须全量落盘（新方案的核心承诺）。"""
+        result = runtime.exec_code('print("x" * 60000)')
+        with open(result["file_path"], encoding="utf-8") as f:
+            content = f.read()
+        self.assertEqual(60001, len(content))
 
-    def test_timeout_raises_timeouterror(self):
-        with self.assertRaises(TimeoutError) as ctx:
-            runtime.exec_code("import time; time.sleep(2)", timeout=0.1)
-        self.assertIn("timed out after", str(ctx.exception))
-        self.assertIn("Partial output", str(ctx.exception))
+    def test_timeout_returns_status_timeout_with_partial_output(self):
+        """超时不再抛异常：status=timeout，部分输出留在文件里。"""
+        result = runtime.exec_code(
+            'import time; print("line1", flush=True); time.sleep(2)', timeout=0.2
+        )
+        self.assertEqual("timeout", result["status"])
+        self.assertNotEqual("", result["file_path"])
+        with open(result["file_path"], encoding="utf-8") as f:
+            self.assertIn("line1", f.read())
 
     def test_consecutive_calls_are_independent(self):
         """Variables from a previous call must not leak into the next."""
         runtime.exec_code("x = 42")
-        output = runtime.exec_code("print(x)")
-        self.assertNotIn("42", output)
-        self.assertIn("NameError", output)
+        result = runtime.exec_code("print(x)")
+        with open(result["file_path"], encoding="utf-8") as f:
+            content = f.read()
+        self.assertNotIn("42", content)
+        self.assertIn("NameError", content)
 
     def test_stdout_restored_after_timeout(self):
         """stdout must point to the original stream even after timeout."""
         orig = sys.stdout
-        try:
-            runtime.exec_code("import time; time.sleep(2)", timeout=0.1)
-        except TimeoutError:
-            pass
+        result = runtime.exec_code("import time; time.sleep(2)", timeout=0.1)
+        self.assertEqual("timeout", result["status"])
         self.assertIs(sys.stdout, orig)
 
     def test_stdout_restored_after_exception(self):
@@ -80,123 +101,67 @@ class ExecCodeTest(unittest.TestCase):
         self.assertIs(sys.stdout, orig)
 
     def test_print_flush_true(self):
-        """print(..., flush=True) must not crash BoundedWriter."""
-        output = runtime.exec_code('print("hello", flush=True)')
-        self.assertIn("hello", output)
+        """print(..., flush=True) must not crash the file writer."""
+        result = runtime.exec_code('print("hello", flush=True)')
+        with open(result["file_path"], encoding="utf-8") as f:
+            self.assertIn("hello", f.read())
+
+    def test_degraded_inline_when_write_fails(self):
+        """cacheDir 不可写时降级 inline（尾部 1MB）。"""
+        cache = tempfile.mkdtemp(prefix="runtime_degraded_")
+        os.chmod(cache, 0o500)  # 不可写 → makedirs(py_output) 失败
+        old = os.environ["ZAFIRO_CACHE_DIR"]
+        try:
+            os.environ["ZAFIRO_CACHE_DIR"] = cache
+            importlib.reload(runtime)
+            result = runtime.exec_code(
+                'print("inline hello"); import sys; print("e1", file=sys.stderr)'
+            )
+            self.assertEqual("ok", result["status"])
+            self.assertEqual("", result["file_path"])
+            self.assertIn("inline hello", result["inline_text"])
+            self.assertIn("e1", result["inline_text"])
+        finally:
+            os.environ["ZAFIRO_CACHE_DIR"] = old
+            os.chmod(cache, 0o755)
+            shutil.rmtree(cache)
+            importlib.reload(runtime)
+
+    def test_concurrent_calls_write_separate_files(self):
+        """并发 exec 的输出各自独立成文件（thread-local 路由）。"""
+        results = [None, None]
+        import threading
+
+        def run(i, code):
+            results[i] = runtime.exec_code(code)
+
+        t1 = threading.Thread(target=run, args=(0, "print('from-t1')"))
+        t2 = threading.Thread(target=run, args=(1, "print('from-t2')"))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+        for result in results:
+            self.assertEqual("ok", result["status"])
+        with open(results[0]["file_path"], encoding="utf-8") as f:
+            self.assertIn("from-t1", f.read())
+        with open(results[1]["file_path"], encoding="utf-8") as f:
+            self.assertIn("from-t2", f.read())
 
 
-class OutputBudgetTest(unittest.TestCase):
-    """Tests for runtime.OutputBudget."""
+class InlineBufferTest(unittest.TestCase):
+    """Tests for runtime._InlineBuffer (degraded in-memory capture)."""
 
-    def test_initial_remaining(self):
-        b = runtime.OutputBudget(max_bytes=1000)
-        self.assertEqual(b.remaining, 1000)
-        self.assertEqual(b.max_bytes, 1000)
+    def test_getvalue_and_get_tail(self):
+        buf = runtime._InlineBuffer()
+        buf.write("hello")
+        self.assertIn("hello", buf.getvalue())
+        self.assertIn("hello", buf.get_tail())
 
-
-class BoundedWriterTest(unittest.TestCase):
-    """Tests for runtime.BoundedWriter."""
-
-    def _budget(self, max_bytes: int) -> runtime.OutputBudget:
-        return runtime.OutputBudget(max_bytes=max_bytes)
-
-    def test_writes_within_limit(self):
-        w = runtime.BoundedWriter(self._budget(100))
-        w.write("hello")
-        self.assertIn("hello", w.getvalue())
-        self.assertNotIn("truncated", w.getvalue())
-
-    def test_truncation_marker(self):
-        budget = self._budget(10)
-        w = runtime.BoundedWriter(budget)
-        w.write("1234567890")  # exactly 10 bytes, fits
-        w.write("abc")          # exceeds → truncated
-        val = w.getvalue()
-        self.assertIn("1234567890", val)
-        self.assertIn("truncated", val)
-
-    def test_write_after_truncation_discarded(self):
-        budget = self._budget(5)
-        w = runtime.BoundedWriter(budget)
-        w.write("12")
-        w.write("34")
-        w.write("abc")  # should be discarded
-        self.assertNotIn("abc", w.getvalue())
-
-    def test_multi_byte_boundary(self):
-        """Truncation on a multi-byte boundary must decode cleanly."""
-        budget = self._budget(6)
-        w = runtime.BoundedWriter(budget)
-        w.write("你好世界")  # 四个中文字符 = 12 bytes
-        val = w.getvalue()
-        self.assertIsInstance(val, str)
-        self.assertIn("truncated", val)
-
-    def test_empty_writer(self):
-        w = runtime.BoundedWriter(self._budget(50))
-        self.assertEqual("", w.getvalue())
-
-    def test_large_single_write_keeps_prefix(self):
-        """A single oversized write keeps as many chars as fit."""
-        budget = self._budget(10)
-        w = runtime.BoundedWriter(budget)
-        w.write("1234567890abc")  # "1234567890" = 10 bytes, "abc" exceeds
-        val = w.getvalue()
-        self.assertIn("1234567890", val)
-        self.assertIn("truncated", val)
-        self.assertNotIn("abc", val)
-
-    def test_shared_budget_stdout_stderr(self):
-        """stdout and stderr share the same budget."""
-        budget = self._budget(20)
-        out = runtime.BoundedWriter(budget)
-        err = runtime.BoundedWriter(budget)
-        out.write("A" * 15)  # 15 bytes
-        err.write("B" * 10)  # 10 bytes requested, only 5 remain
-        self.assertIn("A" * 15, out.getvalue())
-        self.assertIn("B" * 5, err.getvalue())  # only first 5 B's
-        # Total should not exceed 20 + overhead
-        total = len(out.getvalue().encode("utf-8")) + len(err.getvalue().encode("utf-8"))
-        self.assertLessEqual(total, 120)  # generous margin for truncation markers
-
-    def test_flush_is_noop(self):
-        """flush() must exist so print(..., flush=True) doesn't crash."""
-        w = runtime.BoundedWriter(self._budget(100))
-        w.flush()  # must not raise
-        w.write("hello")
-        w.flush()
-        self.assertIn("hello", w.getvalue())
-
-
-class ExecCodeOutputCappingTest(unittest.TestCase):
-    """Verify that BoundedWriter caps stdout during exec_code()."""
-
-    def test_large_output_is_capped(self):
-        """50 KB of output should be capped at ~50 KB."""
-        output = runtime.exec_code(
-            "print('x' * 60_000)",
-            timeout=10.0,
-        )
-        self.assertIn("truncated", output)
-        self.assertLessEqual(len(output.encode("utf-8")), 55_000)  # small margin
-
-    def test_small_output_not_capped(self):
-        output = runtime.exec_code(
-            "print('hello')",
-            timeout=10.0,
-        )
-        self.assertNotIn("truncated", output)
-
-    def test_stderr_also_draws_from_budget(self):
-        """Writing to stderr consumes the same cap as stdout."""
-        # Fill budget with stdout, then write to stderr.
-        code = (
-            "import sys\n"
-            "print('x' * 45_000)\n"       # stdout takes ~45 KB
-            "print('y' * 20_000, file=sys.stderr)"  # stderr barely fits
-        )
-        output = runtime.exec_code(code, timeout=10.0)
-        self.assertIn("truncated", output)
+    def test_tail_is_clipped(self):
+        buf = runtime._InlineBuffer()
+        buf.write("x" * (runtime._InlineBuffer.MAX_BYTES + 100))
+        self.assertLessEqual(len(buf.get_tail().encode("utf-8")), runtime._InlineBuffer.MAX_BYTES)
 
 
 if __name__ == "__main__":

--- a/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
@@ -1095,6 +1095,7 @@ class CustomPyToolApi internal constructor(
     private suspend fun introspectMain(code: String): PyIntrospection {
         val output = try {
             PyRuntime.exec(CustomPyToolHarness.buildIntrospection(code), INTROSPECTION_TIMEOUT_MS)
+                .output
         } catch (e: CancellationException) {
             throw e
         } catch (t: Throwable) {

--- a/xposed-api/src/main/java/com/niki914/xposed/api/util/XProvider.kt
+++ b/xposed-api/src/main/java/com/niki914/xposed/api/util/XProvider.kt
@@ -11,4 +11,7 @@ abstract class XProvider<T> {
     suspend fun await(): T {
         return contextDeferred.await()
     }
+
+    /** 非挂起快照读：未 provide 时返回 null，供无法 suspend 的路径（同步过滤器等）使用。 */
+    fun awaitIfAvailable(): T? = if (contextDeferred.isCompleted) contextDeferred.getCompleted() else null
 }


### PR DESCRIPTION
## Summary

- Python exec 输出不再经 Binder 传内容：`runtime.py` 全量写入 `cacheDir/py_output/<uuid>.log`（取消 50KB 输出预算），Binder 返回结构化 `PyExecResult`（OK / TIMEOUT / EXEC_ERROR），正常路径只传文件路径
- 写盘失败降级：Python 侧尾部 1MB clip 后走 inline 字段，Java 不感知裁剪逻辑，Binder 返回值不再承载两种语义
- 截断（2000 行 / 50KB）与全量导出统一收敛到 `ToolOutputTruncator.filterForAgent`：截断时传输文件零拷贝 move 到 `filesDir/tool_output`（无则现场写入），提示追加 `[Full output: <path>]`（对齐 pi）
- 超时改为返回 `status=timeout` + 部分输出文件路径，删除 Java 侧 `contains("timed out after")` 字符串嗅探；部分输出与正常输出走同一条过滤+导出链路
- `readSession` 默认上限 8KB → 50KB 对齐（异步轮询重构时收口，已标 FIXME）；terminal 前台输出接入统一过滤（行为变更：前台输出从此会被截断）
- worker 启动时设置 `ZAFIRO_CACHE_DIR`，传输文件落 App 沙箱 cacheDir，零存储权限
- `filesDir/tool_output` 注入 PromptComposer 环境块，agent 可用 terminal 回读全量

## Test plan

- [x] Python 单测 14/14（路径返回、全量落盘、超时 status、降级 inline、并发独立文件）
- [x] `:agent-runtime` JVM 单测 410/410（Truncator 截断/导出/降级三分支、超时结构化）
- [x] APK 包内 runtime.pyc 验证为新逻辑
- [ ] 真机 8 项矩阵（Python/Terminal × 不截断/超行数/超体积/双超，重点验证 Python 路径出现 `[Full output: ...]`）

注：`:app` 单测编译失败为基线问题（main 上 `ForkKind.Rewind` 未同步到 `HomeChatControllerTest`），与本 PR 无关。