### PR TITLE
feat: always show message actions

### DIFF
--- a/app/src/main/java/com/niki914/zafiro/app/MainActivity.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.lifecycleScope
+import com.niki914.logging.Logger
 import com.niki914.zafiro.app.ui.ZafiroApp
 import com.niki914.zafiro.app.ui.model.AppLaunchDecision
 import com.niki914.zafiro.app.ui.model.ThemeController
@@ -47,6 +48,9 @@ class MainActivity : AppCompatActivity() {
             val decision = AppLaunchDecision.resolve(startupAssistantUi)
             // 同步读主题偏好：深色模式冷启动首帧不能闪白
             ThemeController.load()
+            // 回填型设置 flow 的冷启动回填（首帧真值，防“进设置页才生效”类 bug）
+            runCatching { XRepo.hydrateSettings() }
+                .onFailure { Logger.w("niki914_nexus_Main", "hydrate failed ${it.message}") }
             decision
         }
         applyLanguageTag(launchDecision.languageTag)

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/GeneralSettingsContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/GeneralSettingsContent.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.runBlocking
 private const val LANGUAGE_ROW_ID = "general.language"
 private const val APPEARANCE_ROW_ID = "general.appearance"
 private const val LOAD_LAST_ROW_ID = "general.load_last"
+private const val ALWAYS_SHOW_ACTIONS_ROW_ID = "general.always_show_message_actions"
 private const val IDLE_TIMEOUT_ROW_ID = "general.idle_timeout"
 private const val RETRY_ATTEMPTS_ROW_ID = "general.retry_attempts"
 private const val KEEP_SCREEN_ON_ROW_ID = "general.keep_screen_on"
@@ -70,6 +71,7 @@ fun GeneralSettingsContent(onPush: (ZafiroPage) -> Unit = {}) {
     val scope = rememberCoroutineScope()
     var savedLanguageTag by rememberSaveable { mutableStateOf<String?>(null) }
     var loadLastConversation by rememberSaveable { mutableStateOf(false) }
+    var alwaysShowMessageActions by rememberSaveable { mutableStateOf(true) }
     var showLanguageDialog by rememberSaveable { mutableStateOf(false) }
     var idleTimeoutSeconds by rememberSaveable { mutableStateOf(60L) }
     var retryMaxAttempts by rememberSaveable { mutableStateOf(3) }
@@ -81,6 +83,7 @@ fun GeneralSettingsContent(onPush: (ZafiroPage) -> Unit = {}) {
         runCatching {
             savedLanguageTag = XRepo.languageTag()
             loadLastConversation = XRepo.loadLastConversationOnStartup()
+            alwaysShowMessageActions = XRepo.alwaysShowMessageActions()
             idleTimeoutSeconds = XRepo.llmIdleTimeoutSeconds()
             retryMaxAttempts = XRepo.llmRetryMaxAttempts()
             keepScreenOn = XRepo.keepScreenOn()
@@ -114,6 +117,11 @@ fun GeneralSettingsContent(onPush: (ZafiroPage) -> Unit = {}) {
                         id = LOAD_LAST_ROW_ID,
                         title = stringResource(R.string.ui_settings_general_load_last_conversation),
                         checked = loadLastConversation,
+                    ),
+                    SettingsRowSpec.Toggle(
+                        id = ALWAYS_SHOW_ACTIONS_ROW_ID,
+                        title = stringResource(R.string.ui_settings_general_always_show_message_actions),
+                        checked = alwaysShowMessageActions,
                     ),
                     SettingsRowSpec.Navigation(
                         id = IDLE_TIMEOUT_ROW_ID,
@@ -155,6 +163,11 @@ fun GeneralSettingsContent(onPush: (ZafiroPage) -> Unit = {}) {
                         loadLastConversation = action.checked
                         scope.launch {
                             XRepo.setLoadLastConversationOnStartup(action.checked)
+                        }
+                    } else if (action.id == ALWAYS_SHOW_ACTIONS_ROW_ID) {
+                        alwaysShowMessageActions = action.checked
+                        scope.launch {
+                            XRepo.setAlwaysShowMessageActions(action.checked)
                         }
                     } else if (action.id == KEEP_SCREEN_ON_ROW_ID) {
                         keepScreenOn = action.checked

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/HomeChatComponents.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/HomeChatComponents.kt
@@ -1,9 +1,11 @@
 package com.niki914.zafiro.app.ui.content
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -80,6 +82,7 @@ import com.niki914.uikit.infra.shape.G2CardShape
 import com.niki914.uikit.infra.shape.G2FieldShape
 import com.niki914.zafiro.app.R
 import com.niki914.zafiro.app.ui.model.ActionSource
+import com.niki914.zafiro.app.ui.model.MessageActionsDisplay
 import com.niki914.zafiro.app.ui.model.HomeChatImage
 import com.niki914.zafiro.chat.LlmErrorCode
 
@@ -522,6 +525,7 @@ fun LiquidChatComposer(
 @Composable
 fun TurnActionRow(
     source: ActionSource,
+    display: MessageActionsDisplay,
     onCopy: () -> Unit,
     onReGenerate: () -> Unit,
     onFork: () -> Unit,
@@ -529,6 +533,8 @@ fun TurnActionRow(
     modifier: Modifier = Modifier,
 ) {
     val isAgent = source == ActionSource.Agent
+    // Always 模式：去背景只留图标，融入背景降噪音
+    val iconOnly = display == MessageActionsDisplay.Always
 
     Box(
         modifier = modifier.fillMaxWidth(),
@@ -542,28 +548,33 @@ fun TurnActionRow(
                 icon = Icons.Default.ContentCopy,
                 contentDescription = stringResource(R.string.ui_home_action_copy_content_description),
                 onClick = onCopy,
+                iconOnly = iconOnly,
             )
             if (isAgent) {
                 ActionButton(
                     icon = Icons.Default.Refresh,
                     contentDescription = stringResource(R.string.ui_home_action_regenerate_content_description),
                     onClick = onReGenerate,
+                    iconOnly = iconOnly,
                 )
                 ActionButton(
                     icon = Icons.AutoMirrored.Filled.CallSplit,
                     contentDescription = stringResource(R.string.ui_home_action_fork_content_description),
                     onClick = onFork,
+                    iconOnly = iconOnly,
                 )
             } else {
                 ActionButton(
                     icon = Icons.Default.Refresh,
                     contentDescription = stringResource(R.string.ui_home_action_regenerate_content_description),
                     onClick = onReGenerate,
+                    iconOnly = iconOnly,
                 )
                 ActionButton(
                     icon = Icons.Default.Undo,
                     contentDescription = stringResource(R.string.ui_home_action_rewind_content_description),
                     onClick = onRewind,
+                    iconOnly = iconOnly,
                 )
             }
         }
@@ -575,25 +586,36 @@ private fun ActionButton(
     icon: ImageVector,
     contentDescription: String,
     onClick: () -> Unit,
+    iconOnly: Boolean,
 ) {
     val colorScheme = MaterialTheme.colorScheme
-    val containerColor = colorScheme.surfaceVariant.copy(alpha = 0.72f)
-    val contentColor = colorScheme.onSurfaceVariant.copy(alpha = 0.82f)
     val shape = G2CardShape(14.dp)
 
     Box(
         modifier = Modifier
             .size(38.dp)
-            .clip(shape)
-            .background(containerColor, shape)
-            .clickable(onClick = onClick),
+            .then(
+                if (iconOnly) {
+                    Modifier
+                } else {
+                    Modifier
+                        .clip(shape)
+                        .background(colorScheme.surfaceVariant.copy(alpha = 0.72f), shape)
+                }
+            )
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                // iconOnly 无背景：波纹会重新暴露按钮矩形，直接禁用点击指示
+                indication = if (iconOnly) null else LocalIndication.current,
+                onClick = onClick,
+            ),
         contentAlignment = Alignment.Center,
     ) {
         Icon(
             imageVector = icon,
             contentDescription = contentDescription,
             modifier = Modifier.size(20.dp),
-            tint = contentColor,
+            tint = colorScheme.onSurfaceVariant.copy(alpha = 0.82f),
         )
     }
 }

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
@@ -103,6 +103,7 @@ import com.niki914.zafiro.app.ui.model.HomeChatIntent
 import com.niki914.zafiro.app.ui.model.HomeChatTurn
 import com.niki914.zafiro.app.ui.model.HomeChatUiState
 import com.niki914.zafiro.app.ui.model.HomeChatViewModel
+import com.niki914.zafiro.app.ui.model.MessageActionsDisplay
 import com.niki914.zafiro.app.ui.model.HomeToolState
 import com.niki914.zafiro.app.ui.model.HomeToolStatus
 import com.niki914.zafiro.app.ui.model.ToolPresentation
@@ -110,6 +111,7 @@ import com.niki914.zafiro.app.ui.nav.TextTitle
 import com.niki914.zafiro.app.ui.nav.TopBarActionSpec
 import com.niki914.zafiro.chat.agentic.shell.ToolPermissionCoordinator
 import com.niki914.zafiro.repo.UpdateCheckHolder
+import com.niki914.zafiro.repo.XRepo
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -142,6 +144,12 @@ fun HomePageContent(
     )
     val latestOnActiveConversationChanged by rememberUpdatedState(onActiveConversationChanged)
     val uiState by viewModel.uiStateFlow.collectAsState()
+    val alwaysShowActions by XRepo.alwaysShowMessageActionsSetting.collectAsState()
+    val actionsDisplay = if (alwaysShowActions) {
+        MessageActionsDisplay.Always
+    } else {
+        MessageActionsDisplay.OnTap
+    }
     val density = LocalDensity.current
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -283,6 +291,7 @@ fun HomePageContent(
 
     HomePageContentBody(
         uiState = uiState,
+        actionsDisplay = actionsDisplay,
         listState = listState,
         composerBottomPadding = composerBottomPadding,
         composerGap = composerGap,
@@ -439,6 +448,7 @@ private fun ToolPermissionDialog() {
 @Composable
 private fun HomePageContentBody(
     uiState: HomeChatUiState,
+    actionsDisplay: MessageActionsDisplay,
     listState: LazyListState,
     composerBottomPadding: Dp,
     composerGap: Dp,
@@ -510,6 +520,9 @@ private fun HomePageContentBody(
             ) { index, turn ->
                 // User 气泡组内位置（渲染层：两个相邻 UserBubble 之间无任何内容即同组，见 userBubblePosition）
                 val position = userBubblePosition(uiState.turns, index)
+                // 组归一化：点组内任意一条都弹/聚合到组尾（操作行在组尾 turn 下渲染）
+                val tailIndex = userGroupTailIndex(uiState.turns, index)
+                val tailTurn = uiState.turns[tailIndex]
                 // 顶距：组中/组末用组内间隙与上一气泡连体；组首/单条维持 turn 分隔
                 val turnTopPad = when {
                     index == 0 -> Modifier
@@ -522,6 +535,10 @@ private fun HomePageContentBody(
                     turn = turn,
                     userBubblePosition = position,
                     isLastTurn = index == uiState.turns.lastIndex,
+                    actionsDisplay = actionsDisplay,
+                    userGroupTailTurnId = tailTurn.id,
+                    userGroupTappable = tailTurn.blocks.isNotEmpty() || tailIndex == uiState.turns.lastIndex,
+                    userGroupText = userGroupText(uiState.turns, index),
                     onContentTap = onContentTap,
                     onReGenerate = onReGenerate,
                     onFork = onFork,
@@ -670,11 +687,39 @@ private fun userBubblePosition(turns: List<HomeChatTurn>, index: Int): UserBubbl
     }
 }
 
+/**
+ * 渲染层连续 User 气泡组（见 [userBubblePosition]）：index 所在组的组尾下标。
+ * 组向下延伸的判定与 userBubblePosition 一致：自身 blocks 为空则下一气泡与本气泡相邻。
+ */
+internal fun userGroupTailIndex(turns: List<HomeChatTurn>, index: Int): Int {
+    var tail = index
+    while (tail < turns.lastIndex && turns[tail].blocks.isEmpty()) tail++
+    return tail
+}
+
+/** index 所在 User 组的组内全部用户文本：按序、双换行分隔、跳过空白（纯图片 turn）。 */
+internal fun userGroupText(turns: List<HomeChatTurn>, index: Int): String {
+    var head = index
+    while (head > 0 && turns[head - 1].blocks.isEmpty()) head--
+    val tail = userGroupTailIndex(turns, index)
+    return turns.subList(head, tail + 1)
+        .map { it.userText }
+        .filter { it.isNotBlank() }
+        .joinToString("\n\n")
+}
+
 @Composable
 private fun HomeChatTurnItem(
     turn: HomeChatTurn,
     userBubblePosition: UserBubblePosition,
     isLastTurn: Boolean,
+    actionsDisplay: MessageActionsDisplay,
+    /** 点组内任意一条时操作行归一到组尾 turn；非组尾成员仅作点击归一目标。 */
+    userGroupTailTurnId: Long,
+    /** 组尾 turn 的操作行资格（blocks 非空或为最后一条）。 */
+    userGroupTappable: Boolean,
+    /** 组内全部用户文本（双换行分隔），供组尾操作行复制。 */
+    userGroupText: String,
     onContentTap: () -> Unit,
     onReGenerate: (Long) -> Unit,
     onFork: (Long) -> Unit,
@@ -692,10 +737,13 @@ private fun HomeChatTurnItem(
     isGenerating: Boolean,
     modifier: Modifier = Modifier,
 ) {
+    val alwaysVisible = actionsDisplay == MessageActionsDisplay.Always
+    // Agent 操作行：生成中隐藏（流式中的重新生成无意义）
     val canToggleAction = !isGenerating && turn.blocks.isNotEmpty()
-    // User 操作行（仅复制）：最后一条 turn 即使无内容（失败后无错误卡/被中断的裸回合）也放开，
-    // 使本条 query 仍可复制；非最后一条裸回合维持不可复制（历史行为），Agent 操作行不放开
-    val canToggleUserAction = !isGenerating && (turn.blocks.isNotEmpty() || isLastTurn)
+    // User 操作行资格：生成中同样放开（历史遗留修复：复制无害，重新生成/回退由 Controller 护栏拦截）；
+    // 最后一条 turn 即使无内容也放开，使本条 query 仍可复制
+    val userRowEligible = turn.blocks.isNotEmpty() || isLastTurn
+    val isUserGroupTail = turn.id == userGroupTailTurnId
 
     val clipboard = LocalClipboard.current
     val scope = rememberCoroutineScope()
@@ -748,8 +796,9 @@ private fun HomeChatTurnItem(
                         indication = null,
                         onClick = {
                             onContentTap()
-                            if (canToggleUserAction) {
-                                onToggleActionRow(turn.id, ActionSource.User)
+                            // Always 模式永不收回；OnTap 模式点组内任意一条都归一到组尾
+                            if (!alwaysVisible && userGroupTappable) {
+                                onToggleActionRow(userGroupTailTurnId, ActionSource.User)
                             }
                         },
                     ),
@@ -760,14 +809,16 @@ private fun HomeChatTurnItem(
         }
 
         AnimatedVisibility(
-            visible = showActionRow && actionSource == ActionSource.User,
+            visible = isUserGroupTail && userRowEligible &&
+                    (alwaysVisible || (showActionRow && actionSource == ActionSource.User)),
             enter = expandVertically() + fadeIn(),
             exit = shrinkVertically() + fadeOut(),
         ) {
             TurnActionRow(
                 source = ActionSource.User,
+                display = actionsDisplay,
                 onCopy = {
-                    copyText(turn.userText)
+                    copyText(userGroupText)
                 },
                 onReGenerate = { onReGenerate(turn.id) },
                 onFork = { onFork(turn.id) },
@@ -816,7 +867,7 @@ private fun HomeChatTurnItem(
                             },
                             onContentClick = {
                                 onContentTap()
-                                if (canToggleAction) {
+                                if (!alwaysVisible && canToggleAction) {
                                     onToggleActionRow(turn.id, ActionSource.Agent)
                                 }
                             },
@@ -834,7 +885,7 @@ private fun HomeChatTurnItem(
                                                 indication = null,
                                                 onClick = {
                                                     onContentTap()
-                                                    if (canToggleAction) {
+                                                    if (!alwaysVisible && canToggleAction) {
                                                         onToggleActionRow(
                                                             turn.id,
                                                             ActionSource.Agent
@@ -924,7 +975,7 @@ private fun HomeChatTurnItem(
                                                 indication = null,
                                                 onClick = {
                                                     onContentTap()
-                                                    if (canToggleAction) {
+                                                    if (!alwaysVisible && canToggleAction) {
                                                         onToggleActionRow(
                                                             turn.id,
                                                             ActionSource.Agent
@@ -953,11 +1004,13 @@ private fun HomeChatTurnItem(
         }
 
         AnimatedVisibility(
-            visible = showActionRow && actionSource == ActionSource.Agent,
+            visible = (alwaysVisible && canToggleAction) ||
+                    (showActionRow && actionSource == ActionSource.Agent),
             enter = expandVertically() + fadeIn(),
         ) {
             TurnActionRow(
                 source = ActionSource.Agent,
+                display = actionsDisplay,
                 onCopy = {
                     val text = turn.blocks
                         .filterIsInstance<HomeChatBlock.Text>()
@@ -1016,6 +1069,7 @@ private fun HomePageContentPreview() {
     BaseTheme {
         ProvideLiquidScreenContentForPreview(topPadding = 0.dp) {
             HomePageContentBody(
+                actionsDisplay = MessageActionsDisplay.OnTap,
                 composerFocusRequester = remember { FocusRequester() },
                 uiState = HomeChatUiState(
                     input = "继续分析",

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/HomeChatState.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/HomeChatState.kt
@@ -74,6 +74,12 @@ private object DefaultHomeConversationStore : HomeConversationStore {
 
 enum class ActionSource { User, Agent }
 
+/**
+ * 消息操作行显示模式：OnTap 点击消息弹出、再点收起；
+ * Always 常显、永不收回，按钮去背景只留图标（降噪音）。
+ */
+enum class MessageActionsDisplay { OnTap, Always }
+
 enum class HomeToolState {
     Running,
     Succeeded,

--- a/app/src/main/java/com/niki914/zafiro/repo/AppStateSettingsCodec.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/AppStateSettingsCodec.kt
@@ -27,6 +27,8 @@ internal data class AppStateSettings(
     val llmRetryMaxAttempts: Int = 3,
     /** 回答进行中保持屏幕常亮。 */
     val keepScreenOn: Boolean = true,
+    /** 消息操作行（复制/重新生成/fork 等）是否常显。 */
+    val alwaysShowMessageActions: Boolean = true,
 )
 
 internal object AppStateSettingsCodec {
@@ -47,6 +49,10 @@ internal object AppStateSettingsCodec {
             llmIdleTimeoutSeconds = root.long(LLM_IDLE_TIMEOUT_KEY, default = 60L),
             llmRetryMaxAttempts = root.int(LLM_RETRY_ATTEMPTS_KEY, default = 3),
             keepScreenOn = root.boolean(KEEP_SCREEN_ON_KEY, default = true),
+            alwaysShowMessageActions = root.boolean(
+                ALWAYS_SHOW_MESSAGE_ACTIONS_KEY,
+                default = true
+            ),
         )
     }
 
@@ -64,6 +70,7 @@ internal object AppStateSettingsCodec {
                 LLM_IDLE_TIMEOUT_KEY to JsonPrimitive(state.llmIdleTimeoutSeconds),
                 LLM_RETRY_ATTEMPTS_KEY to JsonPrimitive(state.llmRetryMaxAttempts),
                 KEEP_SCREEN_ON_KEY to JsonPrimitive(state.keepScreenOn),
+                ALWAYS_SHOW_MESSAGE_ACTIONS_KEY to JsonPrimitive(state.alwaysShowMessageActions),
             )
         ).toString()
     }
@@ -79,4 +86,5 @@ internal object AppStateSettingsCodec {
     private const val LLM_IDLE_TIMEOUT_KEY = "llm_idle_timeout_seconds"
     private const val LLM_RETRY_ATTEMPTS_KEY = "llm_retry_max_attempts"
     private const val KEEP_SCREEN_ON_KEY = "keep_screen_on"
+    private const val ALWAYS_SHOW_MESSAGE_ACTIONS_KEY = "always_show_message_actions"
 }

--- a/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
@@ -352,6 +352,16 @@ object XRepo {
         }
     }
 
+    /**
+     * 回填型设置 flow 的统一冷启动回填：flow 初值是猜的默认值，必须有人调一次
+     * getter 读盘才能对齐真值。MainActivity.onCreate 同步调用。
+     * 新增响应式设置 flow 必须在此登记，否则冷启动首帧读到假值。
+     */
+    suspend fun hydrateSettings() {
+        keepScreenOn()
+        alwaysShowMessageActions()
+    }
+
     suspend fun themeMode(): String {
         return AppStateSettingsCodec.parse(readJson(StoreDescriptorRegistry.APP_STATE_ID)).themeMode
     }

--- a/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
@@ -335,6 +335,23 @@ object XRepo {
         }
     }
 
+    /** 消息操作行常显开关的进程内热更新通道：读时回填初值，写时同步。 */
+    val alwaysShowMessageActionsSetting = MutableStateFlow(true)
+
+    suspend fun alwaysShowMessageActions(): Boolean {
+        return AppStateSettingsCodec.parse(readJson(StoreDescriptorRegistry.APP_STATE_ID))
+            .alwaysShowMessageActions
+            .also { alwaysShowMessageActionsSetting.value = it }
+    }
+
+    suspend fun setAlwaysShowMessageActions(value: Boolean) {
+        alwaysShowMessageActionsSetting.value = value
+        updateJson(StoreDescriptorRegistry.APP_STATE_ID) { json ->
+            val current = AppStateSettingsCodec.parse(json)
+            AppStateSettingsCodec.encode(current.copy(alwaysShowMessageActions = value))
+        }
+    }
+
     suspend fun themeMode(): String {
         return AppStateSettingsCodec.parse(readJson(StoreDescriptorRegistry.APP_STATE_ID)).themeMode
     }

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -326,6 +326,7 @@
     <string name="ui_settings_general_retry_summary">請求失敗後的自動重試</string>
     <string name="ui_settings_general_keep_screen_on">回應期間保持螢幕常亮</string>
     <string name="ui_settings_general_keep_screen_on_summary">回應與工具執行期間保持螢幕常亮</string>
+    <string name="ui_settings_general_always_show_message_actions">總是顯示訊息操作</string>
     <string name="ui_settings_saved_configuration_title">已儲存配置</string>
     <string name="ui_settings_saved_configuration_delete_title">刪除配置</string>
     <string name="ui_settings_saved_configuration_delete_text">該配置將被刪除，此操作無法復原。</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -364,6 +364,7 @@
     <string name="ui_settings_general_retry_summary">Automatic retries after a failed request</string>
     <string name="ui_settings_general_keep_screen_on">Keep screen on while answering</string>
     <string name="ui_settings_general_keep_screen_on_summary">Keep the screen on while the agent is responding and running tools</string>
+    <string name="ui_settings_general_always_show_message_actions">Always show message actions</string>
     <string name="ui_settings_saved_configuration_title">Saved configurations</string>
     <string name="ui_settings_saved_configuration_delete_title">Delete configuration</string>
     <string name="ui_settings_saved_configuration_delete_text">This configuration will be deleted and cannot be recovered.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -364,6 +364,7 @@
     <string name="ui_settings_general_retry_summary">Reintentos automáticos tras un error de solicitud</string>
     <string name="ui_settings_general_keep_screen_on">Mantener la pantalla encendida al responder</string>
     <string name="ui_settings_general_keep_screen_on_summary">Mantener la pantalla encendida mientras el agente responde y ejecuta herramientas</string>
+    <string name="ui_settings_general_always_show_message_actions">Mostrar siempre las acciones de los mensajes</string>
     <string name="ui_settings_saved_configuration_title">Configuraciones guardadas</string>
     <string name="ui_settings_saved_configuration_delete_title">Eliminar configuración</string>
     <string name="ui_settings_saved_configuration_delete_text">Esta configuración se eliminará y la acción no se podrá deshacer.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -363,6 +363,7 @@
     <string name="ui_settings_general_retry_summary">リクエスト失敗後の自動リトライ</string>
     <string name="ui_settings_general_keep_screen_on">回答中は画面をオンに保つ</string>
     <string name="ui_settings_general_keep_screen_on_summary">エージェントの応答とツール実行中は画面をオフにしません</string>
+    <string name="ui_settings_general_always_show_message_actions">メッセージ操作を常に表示</string>
     <string name="ui_settings_saved_configuration_title">保存済みの設定</string>
     <string name="ui_settings_saved_configuration_delete_title">設定の削除</string>
     <string name="ui_settings_saved_configuration_delete_text">この設定は削除されます。この操作は元に戻せません。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -369,6 +369,7 @@
     <string name="ui_settings_general_retry_summary">请求失败后的自动重试</string>
     <string name="ui_settings_general_keep_screen_on">回答期间保持屏幕常亮</string>
     <string name="ui_settings_general_keep_screen_on_summary">回答与工具执行期间保持屏幕常亮</string>
+    <string name="ui_settings_general_always_show_message_actions">总是显示消息操作</string>
     <string name="ui_settings_saved_configuration_title">已保存配置</string>
     <string name="ui_settings_saved_configuration_delete_title">删除配置</string>
     <string name="ui_settings_saved_configuration_delete_text">该配置将被删除，此操作无法恢复。</string>

--- a/app/src/test/java/com/niki914/zafiro/app/ui/model/HomeChatControllerTest.kt
+++ b/app/src/test/java/com/niki914/zafiro/app/ui/model/HomeChatControllerTest.kt
@@ -1328,6 +1328,7 @@ private open class FakeHomeConversationStore : HomeConversationStore {
         val prefix = when (kind) {
             ForkKind.Fork -> "Fork · "
             ForkKind.Regenerate -> "Regenerate · "
+            ForkKind.Rewind -> "Rewind · "
         }
         records[newId] = ConversationRecord(
             summary = source.summary.copy(


### PR DESCRIPTION
Home chat message action rows (copy/regenerate/fork/rewind) are now always visible by default, controlled by a General Settings toggle that defaults to on.

- Settings: new "always show message actions" toggle (on by default), persisted in AppStateSettings + reactive XRepo flow
- Always mode: pinned action rows for every message; icon-only style (no rounded background, no click ripple); taps no longer toggle rows
- Grouped consecutive user messages: tapping any member expands at the group tail; copy joins group texts with double newlines
- Fix: user action row no longer gated on generation state (was hidden mid-generation)
- Fix: XRepo.hydrateSettings() hydrates reactive settings flows at cold start (first-frame truth); test fake gains missing ForkKind.Rewind branch