### PR TITLE
feat: model catalog scan sheet

### DIFF
--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/ConfigurePageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/ConfigurePageContent.kt
@@ -38,6 +38,9 @@ fun ConfigurePageContent(
     onComplete: () -> Unit,
     onConfirmEndpointMismatch: () -> Unit = {},
     onCancelEndpointMismatch: () -> Unit = {},
+    onShowModelCatalogSheet: () -> Unit = {},
+    onHideModelCatalogSheet: () -> Unit = {},
+    onSelectCatalogModel: (String) -> Unit = {},
     requestedFocusField: ConfigureEditableField? = null,
     onRequestedFocusHandled: () -> Unit = {},
 ) {
@@ -84,6 +87,7 @@ fun ConfigurePageContent(
             onModelChange = onModelChange,
             onApiKeyChange = onApiKeyChange,
             onToggleApiKeyVisibility = onToggleApiKeyVisibility,
+            onShowModelCatalogSheet = onShowModelCatalogSheet,
         )
 
         ConfigureProtocolSettingsBlock(
@@ -99,6 +103,14 @@ fun ConfigurePageContent(
         mismatch = uiState.pendingEndpointMismatch,
         onConfirm = onConfirmEndpointMismatch,
         onCancel = onCancelEndpointMismatch,
+    )
+
+    ModelCatalogSheet(
+        visible = uiState.showModelCatalogSheet,
+        catalog = uiState.modelCatalog,
+        currentModelInput = uiState.modelInput,
+        onDismissRequest = onHideModelCatalogSheet,
+        onSelect = onSelectCatalogModel,
     )
 }
 

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/ConfigureSettingsBlocks.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/ConfigureSettingsBlocks.kt
@@ -1,11 +1,18 @@
 package com.niki914.zafiro.app.ui.content
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FormatListBulleted
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.stringResource
+import com.niki914.uikit.infra.ActionBarButton
 import com.niki914.okia.message.ThinkingLevel
 import com.niki914.uikit.infra.component.SettingToggleItem
 import com.niki914.uikit.infra.component.SettingsGroupCard
@@ -64,9 +71,47 @@ internal fun ConfigureConnectionSettingsBlock(
     onModelChange: (String) -> Unit,
     onApiKeyChange: (String) -> Unit,
     onToggleApiKeyVisibility: () -> Unit,
+    onShowModelCatalogSheet: () -> Unit = {},
 ) {
     val onClearActiveField = fieldController.clearActiveField
     SettingsGroupCard {
+        // 填写顺序：API Key → Model；Model 有目录时挤左 + 右侧按钮
+        SettingControlledExpandableTextItem(
+            field = ConfigureEditableField.ApiKey,
+            controller = fieldController,
+            title = stringResource(R.string.ui_onboard_configure_api_key_label),
+            value = uiState.apiKeyInput,
+            onValueChange = onApiKeyChange,
+            placeholder = stringResource(R.string.ui_onboard_configure_api_key_placeholder),
+            description = uiState.apiKeyErrorResId?.let { stringResource(it) },
+            enabled = !uiState.isSaving,
+            minLines = 1,
+            maxLines = 1,
+            secretVisible = uiState.apiKeyVisible,
+            onToggleSecretVisibility = onToggleApiKeyVisibility,
+            toggleSecretVisibleContentDescription = stringResource(
+                R.string.ui_onboard_configure_api_key_show,
+            ),
+            toggleSecretHiddenContentDescription = stringResource(
+                R.string.ui_onboard_configure_api_key_hide,
+            ),
+        )
+        SettingsItemDivider()
+        // 双模式：目录为空 = 输入框占满（现状）；非空 = 输入框挤左 + 右侧按钮
+        val catalogButton: (@Composable () -> Unit)? =
+            if (uiState.modelCatalog.isEmpty()) {
+                null
+            } else {
+                {
+                    ModelCatalogButton(
+                        enabled = !uiState.isSaving,
+                        onClick = {
+                            onClearActiveField()
+                            onShowModelCatalogSheet()
+                        },
+                    )
+                }
+            }
         SettingControlledExpandableTextItem(
             field = ConfigureEditableField.Model,
             controller = fieldController,
@@ -86,6 +131,7 @@ internal fun ConfigureConnectionSettingsBlock(
             enabled = !uiState.isSaving,
             minLines = 1,
             maxLines = 1,
+            fieldTrailingContent = catalogButton,
         )
         SettingsItemDivider()
         if (policy.showEndpointSection) {
@@ -126,26 +172,30 @@ internal fun ConfigureConnectionSettingsBlock(
             }
             SettingsItemDivider()
         }
-        SettingControlledExpandableTextItem(
-            field = ConfigureEditableField.ApiKey,
-            controller = fieldController,
-            title = stringResource(R.string.ui_onboard_configure_api_key_label),
-            value = uiState.apiKeyInput,
-            onValueChange = onApiKeyChange,
-            placeholder = stringResource(R.string.ui_onboard_configure_api_key_placeholder),
-            description = uiState.apiKeyErrorResId?.let { stringResource(it) },
-            enabled = !uiState.isSaving,
-            minLines = 1,
-            maxLines = 1,
-            secretVisible = uiState.apiKeyVisible,
-            onToggleSecretVisibility = onToggleApiKeyVisibility,
-            toggleSecretVisibleContentDescription = stringResource(
-                R.string.ui_onboard_configure_api_key_show,
-            ),
-            toggleSecretHiddenContentDescription = stringResource(
-                R.string.ui_onboard_configure_api_key_hide,
-            ),
-        )
+    }
+}
+
+/** 模型目录按钮：复用 LiquidScreen 左右按钮同款（Home 添加图片按钮同款）。 */
+@Composable
+private fun ModelCatalogButton(
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    // add 按钮恒亮：不随 isSaving 变灰（只有输入框随保存态禁用）
+    CompositionLocalProvider(
+        LocalContentColor provides MaterialTheme.colorScheme.primary,
+    ) {
+        ActionBarButton(
+            onClick = onClick,
+            enabled = enabled,
+        ) {
+            Icon(
+                imageVector = Icons.Default.FormatListBulleted,
+                contentDescription = stringResource(
+                    R.string.ui_onboard_configure_model_catalog_open
+                ),
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/EditableSettingsDetailScaffold.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/EditableSettingsDetailScaffold.kt
@@ -149,6 +149,7 @@ fun <Field : Enum<Field>> SettingControlledExpandableTextItem(
     onToggleSecretVisibility: (() -> Unit)? = null,
     toggleSecretVisibleContentDescription: String? = null,
     toggleSecretHiddenContentDescription: String? = null,
+    fieldTrailingContent: (@Composable () -> Unit)? = null,
 ) {
     SettingExpandableTextItem(
         title = title,
@@ -167,6 +168,7 @@ fun <Field : Enum<Field>> SettingControlledExpandableTextItem(
         onExpandedChange = { expanded ->
             controller.onExpandedFieldChange(if (expanded) field else null)
         },
+        fieldTrailingContent = fieldTrailingContent,
     )
 }
 

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/ModelCatalogSheet.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/ModelCatalogSheet.kt
@@ -1,0 +1,183 @@
+package com.niki914.zafiro.app.ui.content
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.niki914.uikit.infra.component.LiquidTextField
+import com.niki914.uikit.infra.component.SettingsItemSurface
+import com.niki914.uikit.infra.shape.G2FieldShape
+import com.niki914.zafiro.app.R
+import kotlinx.coroutines.launch
+
+/**
+ * 模型目录选择单（id-only，像素级复刻 bukit ChoiceBottomSheet 行）。
+ * - 搜索框 + 名单；点一行即选中回填并收起；背景点击关闭；
+ * - 选中态：单内字符串 == 输入框 trim。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ModelCatalogSheet(
+    visible: Boolean,
+    catalog: List<String>,
+    currentModelInput: String,
+    onDismissRequest: () -> Unit,
+    onSelect: (String) -> Unit,
+) {
+    if (!visible) return
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val scope = rememberCoroutineScope()
+    var query by rememberSaveable { mutableStateOf("") }
+    val trimmedCurrent = currentModelInput.trim()
+    val filtered = rememberFilteredCatalog(catalog, query)
+
+    /** 先走 M3 收起动画，再回调 onDismiss 移除组合，避免 sheet 闪现消失。 */
+    fun hideThen(onHidden: () -> Unit) {
+        scope.launch {
+            sheetState.hide()
+            onHidden()
+        }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(Modifier.fillMaxWidth().padding(bottom = 24.dp)) {
+            // sheet 高度锁在屏高 50%~60%：内容不足撑到 50%，超长列表封顶 60% 内滚动
+            val screenH = LocalConfiguration.current.screenHeightDp.dp
+            Column(
+                Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = screenH * 0.5f, max = screenH * 0.6f)
+            ) {
+                Text(
+                    text = stringResource(R.string.ui_onboard_configure_model_catalog_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
+                )
+                LiquidTextField(
+                    value = query,
+                    onValueChange = { query = it },
+                    placeholder = stringResource(
+                        R.string.ui_onboard_configure_model_catalog_search_placeholder
+                    ),
+                    singleLine = true,
+                    maxLines = 1,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp, vertical = 8.dp),
+                )
+                if (filtered.isEmpty()) {
+                    Text(
+                        text = stringResource(R.string.ui_onboard_configure_model_catalog_empty),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
+                    )
+                } else {
+                    LazyColumn {
+                        items(filtered, key = { it.hashCode() }) { modelId ->
+                            CatalogRow(
+                                modelId = modelId,
+                                checked = modelId == trimmedCurrent,
+                                onClick = { hideThen { onSelect(modelId) } },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** 像素级复刻 bukit ChoiceRow：选中底 + G2 圆角 + 按压效果 + 行高。 */
+@Composable
+private fun CatalogRow(
+    modelId: String,
+    checked: Boolean,
+    onClick: () -> Unit,
+) {
+    // 选中态 = 对比色底 + G2 圆角框，文字换 onContainer 保可读；未选中透明。
+    // clip 保证按压底色与选中底色同形状（zafiro 侧 Surface 无 shape 参数）。
+    val highlightShape = G2FieldShape(16.dp)
+    SettingsItemSurface(
+        onClick = onClick,
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+        minHeight = 64.dp,
+        modifier = Modifier
+            .padding(horizontal = 12.dp, vertical = 4.dp)
+            .clip(highlightShape)
+            .then(
+                if (checked) Modifier.background(
+                    MaterialTheme.colorScheme.primaryContainer,
+                ) else Modifier,
+            ),
+    ) {
+        CatalogRowContent(modelId = modelId, checked = checked)
+    }
+}
+
+@Composable
+private fun RowScope.CatalogRowContent(
+    modelId: String,
+    checked: Boolean,
+) {
+    Column(Modifier.weight(1f)) {
+        Text(
+            text = modelId,
+            style = MaterialTheme.typography.bodyLarge,
+            color = if (checked) {
+                MaterialTheme.colorScheme.onPrimaryContainer
+            } else {
+                MaterialTheme.colorScheme.onSurface
+            },
+            modifier = Modifier.alpha(1f),
+        )
+    }
+    if (checked) {
+        Icon(
+            imageVector = Icons.Default.Check,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onPrimaryContainer,
+            modifier = Modifier.align(Alignment.CenterVertically),
+        )
+    }
+}
+
+@Composable
+private fun rememberFilteredCatalog(
+    catalog: List<String>,
+    query: String,
+): List<String> {
+    val q = query.trim().lowercase()
+    if (q.isBlank()) return catalog
+    return catalog.filter { it.lowercase().contains(q) }
+}

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/SavedConfigDetailContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/SavedConfigDetailContent.kt
@@ -107,12 +107,23 @@ fun SavedConfigDetailContent(
             onToggleApiKeyVisibility = { viewModel.sendIntent(ConfigureIntent.ToggleApiKeyVisibility) },
             onProxyChange = { viewModel.sendIntent(ConfigureIntent.UpdateProxy(it)) },
             onSave = { viewModel.sendIntent(ConfigureIntent.Save) },
+            onShowModelCatalogSheet = { viewModel.sendIntent(ConfigureIntent.ShowModelCatalogSheet) },
+            onHideModelCatalogSheet = { viewModel.sendIntent(ConfigureIntent.HideModelCatalogSheet) },
+            onSelectCatalogModel = { viewModel.sendIntent(ConfigureIntent.SelectCatalogModel(it)) },
         )
 
         EndpointMismatchDialog(
             mismatch = uiState.pendingEndpointMismatch,
             onConfirm = { viewModel.sendIntent(ConfigureIntent.ConfirmEndpointMismatch) },
             onCancel = { viewModel.sendIntent(ConfigureIntent.CancelEndpointMismatch) },
+        )
+
+        ModelCatalogSheet(
+            visible = uiState.showModelCatalogSheet,
+            catalog = uiState.modelCatalog,
+            currentModelInput = uiState.modelInput,
+            onDismissRequest = { viewModel.sendIntent(ConfigureIntent.HideModelCatalogSheet) },
+            onSelect = { viewModel.sendIntent(ConfigureIntent.SelectCatalogModel(it)) },
         )
 
         ConfirmationLiquidDialog(
@@ -148,6 +159,9 @@ private fun SavedConfigDetailContentBody(
     onToggleApiKeyVisibility: () -> Unit,
     onProxyChange: (String) -> Unit,
     onSave: () -> Unit,
+    onShowModelCatalogSheet: () -> Unit = {},
+    onHideModelCatalogSheet: () -> Unit = {},
+    onSelectCatalogModel: (String) -> Unit = {},
 ) {
     // 编辑态不限制端点编辑；新建态仅部分品牌开放自定义端点
     val policy = if (!showEndpointOverrideToggle) {
@@ -185,6 +199,7 @@ private fun SavedConfigDetailContentBody(
             onModelChange = onModelChange,
             onApiKeyChange = onApiKeyChange,
             onToggleApiKeyVisibility = onToggleApiKeyVisibility,
+            onShowModelCatalogSheet = onShowModelCatalogSheet,
         )
 
         ConfigureProtocolSettingsBlock(

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/ConfigureState.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/ConfigureState.kt
@@ -339,6 +339,9 @@ class ConfigureViewModel internal constructor(
                 initialSettingsSnapshot = null,
                 savedConfigs = summariesOf(document),
                 activeConfigId = document.activeId,
+                // 新会话：目录缓存不跨页复用（同 VM 复用时旧名单不清会误回填）
+                modelCatalog = emptyList(),
+                showModelCatalogSheet = false,
             )
             next
         }
@@ -371,6 +374,9 @@ class ConfigureViewModel internal constructor(
                 inlineError = null,
                 savedConfigs = summariesOf(document),
                 activeConfigId = document.activeId,
+                // 新会话：目录缓存不跨页复用（同 VM 复用时旧名单不清会误回填）
+                modelCatalog = emptyList(),
+                showModelCatalogSheet = false,
             )
             // 快照必须取自初始化后的状态，否则未修改也会被判为 dirty
             next.copy(initialSettingsSnapshot = next.toSettingsSnapshot())
@@ -411,6 +417,9 @@ class ConfigureViewModel internal constructor(
                 inlineError = null,
                 savedConfigs = summariesOf(document),
                 activeConfigId = document.activeId,
+                // 新会话：目录缓存不跨页复用（同 VM 复用时旧名单不清会误回填）
+                modelCatalog = emptyList(),
+                showModelCatalogSheet = false,
             )
             // 快照必须取自初始化后的状态，否则未修改也会被判为 dirty
             next.copy(initialSettingsSnapshot = next.toSettingsSnapshot())
@@ -418,7 +427,8 @@ class ConfigureViewModel internal constructor(
     }
 
     /** 模型目录自动拉取：50ms trailing + 取消在途 + 三元组去重 + 空值短路。
-     *  失败 = 无事发生（只记日志）；只刷新缓存，从不覆盖 modelInput。 */
+     *  缓存语义：成功覆盖（含空结果，空 = 藏按钮）；失败与空值短路保留旧缓存，只记日志；
+     *  只刷新缓存，从不覆盖 modelInput。 */
     private fun scheduleCatalogFetch(immediate: Boolean = false) {
         catalogFetchJob?.cancel()
         // 注意：handleIntent 已跑在 viewModelScope 的 intent 串行通道里；
@@ -432,7 +442,7 @@ class ConfigureViewModel internal constructor(
                 protocolWireId = state.protocolWireId,
             )
             if (key == lastCatalogKey) return@launch
-            // 空值短路：Key 或 endpoint 为空直接不发，不清空旧缓存
+            // 空值短路：Key 或 endpoint 为空直接不发，保留旧缓存
             if (key.endpoint.isBlank() || key.apiKey.isBlank()) return@launch
             val protocol = LlmProtocol.fromWire(key.protocolWireId)
             val modelsUrl = EndpointInference.modelsUrl(key.endpoint, protocol)
@@ -440,9 +450,8 @@ class ConfigureViewModel internal constructor(
             lastCatalogKey = key
             try {
                 val ids = dependencies.fetchModelCatalog(modelsUrl, key.apiKey, protocol)
-                if (ids.isNotEmpty()) {
-                    updateState { copy(modelCatalog = ids) }
-                }
+                // 成功覆盖：空结果也写入（藏按钮），失败走 catch 保留旧缓存
+                updateState { copy(modelCatalog = ids) }
             } catch (throwable: Throwable) {
                 if (throwable is CancellationException) throw throwable
                 Logger.w(LOG_TAG, "catalog fetch failed: ${throwable.message}")

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/ConfigureState.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/ConfigureState.kt
@@ -1,15 +1,20 @@
 package com.niki914.zafiro.app.ui.model
 
 import androidx.annotation.StringRes
+import androidx.lifecycle.viewModelScope
 import com.niki914.logging.Logger
 import com.niki914.okia.message.ThinkingLevel
 import com.niki914.uikit.base.ComposeMVIViewModel
 import com.niki914.zafiro.app.R
 import com.niki914.zafiro.repo.LlmConfigsDocument
+import com.niki914.zafiro.repo.ModelCatalogApi
 import com.niki914.zafiro.repo.SavedLlmConfig
 import com.niki914.zafiro.repo.XRepo
 import com.niki914.zafiro.settings.model.LlmProtocol
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import java.net.URI
 
 enum class ConfigureScene {
@@ -60,6 +65,10 @@ data class ConfigureUiState(
     val activeConfigId: String? = null,
     /** 非 null 时应弹出端点不匹配确认弹窗。 */
     val pendingEndpointMismatch: EndpointMismatch? = null,
+    /** 模型目录扫描缓存：为空 = 不显示扫描按钮；非空 = 显示按钮。 */
+    val modelCatalog: List<String> = emptyList(),
+    /** 非 null 时应弹出模型选择单。 */
+    val showModelCatalogSheet: Boolean = false,
 )
 
 data class ConfigureSnapshot(
@@ -111,6 +120,9 @@ sealed interface ConfigureIntent {
     data class ActivateConfig(val configId: String) : ConfigureIntent
     data class DeleteConfig(val configId: String) : ConfigureIntent
     data object Save : ConfigureIntent
+    data object ShowModelCatalogSheet : ConfigureIntent
+    data object HideModelCatalogSheet : ConfigureIntent
+    data class SelectCatalogModel(val modelId: String) : ConfigureIntent
 
     /** 确认端点不匹配弹窗：点击更新。 */
     data object ConfirmEndpointMismatch : ConfigureIntent
@@ -148,6 +160,7 @@ internal data class ConfigureViewModelDependencies(
     val upsertConfig: suspend (SavedLlmConfig) -> String?,
     val deleteConfig: suspend (String) -> Unit,
     val setActiveConfig: suspend (String) -> Unit,
+    val fetchModelCatalog: suspend (modelsUrl: String, apiKey: String, protocol: LlmProtocol) -> List<String>,
 ) {
     companion object {
         val Default = ConfigureViewModelDependencies(
@@ -155,6 +168,9 @@ internal data class ConfigureViewModelDependencies(
             upsertConfig = { XRepo.llmConfigs.upsert(it) },
             deleteConfig = { XRepo.llmConfigs.delete(it) },
             setActiveConfig = { XRepo.llmConfigs.setActive(it) },
+            fetchModelCatalog = { modelsUrl, apiKey, protocol ->
+                ModelCatalogApi.fetch(modelsUrl, apiKey, protocol)
+            },
         )
     }
 }
@@ -168,7 +184,14 @@ class ConfigureViewModel internal constructor(
 
     private companion object {
         private const val LOG_TAG = "niki914_nexus_ConfigureViewModel"
+        /** 输入防抖：停手 50ms 才发； trailing + 取消在途 + 三元组去重。 */
+        private const val CATALOG_DEBOUNCE_MS = 50L
     }
+
+    /** 在途的目录拉取（防抖 + 可取消）。 */
+    private var catalogFetchJob: Job? = null
+    /** 上次已拉取的三元组（endpoint/apiKey/protocol），去重用。 */
+    private var lastCatalogKey: CatalogKey? = null
 
     override suspend fun handleIntent(intent: ConfigureIntent) {
         when (intent) {
@@ -183,7 +206,7 @@ class ConfigureViewModel internal constructor(
 
             is ConfigureIntent.UpdateEndpoint -> updateState {
                 copy(endpointInput = intent.value, endpointErrorResId = null, inlineError = null)
-            }
+            }.also { scheduleCatalogFetch() }
 
             is ConfigureIntent.UpdateModel -> updateState {
                 copy(modelInput = intent.value, modelErrorResId = null, inlineError = null)
@@ -191,7 +214,7 @@ class ConfigureViewModel internal constructor(
 
             is ConfigureIntent.UpdateApiKey -> updateState {
                 copy(apiKeyInput = intent.value, apiKeyErrorResId = null, inlineError = null)
-            }
+            }.also { scheduleCatalogFetch() }
 
             is ConfigureIntent.SelectProtocol -> handleProtocolSwitch(intent.wireId)
 
@@ -217,6 +240,20 @@ class ConfigureViewModel internal constructor(
             ConfigureIntent.Save -> handleSave()
             ConfigureIntent.ConfirmEndpointMismatch -> confirmEndpointMismatch()
             ConfigureIntent.CancelEndpointMismatch -> cancelEndpointMismatch()
+            ConfigureIntent.ShowModelCatalogSheet -> updateState {
+                copy(showModelCatalogSheet = true)
+            }
+            ConfigureIntent.HideModelCatalogSheet -> updateState {
+                copy(showModelCatalogSheet = false)
+            }
+            is ConfigureIntent.SelectCatalogModel -> updateState {
+                copy(
+                    modelInput = intent.modelId,
+                    modelErrorResId = null,
+                    inlineError = null,
+                    showModelCatalogSheet = false,
+                )
+            }
         }
     }
 
@@ -225,6 +262,10 @@ class ConfigureViewModel internal constructor(
         initialProviderId: String?,
         configId: String?,
     ) {
+        // 拉取三元组跨初始化重置：不同配置页实例互不污染
+        lastCatalogKey = null
+        catalogFetchJob?.cancel()
+        catalogFetchJob = null
         try {
             val document = dependencies.loadDocument()
             Logger.d(LOG_TAG, "initialize scene=$scene configs=${document.configs.size}")
@@ -239,6 +280,8 @@ class ConfigureViewModel internal constructor(
                     // configId 缺省时编辑当前生效配置；不存在则回落新建
                     initializeEdit(document, configId ?: document.activeId)
             }
+            // 进页拉一次（Key 为空时内部短路，不发请求）
+            scheduleCatalogFetch(immediate = true)
         } catch (throwable: Throwable) {
             if (throwable is CancellationException) throw throwable
             val message = throwable.message ?: throwable::class.java.simpleName
@@ -279,7 +322,8 @@ class ConfigureViewModel internal constructor(
                 configNameInput = providerSpec.brandName,
                 endpointOverrideEnabled = false,
                 endpointInput = providerSpec.officialEndpoint,
-                modelInput = providerSpec.exampleModelId,
+                // Model 无默认值：用户先填 Key，目录拉回后从底单选，或手填
+                modelInput = "",
                 apiKeyInput = "",
                 apiKeyVisible = false,
                 protocolWireId = providerSpec.defaultProtocol,
@@ -311,7 +355,8 @@ class ConfigureViewModel internal constructor(
                 configNameInput = providerSpec.brandName,
                 endpointOverrideEnabled = false,
                 endpointInput = providerSpec.officialEndpoint,
-                modelInput = providerSpec.exampleModelId,
+                // Model 无默认值：用户先填 Key，目录拉回后从底单选，或手填
+                modelInput = "",
                 apiKeyInput = "",
                 apiKeyVisible = false,
                 protocolWireId = providerSpec.defaultProtocol,
@@ -372,6 +417,45 @@ class ConfigureViewModel internal constructor(
         }
     }
 
+    /** 模型目录自动拉取：50ms trailing + 取消在途 + 三元组去重 + 空值短路。
+     *  失败 = 无事发生（只记日志）；只刷新缓存，从不覆盖 modelInput。 */
+    private fun scheduleCatalogFetch(immediate: Boolean = false) {
+        catalogFetchJob?.cancel()
+        // 注意：handleIntent 已跑在 viewModelScope 的 intent 串行通道里；
+        // 这里起子协程只为防抖 delay 不阻塞后续 intent，取消语义经 job 传递
+        catalogFetchJob = viewModelScope.launch {
+            if (!immediate) delay(CATALOG_DEBOUNCE_MS)
+            val state = currentState
+            val key = CatalogKey(
+                endpoint = state.endpointInput.trim(),
+                apiKey = state.apiKeyInput.trim(),
+                protocolWireId = state.protocolWireId,
+            )
+            if (key == lastCatalogKey) return@launch
+            // 空值短路：Key 或 endpoint 为空直接不发，不清空旧缓存
+            if (key.endpoint.isBlank() || key.apiKey.isBlank()) return@launch
+            val protocol = LlmProtocol.fromWire(key.protocolWireId)
+            val modelsUrl = EndpointInference.modelsUrl(key.endpoint, protocol)
+                ?: return@launch
+            lastCatalogKey = key
+            try {
+                val ids = dependencies.fetchModelCatalog(modelsUrl, key.apiKey, protocol)
+                if (ids.isNotEmpty()) {
+                    updateState { copy(modelCatalog = ids) }
+                }
+            } catch (throwable: Throwable) {
+                if (throwable is CancellationException) throw throwable
+                Logger.w(LOG_TAG, "catalog fetch failed: ${throwable.message}")
+            }
+        }
+    }
+
+    private data class CatalogKey(
+        val endpoint: String,
+        val apiKey: String,
+        val protocolWireId: String,
+    )
+
     private fun setEndpointOverride(enabled: Boolean) {
         updateState {
             val nextEndpointInput = if (enabled) {
@@ -386,6 +470,7 @@ class ConfigureViewModel internal constructor(
                 inlineError = null,
             )
         }
+        scheduleCatalogFetch()
     }
 
     private suspend fun activateConfig(configId: String) {
@@ -439,6 +524,7 @@ class ConfigureViewModel internal constructor(
                     protocolWireId = newProtocolWireId,
                 )
             }
+            scheduleCatalogFetch()
             return
         }
         updateState {
@@ -516,6 +602,7 @@ class ConfigureViewModel internal constructor(
 
     private fun switchProtocolQuietly(wireId: String) {
         updateState { copy(protocolWireId = wireId) }
+        scheduleCatalogFetch()
     }
 
     /** 校验重名与必填字段；不通过时置错误并发焦点 Effect。 */
@@ -666,8 +753,9 @@ private enum class ConfigureFieldTarget {
 
 private fun ConfigureUiState.firstInvalidField(): ConfigureFieldTarget? {
     return when {
-        modelInput.trim().isBlank() -> ConfigureFieldTarget.Model
+        // 与填写顺序一致：API Key → Model → Endpoint → Proxy
         apiKeyInput.trim().isBlank() -> ConfigureFieldTarget.ApiKey
+        modelInput.trim().isBlank() -> ConfigureFieldTarget.Model
         endpointOverrideEnabled && endpointInput.trim().isBlank() -> ConfigureFieldTarget.Endpoint
         isValidProxy(proxyInput).not() -> ConfigureFieldTarget.Proxy
         else -> null

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/EndpointInference.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/EndpointInference.kt
@@ -56,6 +56,25 @@ internal object EndpointInference {
         }
     }
 
+    /** 由对话端点推导模型目录地址（id-only 扫描用）。
+     *  剥末段 API 路径、保留版本段后拼 `/models`；Anthropic 保 `/v1/models`。
+     *  推不出（空白端点）返回 null，调用方按失败静默处理。 */
+    fun modelsUrl(currentEndpoint: String, protocol: LlmProtocol): String? {
+        val e = currentEndpoint.trim().trimEnd('/')
+        if (e.isBlank()) return null
+        val remainder = KNOWN_API_TAILS.firstOrNull { e.endsWith(it) }
+            ?.let { e.removeSuffix(it) }
+            ?: e
+        val version = remainder.substringAfterLast('/').takeIf { it.matches(VERSION_SEGMENT) }
+        val base = version?.let { remainder.removeSuffix("/$it") } ?: remainder
+        if (base.isBlank()) return null
+        return when {
+            version != null -> "$base/$version/models"
+            protocol == LlmProtocol.AnthropicMessages -> "$base/v1/models"
+            else -> "$base/models"
+        }
+    }
+
     /** endpoint 是否为任一预置品牌的官方端点形态（预置端点切协议时静默更新，不弹窗）。
      *  按前缀匹配：host + 品牌路径段一致即算预置，官方端点经静默更新派生的
      *  其他协议形态（如 .../provider/v1/responses）同样命中，避免行为漂移。 */

--- a/app/src/main/java/com/niki914/zafiro/app/ui/route/ConfigurePageRoute.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/route/ConfigurePageRoute.kt
@@ -100,6 +100,9 @@ internal fun ConfigurePageRoute(
         onComplete = { viewModel.sendIntent(ConfigureIntent.Save) },
         onConfirmEndpointMismatch = { viewModel.sendIntent(ConfigureIntent.ConfirmEndpointMismatch) },
         onCancelEndpointMismatch = { viewModel.sendIntent(ConfigureIntent.CancelEndpointMismatch) },
+        onShowModelCatalogSheet = { viewModel.sendIntent(ConfigureIntent.ShowModelCatalogSheet) },
+        onHideModelCatalogSheet = { viewModel.sendIntent(ConfigureIntent.HideModelCatalogSheet) },
+        onSelectCatalogModel = { viewModel.sendIntent(ConfigureIntent.SelectCatalogModel(it)) },
         requestedFocusField = pendingFocusField,
         onRequestedFocusHandled = {
             pendingFocusField = null

--- a/app/src/main/java/com/niki914/zafiro/repo/ModelCatalogApi.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/ModelCatalogApi.kt
@@ -1,0 +1,74 @@
+package com.niki914.zafiro.repo
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import com.niki914.zafiro.settings.model.LlmProtocol
+import okhttp3.Request
+import java.util.concurrent.TimeUnit
+
+/**
+ * 模型目录扫描（id-only）：GET {endpoint→models} 取 `data[].id`。
+ * 失败抛异常，调用方静默吞掉（失败 = 无事发生，只记日志）。
+ * 不走代理；不解析能力 / 计费字段；无缓存、无分页。
+ */
+internal object ModelCatalogApi {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    suspend fun fetch(
+        modelsUrl: String,
+        apiKey: String,
+        protocol: LlmProtocol,
+    ): List<String> = withContext(Dispatchers.IO) {
+        val request = Request.Builder()
+            .url(modelsUrl)
+            .get()
+            .header("Accept", "application/json")
+            .apply {
+                val key = apiKey.trim()
+                if (key.isNotEmpty()) {
+                    if (protocol == LlmProtocol.AnthropicMessages) {
+                        header("x-api-key", key)
+                        header("anthropic-version", "2023-06-01")
+                    } else {
+                        header("Authorization", "Bearer $key")
+                    }
+                }
+            }
+            .build()
+        // 短超时：配置页偶发请求，不阻塞；client 共享 base（连接池复用）
+        val client = SharedHttp.client.newBuilder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .build()
+        client.newCall(request).execute().use { response ->
+            val body = response.body?.string().orEmpty()
+            if (!response.isSuccessful) {
+                error("models HTTP ${response.code}")
+            }
+            parseModelIds(body)
+        }
+    }
+
+    /** 只认 `data[].id`，空 id 丢掉，去重排序。
+     *  纯函数不用 xTry（它内部记日志，纯 JVM 单测无 Log）：runCatching 兜底空列表。 */
+    internal fun parseModelIds(body: String): List<String> {
+        return runCatching {
+            json.parseToJsonElement(body)
+                .jsonObject["data"]
+                ?.jsonArray
+                ?.mapNotNull { element ->
+                    element.jsonObject["id"]?.jsonPrimitive?.contentOrNull
+                        ?.trim()
+                        ?.takeIf(String::isNotBlank)
+                }
+                ?.distinct()
+                ?.sorted()
+                .orEmpty()
+        }.getOrDefault(emptyList())
+    }
+}

--- a/app/src/main/java/com/niki914/zafiro/repo/SharedHttp.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/SharedHttp.kt
@@ -1,0 +1,13 @@
+package com.niki914.zafiro.repo
+
+import okhttp3.OkHttpClient
+
+/**
+ * 业务层共享 OkHttp 单例（连接池 / 线程池复用）。
+ * base 保持直连；需要代理的调用方经 newBuilder clone 隔离，不污染 base。
+ * okia 自有 HttpEngine，不动。
+ */
+// ponytail: 全局共享 base 复用连接池；函数体内禁止 new OkHttpClient()
+internal object SharedHttp {
+    val client: OkHttpClient by lazy { OkHttpClient() }
+}

--- a/app/src/main/java/com/niki914/zafiro/repo/UpdateCheckApi.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/UpdateCheckApi.kt
@@ -11,7 +11,6 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.jsonPrimitive
-import okhttp3.OkHttpClient
 import okhttp3.Request
 
 data class UpdateCheckResult(
@@ -44,7 +43,7 @@ object UpdateCheckHolder {
 }
 
 private object UpdateCheckApi {
-    private val client = OkHttpClient()
+    private val client = SharedHttp.client
     private val json = Json { ignoreUnknownKeys = true }
 
     private const val GITHUB_API_LATEST =

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -19,6 +19,10 @@
     <string name="ui_onboard_configure_model_label">模型 ID</string>
     <string name="ui_onboard_configure_model_placeholder">輸入模型 ID</string>
     <string name="ui_onboard_configure_model_example">例如：%1$s</string>
+    <string name="ui_onboard_configure_model_catalog_open">選擇模型</string>
+    <string name="ui_onboard_configure_model_catalog_title">選擇模型</string>
+    <string name="ui_onboard_configure_model_catalog_search_placeholder">搜尋模型</string>
+    <string name="ui_onboard_configure_model_catalog_empty">無相符模型</string>
     <string name="ui_onboard_configure_api_key_label">API Key</string>
     <string name="ui_onboard_configure_api_key_placeholder">輸入 API Key</string>
     <string name="ui_onboard_configure_api_key_show">顯示 API Key</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -19,6 +19,10 @@
     <string name="ui_onboard_configure_model_label">Model ID</string>
     <string name="ui_onboard_configure_model_placeholder">Enter your model ID</string>
     <string name="ui_onboard_configure_model_example">Example: %1$s</string>
+    <string name="ui_onboard_configure_model_catalog_open">Pick a model</string>
+    <string name="ui_onboard_configure_model_catalog_title">Pick a model</string>
+    <string name="ui_onboard_configure_model_catalog_search_placeholder">Search models</string>
+    <string name="ui_onboard_configure_model_catalog_empty">No matching models</string>
     <string name="ui_onboard_configure_api_key_label">API Key</string>
     <string name="ui_onboard_configure_api_key_placeholder">Enter your API Key</string>
     <string name="ui_onboard_configure_api_key_show">Show API Key</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -19,6 +19,10 @@
     <string name="ui_onboard_configure_model_label">Nombre del modelo</string>
     <string name="ui_onboard_configure_model_placeholder">Introduzca el nombre del modelo</string>
     <string name="ui_onboard_configure_model_example">Ejemplo: %1$s</string>
+    <string name="ui_onboard_configure_model_catalog_open">Elegir modelo</string>
+    <string name="ui_onboard_configure_model_catalog_title">Elegir modelo</string>
+    <string name="ui_onboard_configure_model_catalog_search_placeholder">Buscar modelos</string>
+    <string name="ui_onboard_configure_model_catalog_empty">Sin modelos coincidentes</string>
     <string name="ui_onboard_configure_api_key_label">API Key</string>
     <string name="ui_onboard_configure_api_key_placeholder">Introduzca su API Key</string>
     <string name="ui_onboard_configure_api_key_show">Mostrar API Key</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -19,6 +19,10 @@
     <string name="ui_onboard_configure_model_label">モデル名</string>
     <string name="ui_onboard_configure_model_placeholder">モデル名を入力</string>
     <string name="ui_onboard_configure_model_example">例：%1$s</string>
+    <string name="ui_onboard_configure_model_catalog_open">モデルを選択</string>
+    <string name="ui_onboard_configure_model_catalog_title">モデルを選択</string>
+    <string name="ui_onboard_configure_model_catalog_search_placeholder">モデルを検索</string>
+    <string name="ui_onboard_configure_model_catalog_empty">一致するモデルがありません</string>
     <string name="ui_onboard_configure_api_key_label">API キー</string>
     <string name="ui_onboard_configure_api_key_placeholder">API キーを入力</string>
     <string name="ui_onboard_configure_api_key_show">API キーを表示</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,10 @@
     <string name="ui_onboard_configure_model_label">模型代号</string>
     <string name="ui_onboard_configure_model_placeholder">输入你的模型代号</string>
     <string name="ui_onboard_configure_model_example">如：%1$s</string>
+    <string name="ui_onboard_configure_model_catalog_open">选择模型</string>
+    <string name="ui_onboard_configure_model_catalog_title">选择模型</string>
+    <string name="ui_onboard_configure_model_catalog_search_placeholder">搜索模型</string>
+    <string name="ui_onboard_configure_model_catalog_empty">无匹配模型</string>
     <string name="ui_onboard_configure_api_key_label">API Key</string>
     <string name="ui_onboard_configure_api_key_placeholder">输入你的 API Key</string>
     <string name="ui_onboard_configure_api_key_show">显示 API Key</string>

--- a/app/src/test/java/com/niki914/zafiro/app/ui/model/ConfigureViewModelTest.kt
+++ b/app/src/test/java/com/niki914/zafiro/app/ui/model/ConfigureViewModelTest.kt
@@ -33,6 +33,8 @@ class ConfigureViewModelTest {
         val upserted = mutableListOf<SavedLlmConfig>()
         val deletedIds = mutableListOf<String>()
         val activatedIds = mutableListOf<String>()
+        var catalogResult: List<String> = emptyList()
+        var catalogError: Throwable? = null
 
         fun toDependencies(): ConfigureViewModelDependencies =
             ConfigureViewModelDependencies(
@@ -66,7 +68,10 @@ class ConfigureViewModelTest {
                     activatedIds += id
                     document = document.copy(activeId = id)
                 },
-                fetchModelCatalog = { _, _, _ -> emptyList() },
+                fetchModelCatalog = { _, _, _ ->
+                    catalogError?.let { throw it }
+                    catalogResult
+                },
             )
     }
 
@@ -169,6 +174,62 @@ class ConfigureViewModelTest {
         // VM 契约：编辑保存只 upsert，归属判定交给 repo 层
         assertEquals(1, deps.upserted.size)
         assertTrue(deps.activatedIds.isEmpty())
+    }
+
+    @Test
+    fun save_withBlankModel_sendsFocusEffectWithoutWriting() = runTest {
+        val deps = RecordingDeps()
+        val viewModel = ConfigureViewModel(deps.toDependencies())
+        viewModel.sendIntent(ConfigureIntent.Initialize(ConfigureScene.SettingsNew))
+        advanceUntilIdle()
+        val effectDeferred = async { viewModel.uiEffect.first() }
+
+        // ApiKey 已填：只剩 Model 为空，校验应停在 Model 分支
+        viewModel.sendIntent(ConfigureIntent.UpdateApiKey("sk"))
+        viewModel.sendIntent(ConfigureIntent.UpdateModel(""))
+        viewModel.sendIntent(ConfigureIntent.Save)
+        advanceUntilIdle()
+
+        assertTrue(deps.upserted.isEmpty())
+        assertEquals(ConfigureEffect.FocusModel, effectDeferred.await())
+    }
+
+    @Test
+    fun catalogFetch_successOverwritesIncludingEmpty() = runTest {
+        val deps = RecordingDeps()
+        deps.catalogResult = listOf("m-1")
+        val viewModel = ConfigureViewModel(deps.toDependencies())
+        viewModel.sendIntent(ConfigureIntent.Initialize(ConfigureScene.SettingsNew))
+        advanceUntilIdle()
+
+        viewModel.sendIntent(ConfigureIntent.UpdateApiKey("sk-1"))
+        advanceUntilIdle()
+        assertEquals(listOf("m-1"), viewModel.uiStateFlow.value.modelCatalog)
+
+        // 成功空结果也覆盖：按钮藏起，不残留旧名单
+        deps.catalogResult = emptyList()
+        viewModel.sendIntent(ConfigureIntent.UpdateApiKey("sk-2"))
+        advanceUntilIdle()
+        assertTrue(viewModel.uiStateFlow.value.modelCatalog.isEmpty())
+    }
+
+    @Test
+    fun catalogFetch_failureKeepsOldCache() = runTest {
+        val deps = RecordingDeps()
+        deps.catalogResult = listOf("m-1")
+        val viewModel = ConfigureViewModel(deps.toDependencies())
+        viewModel.sendIntent(ConfigureIntent.Initialize(ConfigureScene.SettingsNew))
+        advanceUntilIdle()
+
+        viewModel.sendIntent(ConfigureIntent.UpdateApiKey("sk-1"))
+        advanceUntilIdle()
+        assertEquals(listOf("m-1"), viewModel.uiStateFlow.value.modelCatalog)
+
+        // 失败保留旧缓存：不断网恢复前按钮仍可用
+        deps.catalogError = RuntimeException("boom")
+        viewModel.sendIntent(ConfigureIntent.UpdateApiKey("sk-2"))
+        advanceUntilIdle()
+        assertEquals(listOf("m-1"), viewModel.uiStateFlow.value.modelCatalog)
     }
 
     @Test

--- a/app/src/test/java/com/niki914/zafiro/app/ui/model/ConfigureViewModelTest.kt
+++ b/app/src/test/java/com/niki914/zafiro/app/ui/model/ConfigureViewModelTest.kt
@@ -66,6 +66,7 @@ class ConfigureViewModelTest {
                     activatedIds += id
                     document = document.copy(activeId = id)
                 },
+                fetchModelCatalog = { _, _, _ -> emptyList() },
             )
     }
 
@@ -171,19 +172,19 @@ class ConfigureViewModelTest {
     }
 
     @Test
-    fun save_withBlankModel_sendsFocusEffectWithoutWriting() = runTest {
+    fun save_withBlankApiKey_sendsFocusEffectWithoutWriting() = runTest {
         val deps = RecordingDeps()
         val viewModel = ConfigureViewModel(deps.toDependencies())
         viewModel.sendIntent(ConfigureIntent.Initialize(ConfigureScene.SettingsNew))
         advanceUntilIdle()
         val effectDeferred = async { viewModel.uiEffect.first() }
 
-        viewModel.sendIntent(ConfigureIntent.UpdateModel(""))
+        viewModel.sendIntent(ConfigureIntent.UpdateApiKey(""))
         viewModel.sendIntent(ConfigureIntent.Save)
         advanceUntilIdle()
 
         assertTrue(deps.upserted.isEmpty())
-        assertEquals(ConfigureEffect.FocusModel, effectDeferred.await())
+        assertEquals(ConfigureEffect.FocusApiKey, effectDeferred.await())
     }
 
 

--- a/app/src/test/java/com/niki914/zafiro/app/ui/model/EndpointInferenceTest.kt
+++ b/app/src/test/java/com/niki914/zafiro/app/ui/model/EndpointInferenceTest.kt
@@ -241,6 +241,43 @@ class EndpointInferenceTest {
     }
 
     @Test
+    fun `modelsUrl derives models endpoint preserving version segment`() {
+        assertEquals(
+            "https://api.openai.com/v1/models",
+            EndpointInference.modelsUrl(
+                "https://api.openai.com/v1/chat/completions",
+                LlmProtocol.OpenAiChatCompletions,
+            ),
+        )
+        assertEquals(
+            "https://dashscope.aliyuncs.com/compatible-mode/v1/models",
+            EndpointInference.modelsUrl(
+                "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions",
+                LlmProtocol.OpenAiChatCompletions,
+            ),
+        )
+        assertEquals(
+            "https://api.deepseek.com/models",
+            EndpointInference.modelsUrl(
+                "https://api.deepseek.com/chat/completions",
+                LlmProtocol.OpenAiChatCompletions,
+            ),
+        )
+        assertEquals(
+            "https://api.anthropic.com/v1/models",
+            EndpointInference.modelsUrl(
+                "https://api.anthropic.com/v1/messages",
+                LlmProtocol.AnthropicMessages,
+            ),
+        )
+    }
+
+    @Test
+    fun `modelsUrl returns null for blank endpoint`() {
+        assertEquals(null, EndpointInference.modelsUrl("  ", LlmProtocol.OpenAiResponses))
+    }
+
+    @Test
     fun `openai spec endpoint matches its default protocol`() {
         // OpenAI officialEndpoint 与 defaultProtocol 必须自洽，否则新建即不匹配
         val openai = ProviderSpecs.find("openai")

--- a/app/src/test/java/com/niki914/zafiro/repo/ModelCatalogApiTest.kt
+++ b/app/src/test/java/com/niki914/zafiro/repo/ModelCatalogApiTest.kt
@@ -1,0 +1,26 @@
+package com.niki914.zafiro.repo
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ModelCatalogApiTest {
+
+    @Test
+    fun `parseModelIds extracts sorted distinct ids`() {
+        val body = """{"data":[{"id":"gpt-b"},{"id":"gpt-a"},{"id":"gpt-b"},{"id":"  "}]}"""
+        assertEquals(listOf("gpt-a", "gpt-b"), ModelCatalogApi.parseModelIds(body))
+    }
+
+    @Test
+    fun `parseModelIds returns empty on missing data or garbage`() {
+        assertEquals(emptyList<String>(), ModelCatalogApi.parseModelIds("""{"object":"list"}"""))
+        assertEquals(emptyList<String>(), ModelCatalogApi.parseModelIds("not json"))
+        assertEquals(emptyList<String>(), ModelCatalogApi.parseModelIds(""))
+    }
+
+    @Test
+    fun `parseModelIds handles anthropic shape`() {
+        val body = """{"data":[{"id":"claude-x","display_name":"X"},{"id":""}]}"""
+        assertEquals(listOf("claude-x"), ModelCatalogApi.parseModelIds(body))
+    }
+}

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingExpandableTextCard.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingExpandableTextCard.kt
@@ -21,6 +21,7 @@ fun SettingExpandableTextCard(
     toggleSecretVisibleContentDescription: String? = null,
     toggleSecretHiddenContentDescription: String? = null,
     onExpandedChange: ((Boolean) -> Unit)? = null,
+    fieldTrailingContent: (@Composable () -> Unit)? = null,
 ) {
     SettingsGroupCard(
         title = null,
@@ -42,6 +43,7 @@ fun SettingExpandableTextCard(
             toggleSecretVisibleContentDescription = toggleSecretVisibleContentDescription,
             toggleSecretHiddenContentDescription = toggleSecretHiddenContentDescription,
             onExpandedChange = onExpandedChange,
+            fieldTrailingContent = fieldTrailingContent,
         )
     }
 }

--- a/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingExpandableTextItem.kt
+++ b/ui-kit/src/main/java/com/niki914/uikit/infra/component/SettingExpandableTextItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -54,6 +55,8 @@ fun SettingExpandableTextItem(
     toggleSecretVisibleContentDescription: String? = null,
     toggleSecretHiddenContentDescription: String? = null,
     onExpandedChange: ((Boolean) -> Unit)? = null,
+    /** 展开后输入框行的尾部内容（如模型扫描按钮）；null = 输入框占满。 */
+    fieldTrailingContent: (@Composable () -> Unit)? = null,
 ) {
     var internalExpanded by rememberSaveable { mutableStateOf(initiallyExpanded) }
     val isExpanded = expanded ?: internalExpanded
@@ -92,6 +95,7 @@ fun SettingExpandableTextItem(
                 updateExpanded(!isExpanded)
             }
         },
+        fieldTrailingContent = fieldTrailingContent,
         modifier = modifier,
     )
 }
@@ -113,6 +117,7 @@ internal fun SettingExpandableTextItemContent(
     toggleSecretHiddenContentDescription: String?,
     focusRequester: FocusRequester,
     onToggleExpanded: () -> Unit,
+    fieldTrailingContent: (@Composable () -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val animationSpec = tween<IntSize>(durationMillis = 320, easing = FastOutSlowInEasing)
@@ -191,42 +196,56 @@ internal fun SettingExpandableTextItemContent(
 
         if (expanded) {
             Spacer(modifier = Modifier.height(12.dp))
-            if (usesSecretField) {
-                LiquidSecretTextField(
-                    value = value,
-                    onValueChange = onValueChange,
-                    placeholder = placeholder,
-                    visible = secretVisible,
-                    onToggleVisibility = requireNotNull(onToggleSecretVisibility),
-                    toggleVisibleContentDescription = requireNotNull(
-                        toggleSecretVisibleContentDescription,
-                    ),
-                    toggleHiddenContentDescription = requireNotNull(
-                        toggleSecretHiddenContentDescription,
-                    ),
-                    enabled = enabled,
-                    singleLine = singleLine,
-                    moveCursorToEndOnFocus = true,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(min = fieldMinHeight)
-                        .focusRequester(focusRequester),
-                )
+            @Composable
+            fun fieldContent(fieldModifier: Modifier) {
+                if (usesSecretField) {
+                    LiquidSecretTextField(
+                        value = value,
+                        onValueChange = onValueChange,
+                        placeholder = placeholder,
+                        visible = secretVisible,
+                        onToggleVisibility = requireNotNull(onToggleSecretVisibility),
+                        toggleVisibleContentDescription = requireNotNull(
+                            toggleSecretVisibleContentDescription,
+                        ),
+                        toggleHiddenContentDescription = requireNotNull(
+                            toggleSecretHiddenContentDescription,
+                        ),
+                        enabled = enabled,
+                        singleLine = singleLine,
+                        moveCursorToEndOnFocus = true,
+                        modifier = fieldModifier
+                            .heightIn(min = fieldMinHeight)
+                            .focusRequester(focusRequester),
+                    )
+                } else {
+                    LiquidTextField(
+                        value = value,
+                        onValueChange = onValueChange,
+                        placeholder = placeholder,
+                        enabled = enabled,
+                        singleLine = singleLine,
+                        minLines = minLines,
+                        maxLines = maxLines,
+                        moveCursorToEndOnFocus = true,
+                        modifier = fieldModifier
+                            .heightIn(min = fieldMinHeight)
+                            .focusRequester(focusRequester),
+                    )
+                }
+            }
+            val trailing = fieldTrailingContent
+            if (trailing != null) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    fieldContent(Modifier.weight(1f))
+                    trailing()
+                }
             } else {
-                LiquidTextField(
-                    value = value,
-                    onValueChange = onValueChange,
-                    placeholder = placeholder,
-                    enabled = enabled,
-                    singleLine = singleLine,
-                    minLines = minLines,
-                    maxLines = maxLines,
-                    moveCursorToEndOnFocus = true,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(min = fieldMinHeight)
-                        .focusRequester(focusRequester),
-                )
+                fieldContent(Modifier.fillMaxWidth())
             }
         }
     }


### PR DESCRIPTION
## Summary

- Add id-only model catalog scan on the Configure page: auto-fetch model list when endpoint + API Key are filled, show a bottom sheet to pick a model ID
- Keep existing free-form Model field; the scan button only appears when a non-empty catalog is available
- Shared `OkHttpClient` singleton via `SharedHttp` for connection pool reuse; `UpdateCheckApi` migrated to share it

## Cache semantics

- Clear catalog cache on every `Initialize` (onboarding / new / edit) so the same ViewModel instance does not leak a previous session's list
- On fetch success: overwrite cache with the result (including empty — empty hides the button)
- On fetch failure or blank key/endpoint: keep the existing cache, log only

## Validation order

- First invalid field order is now ApiKey → Model → Endpoint → Proxy
- Removed default `exampleModelId` from Model on init; user fills Key first, then picks from the catalog or types manually

## Tests

- Restore `save_withBlankModel` coverage (ApiKey filled, Model empty → `FocusModel`)
- Add `catalogFetch_successOverwritesIncludingEmpty` and `catalogFetch_failureKeepsOldCache` regression tests
- Add `EndpointInference.modelsUrl` unit tests covering version segment preservation, DeepSeek bare domain, and blank endpoint
- Add `ModelCatalogApi.parseModelIds` tests for dedup/sort, error shapes, and Anthropic extra fields

## Notes

- Catalog fetch is not proxied (documented)
- No pagination, no capability/price parsing
- Proxy-disabled environments fall back to manual entry (button stays hidden)