### PR TITLE
fix: tighten icon-only message actions, keep finished rows visible while generating

### DIFF
--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/HomeChatComponents.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/HomeChatComponents.kt
@@ -541,7 +541,7 @@ fun TurnActionRow(
         contentAlignment = if (isAgent) Alignment.CenterStart else Alignment.CenterEnd,
     ) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(if (iconOnly) 2.dp else 8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             ActionButton(
@@ -593,7 +593,7 @@ private fun ActionButton(
 
     Box(
         modifier = Modifier
-            .size(38.dp)
+            .size(if (iconOnly) 28.dp else 38.dp)
             .then(
                 if (iconOnly) {
                     Modifier
@@ -614,7 +614,7 @@ private fun ActionButton(
         Icon(
             imageVector = icon,
             contentDescription = contentDescription,
-            modifier = Modifier.size(20.dp),
+            modifier = Modifier.size(if (iconOnly) 16.dp else 20.dp),
             tint = colorScheme.onSurfaceVariant.copy(alpha = 0.82f),
         )
     }

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/HomePageContent.kt
@@ -738,8 +738,9 @@ private fun HomeChatTurnItem(
     modifier: Modifier = Modifier,
 ) {
     val alwaysVisible = actionsDisplay == MessageActionsDisplay.Always
-    // Agent 操作行：生成中隐藏（流式中的重新生成无意义）
-    val canToggleAction = !isGenerating && turn.blocks.isNotEmpty()
+    // Agent 操作行：仅正生成中的末轮隐藏；已结束的旧 turn 常显（复制无害，
+    // 重新生成/分叉/回退在生成中点按弹 toast，见 guarded 回调）
+    val canToggleAction = turn.blocks.isNotEmpty() && (!isGenerating || !isLastTurn)
     // User 操作行资格：生成中同样放开（历史遗留修复：复制无害，重新生成/回退由 Controller 护栏拦截）；
     // 最后一条 turn 即使无内容也放开，使本条 query 仍可复制
     val userRowEligible = turn.blocks.isNotEmpty() || isLastTurn
@@ -754,6 +755,20 @@ private fun HomeChatTurnItem(
             clipboard.setClipEntry(ClipEntry(ClipData.newPlainText(null, text)))
         }
         Toast.makeText(context, R.string.ui_toast_copied, Toast.LENGTH_SHORT).show()
+    }
+
+    fun toastGenerating() {
+        Toast.makeText(context, R.string.ui_toast_generating, Toast.LENGTH_SHORT).show()
+    }
+    // 生成中：危险动作（重新生成/分叉/回退）弹 toast 提示，不透传给 Controller（其护栏会静默吞掉）
+    val guardedReGenerate: (Long) -> Unit = { id ->
+        if (isGenerating) toastGenerating() else onReGenerate(id)
+    }
+    val guardedFork: (Long) -> Unit = { id ->
+        if (isGenerating) toastGenerating() else onFork(id)
+    }
+    val guardedRewind: (Long) -> Unit = { id ->
+        if (isGenerating) toastGenerating() else onRewind(id)
     }
 
     val isActionExpanded = expandedActionTurnId == turn.id
@@ -820,9 +835,9 @@ private fun HomeChatTurnItem(
                 onCopy = {
                     copyText(userGroupText)
                 },
-                onReGenerate = { onReGenerate(turn.id) },
-                onFork = { onFork(turn.id) },
-                onRewind = { onRewind(turn.id) },
+                onReGenerate = { guardedReGenerate(turn.id) },
+                onFork = { guardedFork(turn.id) },
+                onRewind = { guardedRewind(turn.id) },
             )
         }
 
@@ -1017,8 +1032,8 @@ private fun HomeChatTurnItem(
                         .joinToString("\n\n") { it.text }
                     copyText(text)
                 },
-                onReGenerate = { onReGenerate(turn.id) },
-                onFork = { onFork(turn.id) },
+                onReGenerate = { guardedReGenerate(turn.id) },
+                onFork = { guardedFork(turn.id) },
             )
         }
     }

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -50,6 +50,7 @@
     <string name="ui_home_action_fork_content_description">分叉對話</string>
     <string name="ui_home_action_rewind_content_description">Rewind</string>
     <string name="ui_toast_copied">已複製</string>
+    <string name="ui_toast_generating">生成中，請稍後</string>
     <string name="ui_home_error_retry_body">請稍後再試。</string>
     <string name="ui_home_error_config_required_title">模型配置不完整</string>
     <string name="ui_home_error_config_required_body">請前往填寫模型配置。</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -51,6 +51,7 @@
     <string name="ui_home_action_fork_content_description">Fork conversation</string>
     <string name="ui_home_action_rewind_content_description">Rewind</string>
     <string name="ui_toast_copied">Copied</string>
+    <string name="ui_toast_generating">Generating, please wait</string>
     <string name="ui_home_error_retry_body">Please try again later.</string>
     <string name="ui_home_error_config_required_title">Model configuration is incomplete</string>
     <string name="ui_home_error_config_required_body">Please go fill in the model configuration.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -51,6 +51,7 @@
     <string name="ui_home_action_fork_content_description">Crear bifurcación</string>
     <string name="ui_home_action_rewind_content_description">Rewind</string>
     <string name="ui_toast_copied">Copiado al portapapeles</string>
+    <string name="ui_toast_generating">Generando, espere un momento</string>
     <string name="ui_home_error_retry_body">Inténtelo de nuevo más tarde.</string>
     <string name="ui_home_error_config_required_title">Configuración del modelo incompleta</string>
     <string name="ui_home_error_config_required_body">Complete la configuración del modelo antes de continuar.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -50,6 +50,7 @@
     <string name="ui_home_action_fork_content_description">会話を分岐</string>
     <string name="ui_home_action_rewind_content_description">Rewind</string>
     <string name="ui_toast_copied">コピーしました</string>
+    <string name="ui_toast_generating">生成中です、しばらくお待ちください</string>
     <string name="ui_home_error_retry_body">しばらくしてからもう一度お試しください。</string>
     <string name="ui_home_error_config_required_title">モデル設定が不完全です</string>
     <string name="ui_home_error_config_required_body">モデル設定を完了してください。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="ui_home_action_fork_content_description">分叉对话</string>
     <string name="ui_home_action_rewind_content_description">Rewind</string>
     <string name="ui_toast_copied">已复制</string>
+    <string name="ui_toast_generating">生成中，请稍后</string>
     <string name="ui_home_error_retry_body">请稍后重试。</string>
     <string name="ui_home_error_config_required_title">模型配置不完整</string>
     <string name="ui_home_error_config_required_body">请前往填写模型配置。</string>


### PR DESCRIPTION
## 内容

1. icon-only（Always）模式收紧：触摸框 38dp → 28dp，图标间距 8dp → 2dp，图标 20dp → 16dp。
2. 发新消息时已结束的 agent 操作行不再短暂消失：显示资格改看末轮（有 blocks 且非正生成中的末轮不隐藏），去全局 isGenerating。
3. 生成中点旧条的重新生成/分叉/回退弹多语言 toast（ui_toast_generating，5 套 strings），复制不受影响。

## 验证

- debug 包本地构建通过并真机验收通过。