### PR TITLE
feat: add storage management page in settings

### DIFF
--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/SettingsDetailPageContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/SettingsDetailPageContent.kt
@@ -78,6 +78,11 @@ fun SettingsDetailPageContent(
         return
     }
 
+    if (group == ZafiroSettingsGroup.Storage) {
+        StorageSettingsContent()
+        return
+    }
+
     if (group == ZafiroSettingsGroup.About) {
         AboutSettingsContent()
         return

--- a/app/src/main/java/com/niki914/zafiro/app/ui/content/StorageSettingsContent.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/content/StorageSettingsContent.kt
@@ -1,0 +1,184 @@
+package com.niki914.zafiro.app.ui.content
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.niki914.uikit.base.BaseTheme
+import com.niki914.uikit.infra.ConfirmationLiquidDialog
+import com.niki914.uikit.infra.ProvideLiquidScreenContentForPreview
+import com.niki914.uikit.infra.component.SettingsGroupCard
+import com.niki914.uikit.infra.component.SettingsItemDivider
+import com.niki914.uikit.infra.component.SettingsListItem
+import com.niki914.uikit.infra.component.SettingsListPageContent
+import com.niki914.uikit.infra.nav.pageViewModel
+import com.niki914.zafiro.app.R
+import com.niki914.zafiro.app.ui.PageBackHandler
+import com.niki914.zafiro.app.ui.PageChromeContribution
+import com.niki914.zafiro.app.ui.RegisterPageChrome
+import com.niki914.zafiro.app.ui.model.StorageCategory
+import com.niki914.zafiro.app.ui.model.StorageCategoryUiState
+import com.niki914.zafiro.app.ui.model.StorageConfirmationState
+import com.niki914.zafiro.app.ui.model.StorageInlineError
+import com.niki914.zafiro.app.ui.model.StorageSettingsIntent
+import com.niki914.zafiro.app.ui.model.StorageSettingsUiState
+import com.niki914.zafiro.app.ui.model.StorageSettingsViewModel
+import com.niki914.zafiro.app.ui.model.formatStorageBytes
+
+@Composable
+fun StorageSettingsContent() {
+    val viewModel = pageViewModel<StorageSettingsViewModel>()
+    val uiState by viewModel.uiStateFlow.collectAsState()
+    val latestUiState by rememberUpdatedState(uiState)
+    val latestViewModel by rememberUpdatedState(viewModel)
+    val pageChromeContribution = remember(viewModel) {
+        PageChromeContribution(
+            backHandler = PageBackHandler(
+                shouldConsumeBack = { latestUiState.confirmation != null },
+                onConsumeBack = {
+                    latestViewModel.sendIntent(StorageSettingsIntent.DismissConfirmation)
+                },
+            ),
+        )
+    }
+    RegisterPageChrome(pageChromeContribution)
+
+    LaunchedEffect(Unit) {
+        viewModel.sendIntent(StorageSettingsIntent.Load)
+    }
+
+    StorageSettingsContentBody(
+        uiState = uiState,
+        onRequestClear = { category ->
+            viewModel.sendIntent(StorageSettingsIntent.RequestClear(category))
+        },
+        onConfirmationDismiss = {
+            viewModel.sendIntent(StorageSettingsIntent.DismissConfirmation)
+        },
+        onConfirmationConfirm = {
+            viewModel.sendIntent(StorageSettingsIntent.ConfirmClear)
+        },
+    )
+}
+
+@Composable
+private fun StorageSettingsContentBody(
+    uiState: StorageSettingsUiState,
+    onRequestClear: (StorageCategory) -> Unit,
+    onConfirmationDismiss: () -> Unit,
+    onConfirmationConfirm: () -> Unit,
+) {
+    SettingsListPageContent(
+        description = stringResource(R.string.ui_settings_storage_description),
+    ) {
+        SettingsGroupCard {
+            if (uiState.isLoading && uiState.categories.isEmpty()) {
+                SettingsListItem(
+                    title = stringResource(R.string.ui_settings_storage_loading),
+                    onClick = null,
+                )
+            } else {
+                uiState.categories.forEachIndexed { index, item ->
+                    if (index > 0) {
+                        SettingsItemDivider()
+                    }
+                    SettingsListItem(
+                        title = stringResource(item.category.titleRes),
+                        summary = stringResource(item.category.descriptionRes),
+                        currentState = if (item.isClearing) {
+                            "…"
+                        } else {
+                            formatStorageBytes(item.bytes)
+                        },
+                        showChevron = true,
+                        enabled = !item.isClearing,
+                        onClick = {
+                            onRequestClear(item.category)
+                        },
+                    )
+                }
+            }
+        }
+
+        uiState.inlineError?.let { error ->
+            StorageInlineErrorText(error = error)
+        }
+    }
+
+    StorageClearConfirmationDialog(
+        state = uiState.confirmation,
+        onDismissRequest = onConfirmationDismiss,
+        onConfirmClick = onConfirmationConfirm,
+    )
+}
+
+@Composable
+private fun StorageClearConfirmationDialog(
+    state: StorageConfirmationState?,
+    onDismissRequest: () -> Unit,
+    onConfirmClick: () -> Unit,
+) {
+    if (state == null) return
+    ConfirmationLiquidDialog(
+        visible = true,
+        onDismissRequest = onDismissRequest,
+        title = stringResource(R.string.ui_settings_storage_clear_dialog_title),
+        text = stringResource(
+            R.string.ui_settings_storage_clear_dialog_text,
+            stringResource(state.category.titleRes),
+        ),
+        negativeButtonText = stringResource(R.string.ui_settings_storage_clear_dialog_cancel),
+        positiveButtonText = stringResource(R.string.ui_settings_storage_clear_dialog_confirm),
+        onNegativeClick = onDismissRequest,
+        onPositiveClick = onConfirmClick,
+    )
+}
+
+@Composable
+private fun StorageInlineErrorText(error: StorageInlineError) {
+    val message = when (error) {
+        is StorageInlineError.LoadFailed -> stringResource(
+            R.string.ui_settings_storage_error_load_failed,
+            error.message ?: "",
+        )
+        is StorageInlineError.ClearFailed -> stringResource(
+            R.string.ui_settings_storage_error_clear_failed,
+            error.message ?: "",
+        )
+    }
+    Text(
+        text = message,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.error,
+    )
+}
+
+@Preview(name = "Storage Settings", showBackground = true, widthDp = 420, heightDp = 900)
+@Composable
+private fun StorageSettingsContentPreview() {
+    BaseTheme(darkTheme = false, dynamicColor = false) {
+        ProvideLiquidScreenContentForPreview(topPadding = 0.dp) {
+            StorageSettingsContentBody(
+                uiState = StorageSettingsUiState(
+                    categories = StorageCategory.entries.mapIndexed { index, category ->
+                        StorageCategoryUiState(
+                            category = category,
+                            bytes = (index + 1) * 12_582_912L,
+                        )
+                    },
+                    isLoading = false,
+                ),
+                onRequestClear = {},
+                onConfirmationDismiss = {},
+                onConfirmationConfirm = {},
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/SettingsState.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/SettingsState.kt
@@ -93,6 +93,7 @@ private fun settingsSections(): List<SettingsSectionDefinition> {
         SettingsSectionDefinition(
             titleRes = R.string.ui_settings_section_app,
             groups = listOf(
+                ZafiroSettingsGroup.Storage,
                 ZafiroSettingsGroup.About,
             ),
         ),

--- a/app/src/main/java/com/niki914/zafiro/app/ui/model/StorageSettingsState.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/model/StorageSettingsState.kt
@@ -1,0 +1,176 @@
+package com.niki914.zafiro.app.ui.model
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.viewModelScope
+import com.niki914.logging.Logger
+import com.niki914.uikit.base.ComposeMVIViewModel
+import com.niki914.zafiro.app.R
+import com.niki914.zafiro.repo.StorageApi
+import com.niki914.zafiro.repo.StorageKind
+import com.niki914.zafiro.repo.StorageUsage
+import com.niki914.zafiro.repo.XRepo
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+
+enum class StorageCategory(
+    val kind: StorageKind,
+    @StringRes val titleRes: Int,
+    @StringRes val descriptionRes: Int,
+) {
+    ToolOutput(
+        kind = StorageKind.ToolOutput,
+        titleRes = R.string.ui_settings_storage_tool_output,
+        descriptionRes = R.string.ui_settings_storage_tool_output_summary,
+    ),
+    ImageCache(
+        kind = StorageKind.ImageCache,
+        titleRes = R.string.ui_settings_storage_image_cache,
+        descriptionRes = R.string.ui_settings_storage_image_cache_summary,
+    ),
+    Downloads(
+        kind = StorageKind.Downloads,
+        titleRes = R.string.ui_settings_storage_downloads,
+        descriptionRes = R.string.ui_settings_storage_downloads_summary,
+    ),
+    OtherCache(
+        kind = StorageKind.OtherCache,
+        titleRes = R.string.ui_settings_storage_other_cache,
+        descriptionRes = R.string.ui_settings_storage_other_cache_summary,
+    ),
+}
+
+data class StorageCategoryUiState(
+    val category: StorageCategory,
+    val bytes: Long,
+    val isClearing: Boolean = false,
+)
+
+data class StorageConfirmationState(
+    val category: StorageCategory,
+)
+
+data class StorageSettingsUiState(
+    val categories: List<StorageCategoryUiState> = emptyList(),
+    val isLoading: Boolean = true,
+    val confirmation: StorageConfirmationState? = null,
+    val inlineError: StorageInlineError? = null,
+)
+
+sealed interface StorageInlineError {
+    data class LoadFailed(val message: String?) : StorageInlineError
+    data class ClearFailed(val message: String?) : StorageInlineError
+}
+
+sealed interface StorageSettingsIntent {
+    data object Load : StorageSettingsIntent
+    data class RequestClear(val category: StorageCategory) : StorageSettingsIntent
+    data object DismissConfirmation : StorageSettingsIntent
+    data object ConfirmClear : StorageSettingsIntent
+}
+
+interface StorageUsageProvider {
+    suspend fun usage(): List<StorageUsage>
+    suspend fun clear(kind: StorageKind)
+}
+
+class XRepoStorageUsageProvider : StorageUsageProvider {
+    private val api: StorageApi
+        get() = XRepo.storage
+
+    override suspend fun usage(): List<StorageUsage> = api.usage()
+    override suspend fun clear(kind: StorageKind) = api.clear(kind)
+}
+
+class StorageSettingsViewModel(
+    private val provider: StorageUsageProvider = XRepoStorageUsageProvider(),
+) : ComposeMVIViewModel<StorageSettingsIntent, StorageSettingsUiState, Nothing>() {
+
+    override fun initUiState(): StorageSettingsUiState = StorageSettingsUiState()
+
+    override suspend fun handleIntent(intent: StorageSettingsIntent) {
+        when (intent) {
+            StorageSettingsIntent.Load -> load()
+            is StorageSettingsIntent.RequestClear -> updateState {
+                copy(confirmation = StorageConfirmationState(intent.category), inlineError = null)
+            }
+            StorageSettingsIntent.DismissConfirmation -> updateState {
+                copy(confirmation = null, inlineError = null)
+            }
+            StorageSettingsIntent.ConfirmClear -> confirmClear()
+        }
+    }
+
+    private suspend fun load() {
+        updateState { copy(isLoading = true) }
+        try {
+            val usage = provider.usage().associateBy { it.kind }
+            updateState {
+                copy(
+                    categories = StorageCategory.entries.map { category ->
+                        StorageCategoryUiState(
+                            category = category,
+                            bytes = usage[category.kind]?.bytes ?: 0L,
+                        )
+                    },
+                    isLoading = false,
+                    confirmation = null,
+                    inlineError = null,
+                )
+            }
+        } catch (throwable: Throwable) {
+            if (throwable is CancellationException) throw throwable
+            Logger.w(LOG_TAG, "load failed reason=${throwable.message}")
+            updateState {
+                copy(
+                    isLoading = false,
+                    inlineError = StorageInlineError.LoadFailed(throwable.message),
+                )
+            }
+        }
+    }
+
+    private suspend fun confirmClear() {
+        val category = currentState.confirmation?.category ?: return
+        updateState {
+            copy(
+                confirmation = null,
+                categories = categories.map {
+                    if (it.category == category) it.copy(isClearing = true) else it
+                },
+                inlineError = null,
+            )
+        }
+        try {
+            provider.clear(category.kind)
+            Logger.i(LOG_TAG, "clear succeeded category=${category.kind}")
+            load()
+        } catch (throwable: Throwable) {
+            if (throwable is CancellationException) throw throwable
+            Logger.w(LOG_TAG, "clear failed category=${category.kind} reason=${throwable.message}")
+            load()
+            updateState {
+                copy(inlineError = StorageInlineError.ClearFailed(throwable.message))
+            }
+        }
+    }
+
+    private companion object {
+        private const val LOG_TAG = "niki914_nexus_StorageSettingsViewModel"
+    }
+}
+
+internal fun formatStorageBytes(bytes: Long): String {
+    if (bytes <= 0L) return "0 B"
+    val units = arrayOf("B", "KB", "MB", "GB")
+    var value = bytes.toDouble()
+    var unitIndex = 0
+    while (value >= 1024 && unitIndex < units.lastIndex) {
+        value /= 1024
+        unitIndex++
+    }
+    return if (unitIndex == 0) {
+        "${value.toLong()} ${units[unitIndex]}"
+    } else {
+        "%.1f %s".format(value, units[unitIndex])
+    }
+}

--- a/app/src/main/java/com/niki914/zafiro/app/ui/nav/ZafiroSettingsGroup.kt
+++ b/app/src/main/java/com/niki914/zafiro/app/ui/nav/ZafiroSettingsGroup.kt
@@ -48,6 +48,11 @@ enum class ZafiroSettingsGroup(
         summaryRes = R.string.ui_settings_general_summary,
         routeSuffix = "general-settings",
     ),
+    Storage(
+        titleRes = R.string.ui_settings_storage,
+        summaryRes = R.string.ui_settings_storage_summary,
+        routeSuffix = "storage",
+    ),
     About(
         titleRes = R.string.ui_settings_about,
         summaryRes = R.string.ui_settings_about_summary,

--- a/app/src/main/java/com/niki914/zafiro/repo/StorageApi.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/StorageApi.kt
@@ -1,0 +1,64 @@
+package com.niki914.zafiro.repo
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+enum class StorageKind {
+    ToolOutput,
+    ImageCache,
+    Downloads,
+    OtherCache,
+}
+
+data class StorageUsage(
+    val kind: StorageKind,
+    val bytes: Long,
+)
+
+class StorageApi internal constructor(
+    private val repo: XRepo,
+) {
+    suspend fun usage(): List<StorageUsage> {
+        return withContext(Dispatchers.IO) {
+            val context = repo.context()
+            StorageKind.entries.map { kind ->
+                StorageUsage(kind, dirSize(resolveDir(context, kind)))
+            }
+        }
+    }
+
+    suspend fun clear(kind: StorageKind) {
+        withContext(Dispatchers.IO) {
+            val dir = resolveDir(repo.context(), kind)
+            if (!dir.exists()) return@withContext
+            dir.listFiles()?.forEach { child ->
+                runCatching {
+                    if (child.isDirectory) child.deleteRecursively() else child.delete()
+                }
+            }
+        }
+    }
+
+    private fun resolveDir(context: android.content.Context, kind: StorageKind): File {
+        return when (kind) {
+            StorageKind.ToolOutput -> File(context.filesDir, TOOL_OUTPUT_DIR_NAME)
+            StorageKind.ImageCache -> File(context.filesDir, IMAGE_CACHE_DIR_NAME)
+            StorageKind.Downloads -> File(context.filesDir, DOWNLOADS_DIR_NAME)
+            StorageKind.OtherCache -> context.cacheDir
+        }
+    }
+
+    private fun dirSize(dir: File): Long {
+        if (!dir.exists()) return 0L
+        return runCatching {
+            dir.walkTopDown().filter { it.isFile }.sumOf { it.length() }
+        }.getOrDefault(0L)
+    }
+
+    private companion object {
+        const val TOOL_OUTPUT_DIR_NAME = "tool_output"
+        const val IMAGE_CACHE_DIR_NAME = "image_cache"
+        const val DOWNLOADS_DIR_NAME = "downloads"
+    }
+}

--- a/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
+++ b/app/src/main/java/com/niki914/zafiro/repo/XRepo.kt
@@ -48,6 +48,7 @@ object XRepo {
     val takeoverRules: TakeoverRulesApi = TakeoverRulesApi(this)
     val agents: AgentApi = AgentApi(this)
     val skills: SkillApi = SkillApi(this)
+    val storage: StorageApi = StorageApi(this)
     val llmConfigs = LlmConfigsApi(this)
 
     private val writeMutex = Mutex()

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -125,6 +125,8 @@
     <string name="ui_settings_takeover_summary">設定哪些輸入交給原生助理或 Zafiro</string>
     <string name="ui_settings_execution_rules">執行規則</string>
     <string name="ui_settings_execution_rules_summary">設定 Shell 的安全策略</string>
+    <string name="ui_settings_storage">儲存空間</string>
+    <string name="ui_settings_storage_summary">清理快取與下載檔案</string>
     <string name="ui_settings_about">關於</string>
     <string name="ui_settings_about_summary"></string>
     <string name="ui_settings_about_description">讓語音助理用上你自己的模型能力</string>
@@ -135,6 +137,23 @@
     <string name="ui_settings_about_feedback_feature">功能建議</string>
     <string name="ui_settings_about_feedback_bug">Bug 回報</string>
     <string name="ui_settings_about_version">版本</string>
+
+    <string name="ui_settings_storage_description">查看各類快取佔用的空間，點選某一項即可清理。清理不會影響設定、記憶與對話記錄。</string>
+    <string name="ui_settings_storage_tool_output">工具輸出快取</string>
+    <string name="ui_settings_storage_tool_output_summary">超長工具輸出的截斷匯出</string>
+    <string name="ui_settings_storage_image_cache">圖片快取</string>
+    <string name="ui_settings_storage_image_cache_summary">清理後歷史訊息中的圖片將無法顯示</string>
+    <string name="ui_settings_storage_downloads">下載檔案</string>
+    <string name="ui_settings_storage_downloads_summary">Agent 在任務過程中下載的檔案</string>
+    <string name="ui_settings_storage_other_cache">其他快取</string>
+    <string name="ui_settings_storage_other_cache_summary">應用運行時的暫存檔案</string>
+    <string name="ui_settings_storage_loading">正在統計儲存空間...</string>
+    <string name="ui_settings_storage_clear_dialog_title">清理快取</string>
+    <string name="ui_settings_storage_clear_dialog_text">確定要清空「%1$s」嗎？此操作不可撤銷。</string>
+    <string name="ui_settings_storage_clear_dialog_confirm">清理</string>
+    <string name="ui_settings_storage_clear_dialog_cancel">取消</string>
+    <string name="ui_settings_storage_error_load_failed">統計儲存空間失敗：%1$s</string>
+    <string name="ui_settings_storage_error_clear_failed">清理失敗：%1$s</string>
 
     <!-- Settings Detail Shared -->
     <string name="ui_todo_page_title">功能開發中</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -126,6 +126,8 @@
     <string name="ui_settings_takeover_summary">Route matched requests to the native assistant or Zafiro</string>
     <string name="ui_settings_execution_rules">Execution Rules</string>
     <string name="ui_settings_execution_rules_summary">Set safety rules for Shell execution</string>
+    <string name="ui_settings_storage">Storage</string>
+    <string name="ui_settings_storage_summary">Clear caches and downloaded files</string>
     <string name="ui_settings_about">About</string>
     <string name="ui_settings_about_summary"></string>
     <string name="ui_settings_about_description">Bring your own model to your voice assistant</string>
@@ -136,6 +138,23 @@
     <string name="ui_settings_about_feedback_feature">Feature Requests</string>
     <string name="ui_settings_about_feedback_bug">Bug Reports</string>
     <string name="ui_settings_about_version">Version</string>
+
+    <string name="ui_settings_storage_description">See how much space each cache takes. Tap an item to clear it. Clearing never touches settings, memories, or conversations.</string>
+    <string name="ui_settings_storage_tool_output">Tool output cache</string>
+    <string name="ui_settings_storage_tool_output_summary">Exported full output of truncated tool results</string>
+    <string name="ui_settings_storage_image_cache">Image cache</string>
+    <string name="ui_settings_storage_image_cache_summary">Images in past conversations will no longer load</string>
+    <string name="ui_settings_storage_downloads">Downloaded files</string>
+    <string name="ui_settings_storage_downloads_summary">Files downloaded by the Agent during tasks</string>
+    <string name="ui_settings_storage_other_cache">Other caches</string>
+    <string name="ui_settings_storage_other_cache_summary">Temporary files from normal app operation</string>
+    <string name="ui_settings_storage_loading">Measuring storage...</string>
+    <string name="ui_settings_storage_clear_dialog_title">Clear cache</string>
+    <string name="ui_settings_storage_clear_dialog_text">Clear \"%1$s\"? This action cannot be undone.</string>
+    <string name="ui_settings_storage_clear_dialog_confirm">Clear</string>
+    <string name="ui_settings_storage_clear_dialog_cancel">Cancel</string>
+    <string name="ui_settings_storage_error_load_failed">Failed to measure storage: %1$s</string>
+    <string name="ui_settings_storage_error_clear_failed">Failed to clear: %1$s</string>
 
     <!-- Settings Detail Shared -->
     <string name="ui_todo_page_title">Coming Soon</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -126,6 +126,8 @@
     <string name="ui_settings_takeover_summary">Configurar qué entradas procesa el asistente nativo o Zafiro</string>
     <string name="ui_settings_execution_rules">Reglas de ejecución</string>
     <string name="ui_settings_execution_rules_summary">Configurar la política de seguridad para comandos Shell</string>
+    <string name="ui_settings_storage">Almacenamiento</string>
+    <string name="ui_settings_storage_summary">Borrar cachés y archivos descargados</string>
     <string name="ui_settings_about">Acerca de</string>
     <string name="ui_settings_about_summary"></string>
     <string name="ui_settings_about_description">Conecte su asistente de voz a sus propios modelos</string>
@@ -136,6 +138,23 @@
     <string name="ui_settings_about_feedback_feature">Sugerir función</string>
     <string name="ui_settings_about_feedback_bug">Notificar error</string>
     <string name="ui_settings_about_version">Versión</string>
+
+    <string name="ui_settings_storage_description">Consulta el espacio que ocupa cada caché y tócalo para borrarlo. Nunca se tocan los ajustes, los recuerdos ni las conversaciones.</string>
+    <string name="ui_settings_storage_tool_output">Caché de salida</string>
+    <string name="ui_settings_storage_tool_output_summary">Salida completa exportada de resultados truncados</string>
+    <string name="ui_settings_storage_image_cache">Caché de imágenes</string>
+    <string name="ui_settings_storage_image_cache_summary">Las imágenes de conversaciones anteriores dejarán de mostrarse</string>
+    <string name="ui_settings_storage_downloads">Archivos descargados</string>
+    <string name="ui_settings_storage_downloads_summary">Archivos descargados por el Agente durante las tareas</string>
+    <string name="ui_settings_storage_other_cache">Otras cachés</string>
+    <string name="ui_settings_storage_other_cache_summary">Archivos temporales del funcionamiento normal</string>
+    <string name="ui_settings_storage_loading">Midiendo el almacenamiento...</string>
+    <string name="ui_settings_storage_clear_dialog_title">Borrar caché</string>
+    <string name="ui_settings_storage_clear_dialog_text">¿Vaciar «%1$s»? Esta acción no se puede deshacer.</string>
+    <string name="ui_settings_storage_clear_dialog_confirm">Borrar</string>
+    <string name="ui_settings_storage_clear_dialog_cancel">Cancelar</string>
+    <string name="ui_settings_storage_error_load_failed">No se pudo medir el almacenamiento: %1$s</string>
+    <string name="ui_settings_storage_error_clear_failed">No se pudo borrar: %1$s</string>
 
     <!-- Settings Detail Shared -->
     <string name="ui_todo_page_title">Función en desarrollo</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -125,6 +125,8 @@
     <string name="ui_settings_takeover_summary">入力に応じてネイティブアシスタントと Zafiro のどちらが応答するかを設定</string>
     <string name="ui_settings_execution_rules">実行ルール</string>
     <string name="ui_settings_execution_rules_summary">Shell のセキュリティポリシーを設定</string>
+    <string name="ui_settings_storage">ストレージ</string>
+    <string name="ui_settings_storage_summary">キャッシュとダウンロード済みファイルを削除</string>
     <string name="ui_settings_about">アプリについて</string>
     <string name="ui_settings_about_summary"></string>
     <string name="ui_settings_about_description">音声アシスタントに独自のモデル機能を連携</string>
@@ -135,6 +137,23 @@
     <string name="ui_settings_about_feedback_feature">機能のリクエスト</string>
     <string name="ui_settings_about_feedback_bug">バグ報告</string>
     <string name="ui_settings_about_version">バージョン</string>
+
+    <string name="ui_settings_storage_description">各種キャッシュの使用量を確認し、タップして削除できます。設定・記憶・会話履歴には影響しません。</string>
+    <string name="ui_settings_storage_tool_output">ツール出力キャッシュ</string>
+    <string name="ui_settings_storage_tool_output_summary">切り詰められたツール出力のフルエクスポート</string>
+    <string name="ui_settings_storage_image_cache">画像キャッシュ</string>
+    <string name="ui_settings_storage_image_cache_summary">削除すると過去のメッセージの画像が表示できなくなります</string>
+    <string name="ui_settings_storage_downloads">ダウンロード済みファイル</string>
+    <string name="ui_settings_storage_downloads_summary">タスク中に Agent がダウンロードしたファイル</string>
+    <string name="ui_settings_storage_other_cache">その他のキャッシュ</string>
+    <string name="ui_settings_storage_other_cache_summary">通常動作で生じる一時ファイル</string>
+    <string name="ui_settings_storage_loading">ストレージを計測中...</string>
+    <string name="ui_settings_storage_clear_dialog_title">キャッシュを削除</string>
+    <string name="ui_settings_storage_clear_dialog_text">「%1$s」を空にしてもよろしいですか？この操作は取り消せません。</string>
+    <string name="ui_settings_storage_clear_dialog_confirm">削除</string>
+    <string name="ui_settings_storage_clear_dialog_cancel">キャンセル</string>
+    <string name="ui_settings_storage_error_load_failed">ストレージの計測に失敗しました：%1$s</string>
+    <string name="ui_settings_storage_error_clear_failed">削除に失敗しました：%1$s</string>
 
     <!-- Settings Detail Shared -->
     <string name="ui_todo_page_title">開発中の機能です</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,6 +125,8 @@
     <string name="ui_settings_takeover_summary">设置哪些输入交给原生助手或 Zafiro</string>
     <string name="ui_settings_execution_rules">执行规则</string>
     <string name="ui_settings_execution_rules_summary">设置 Shell 的安全策略</string>
+    <string name="ui_settings_storage">存储空间</string>
+    <string name="ui_settings_storage_summary">清理缓存与下载文件</string>
     <string name="ui_settings_about">关于</string>
     <string name="ui_settings_about_summary"></string>
     <string name="ui_settings_about_description">让语音助手，接入您自己的模型能力</string>
@@ -135,6 +137,23 @@
     <string name="ui_settings_about_feedback_feature">功能建议</string>
     <string name="ui_settings_about_feedback_bug">Bug 反馈</string>
     <string name="ui_settings_about_version">版本号</string>
+
+    <string name="ui_settings_storage_description">查看各类缓存占用的空间，点击某一项可清理。清理不会影响配置、记忆与对话记录。</string>
+    <string name="ui_settings_storage_tool_output">工具输出缓存</string>
+    <string name="ui_settings_storage_tool_output_summary">超长工具输出的截断导出</string>
+    <string name="ui_settings_storage_image_cache">图片缓存</string>
+    <string name="ui_settings_storage_image_cache_summary">清理后历史消息中的图片将无法显示</string>
+    <string name="ui_settings_storage_downloads">下载文件</string>
+    <string name="ui_settings_storage_downloads_summary">Agent 在任务过程中下载的文件</string>
+    <string name="ui_settings_storage_other_cache">其他缓存</string>
+    <string name="ui_settings_storage_other_cache_summary">应用运行时的临时文件</string>
+    <string name="ui_settings_storage_loading">正在统计存储空间...</string>
+    <string name="ui_settings_storage_clear_dialog_title">清理缓存</string>
+    <string name="ui_settings_storage_clear_dialog_text">确定要清空「%1$s」吗？此操作不可撤销。</string>
+    <string name="ui_settings_storage_clear_dialog_confirm">清理</string>
+    <string name="ui_settings_storage_clear_dialog_cancel">取消</string>
+    <string name="ui_settings_storage_error_load_failed">统计存储空间失败：%1$s</string>
+    <string name="ui_settings_storage_error_clear_failed">清理失败：%1$s</string>
 
     <!-- Settings Detail Shared -->
     <string name="ui_todo_page_title">功能正在开发中</string>

--- a/app/src/test/java/com/niki914/zafiro/app/ui/model/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/niki914/zafiro/app/ui/model/SettingsViewModelTest.kt
@@ -22,7 +22,7 @@ class SettingsViewModelTest {
             )
         )
 
-        assertEquals(4, state.sections.size)
+        assertEquals(5, state.sections.size)
         assertEquals(
             listOf(ZafiroSettingsGroup.ModelConfig),
             state.sections[0].groups,
@@ -45,6 +45,10 @@ class SettingsViewModelTest {
             ),
             state.sections[3].groups,
         )
+        assertEquals(
+            listOf(ZafiroSettingsGroup.Storage),
+            state.sections[4].groups,
+        )
     }
 
     @Test
@@ -59,6 +63,7 @@ class SettingsViewModelTest {
         assertTrue(state.isGroupVisible(ZafiroSettingsGroup.Mcp))
         assertTrue(state.isGroupVisible(ZafiroSettingsGroup.Takeover))
         assertTrue(state.isGroupVisible(ZafiroSettingsGroup.ExecutionRules))
+        assertTrue(state.isGroupVisible(ZafiroSettingsGroup.Storage))
         assertTrue(state.isGroupVisible(ZafiroSettingsGroup.About))
     }
 }

--- a/app/src/test/java/com/niki914/zafiro/app/ui/model/StorageSettingsViewModelTest.kt
+++ b/app/src/test/java/com/niki914/zafiro/app/ui/model/StorageSettingsViewModelTest.kt
@@ -1,0 +1,127 @@
+package com.niki914.zafiro.app.ui.model
+
+import com.niki914.zafiro.app.util.SilentLoggerRule
+import com.niki914.zafiro.repo.StorageKind
+import com.niki914.zafiro.repo.StorageUsage
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StorageSettingsViewModelTest {
+    @get:Rule
+    val silentLoggerRule = SilentLoggerRule()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun load_withUsage_showsCategoriesAndSizes() = runTest {
+        val viewModel = StorageSettingsViewModel(
+            FakeStorageUsageProvider(
+                usage = listOf(
+                    StorageUsage(StorageKind.ToolOutput, 1024L),
+                    StorageUsage(StorageKind.ImageCache, 2_097_152L),
+                ),
+            ),
+        )
+
+        viewModel.sendIntent(StorageSettingsIntent.Load)
+        advanceUntilIdle()
+
+        val state = viewModel.uiStateFlow.value
+        assertFalse(state.isLoading)
+        assertEquals(4, state.categories.size)
+        assertEquals(1024L, state.categories[0].bytes)
+        assertEquals(2_097_152L, state.categories[1].bytes)
+        assertEquals(0L, state.categories[2].bytes)
+        assertEquals(0L, state.categories[3].bytes)
+        assertNull(state.inlineError)
+    }
+
+    @Test
+    fun load_whenProviderThrows_setsLoadFailed() = runTest {
+        val viewModel = StorageSettingsViewModel(
+            FakeStorageUsageProvider(loadThrowable = IllegalStateException("boom")),
+        )
+
+        viewModel.sendIntent(StorageSettingsIntent.Load)
+        advanceUntilIdle()
+
+        val state = viewModel.uiStateFlow.value
+        assertFalse(state.isLoading)
+        assertTrue(state.inlineError is StorageInlineError.LoadFailed)
+    }
+
+    @Test
+    fun confirmClear_clearsCategoryAndReloads() = runTest {
+        val provider = FakeStorageUsageProvider(
+            usage = listOf(StorageUsage(StorageKind.Downloads, 4096L)),
+        )
+        val viewModel = StorageSettingsViewModel(provider)
+        viewModel.sendIntent(StorageSettingsIntent.Load)
+        advanceUntilIdle()
+
+        viewModel.sendIntent(StorageSettingsIntent.RequestClear(StorageCategory.Downloads))
+        advanceUntilIdle()
+        viewModel.sendIntent(StorageSettingsIntent.ConfirmClear)
+        advanceUntilIdle()
+
+        assertEquals(listOf(StorageKind.Downloads), provider.cleared)
+        val state = viewModel.uiStateFlow.value
+        assertNull(state.confirmation)
+        assertFalse(state.categories[2].isClearing)
+        assertNull(state.inlineError)
+    }
+
+    @Test
+    fun confirmClear_whenProviderThrows_setsClearFailed() = runTest {
+        val viewModel = StorageSettingsViewModel(
+            FakeStorageUsageProvider(clearThrowable = IllegalStateException("boom")),
+        )
+        viewModel.sendIntent(StorageSettingsIntent.Load)
+        advanceUntilIdle()
+
+        viewModel.sendIntent(StorageSettingsIntent.RequestClear(StorageCategory.OtherCache))
+        advanceUntilIdle()
+        viewModel.sendIntent(StorageSettingsIntent.ConfirmClear)
+        advanceUntilIdle()
+
+        val state = viewModel.uiStateFlow.value
+        assertNull(state.confirmation)
+        assertTrue(state.inlineError is StorageInlineError.ClearFailed)
+    }
+
+    @Test
+    fun formatStorageBytes_formatsUnits() {
+        assertEquals("0 B", formatStorageBytes(0L))
+        assertEquals("512 B", formatStorageBytes(512L))
+        assertEquals("1.0 KB", formatStorageBytes(1024L))
+        assertEquals("12.0 MB", formatStorageBytes(12_582_912L))
+        assertEquals("2.0 GB", formatStorageBytes(2_147_483_648L))
+    }
+
+    private class FakeStorageUsageProvider(
+        private val usage: List<StorageUsage> = emptyList(),
+        private val loadThrowable: Throwable? = null,
+        private val clearThrowable: Throwable? = null,
+    ) : StorageUsageProvider {
+        val cleared = mutableListOf<StorageKind>()
+
+        override suspend fun usage(): List<StorageUsage> {
+            loadThrowable?.let { throw it }
+            return usage
+        }
+
+        override suspend fun clear(kind: StorageKind) {
+            clearThrowable?.let { throw it }
+            cleared += kind
+        }
+    }
+}

--- a/app/src/test/java/com/niki914/zafiro/repo/StorageApiTest.kt
+++ b/app/src/test/java/com/niki914/zafiro/repo/StorageApiTest.kt
@@ -1,0 +1,75 @@
+package com.niki914.zafiro.repo
+
+import android.content.Context
+import android.content.ContextWrapper
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class StorageApiTest {
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private val filesDir: File by lazy { temporaryFolder.newFolder("files") }
+    private val cacheDir: File by lazy { temporaryFolder.newFolder("cache") }
+    private val context: Context = object : ContextWrapper(null) {
+        override fun getApplicationContext(): Context = this
+        override fun getFilesDir(): File = this@StorageApiTest.filesDir
+        override fun getCacheDir(): File = this@StorageApiTest.cacheDir
+    }
+
+    @After
+    fun tearDown() {
+        XRepo.resetForTest()
+    }
+
+    @Test
+    fun usage_sumsFilesAndTreatsMissingDirAsZero() = runTest {
+        XRepo.init(context)
+        writeBytes(File(filesDir, "tool_output/a.log"), 100)
+        writeBytes(File(filesDir, "tool_output/sub/b.log"), 50)
+        writeBytes(File(filesDir, "downloads/x.apk"), 1000)
+
+        val usage = XRepo.storage.usage().associateBy { it.kind }
+
+        assertEquals(150L, usage[StorageKind.ToolOutput]?.bytes)
+        assertEquals(0L, usage[StorageKind.ImageCache]?.bytes)
+        assertEquals(1000L, usage[StorageKind.Downloads]?.bytes)
+        assertEquals(0L, usage[StorageKind.OtherCache]?.bytes)
+    }
+
+    @Test
+    fun clear_removesChildrenButKeepsDir() = runTest {
+        XRepo.init(context)
+        writeBytes(File(filesDir, "downloads/a.apk"), 10)
+        writeBytes(File(filesDir, "downloads/sub/b.apk"), 20)
+
+        XRepo.storage.clear(StorageKind.Downloads)
+
+        val dir = File(filesDir, "downloads")
+        assertTrue(dir.exists())
+        assertEquals(0, dir.walkTopDown().count { it.isFile })
+        assertEquals(0L, XRepo.storage.usage().associateBy { it.kind }[StorageKind.Downloads]?.bytes)
+    }
+
+    @Test
+    fun clear_missingDir_isNoop() = runTest {
+        XRepo.init(context)
+
+        XRepo.storage.clear(StorageKind.ImageCache)
+
+        assertFalse(File(filesDir, "image_cache").exists())
+    }
+
+    private fun writeBytes(file: File, size: Int) {
+        file.parentFile?.mkdirs()
+        file.writeBytes(ByteArray(size))
+    }
+}


### PR DESCRIPTION
## Summary
- Settings home adds a Storage entry above About (app section), routing to a new Storage page via `storage` route suffix.
- Storage page lists four top-level categories as Value rows with live sizes: tool output cache (`filesDir/tool_output`), image cache (`filesDir/image_cache`), downloads (`filesDir/downloads`), other caches (whole `cacheDir`, including screenshot staging and Python transfer leftovers).
- Tapping a row opens a unified ConfirmationLiquidDialog; confirming clears that category only (children removed, dir shell kept). No clear-all button.
- Python runtime untouched: Chaquopy interpreter and pip packages excluded; only transfer leftovers under cacheDir are covered by Other caches.
- Strings added in 5 locales (zh, en, zh-Hant, es, ja).

## Testing
- `./gradlew :app:compileDebugKotlin --offline` BUILD SUCCESSFUL.
- `./gradlew :app:testDebugUnitTest --offline --tests StorageSettingsViewModelTest --tests StorageApiTest --tests SettingsViewModelTest` BUILD SUCCESSFUL (5 new ViewModel tests incl. size formatting, 3 StorageApi tests, updated Settings entry test).
- `./gradlew :app:assembleDebug --offline` BUILD SUCCESSFUL; debug APK verified on device path prior to PR.